### PR TITLE
close_btn_backdrop_color_and_hover

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -4538,7 +4538,7 @@ button.titlebutton {
 
   &.close {
     @include draw_circle($selected_bg_color, $close:true);
-    &:backdrop{@include draw_circle(darken($headerbar_fg_color,60%), $close:true)}
+    &:backdrop{@include draw_circle(transparent, $close:true)}
     &:backdrop:hover{@include draw_circle(darken($headerbar_fg_color,50%), $close:true)}
   }
 }


### PR DESCRIPTION
Fixing the request for hover colors of window controls in the backdrop + permanent grey for the close button in the backdrop
@madsrh @clobrano @clobrano feel free to merge/request changes