### PR TITLE
Bright border color in maximized window mode

### DIFF
--- a/Communitheme/gtk-3.0/_common.scss
+++ b/Communitheme/gtk-3.0/_common.scss
@@ -1793,7 +1793,8 @@ headerbar {
   .tiled-left &,
   .maximized &,
   .fullscreen & {
-    border-color: transparentize(_border_color($headerbar_bg_color), 0.7);
+    border-color: $inkstone; //transparentize(_border_color($headerbar_bg_color), 0.7);
+
     &.selection-mode { border: none; }
 
     &:backdrop, & {
@@ -2161,6 +2162,19 @@ treeview.view {
 /*********
  * Menus *
  *********/
+menubar {
+  tiled &,
+  .tiled-top &,
+  .tiled-right &,
+  .tiled-bottom &,
+  .tiled-left &,
+  .maximized &,
+  .fullscreen & {
+    border-left-color: $inkstone;
+    border-right-color: $inkstone;
+  }
+}
+
 menubar,
 .menubar {
   -GtkWidget-window-dragging: true;


### PR DESCRIPTION
Changed border color of headerbar, titlebar and menubar (only GTK3) when
the window is in maximized, tiled, fullscreen state.

Known limitation:
- GTK2 menubar is not able to change when a window is
in maximized state.

Dependency:
- dock top border should change to the same color if this change will
  be accepted. However the dock top border color would always be the
  same color, that is, it won't change according to window mode.

TODO:
- [x] fix [issue 752](https://github.com/micheleg/dash-to-dock/issues/752) on dash-to-dock
- [ ] wait for fix to be released officially (fix released in [ubuntu-dock-63ubuntu1](https://github.com/micheleg/dash-to-dock/releases/tag/ubuntu-dock-63ubuntu1) that will land in Cosmic
- [ ] implement and merge twin change on gnome-shell-communitheme