### PR TITLE
Make headerbar text buttons not flat

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1715,6 +1715,26 @@ headerbar {
       }
     }
 
+    :not(.linked) button.text-button:not(.suggested-action):not(.destructive-action):not(:indeterminate) {
+        // non-special text buttons are not flat
+        $c: $headerbar_bg_color;
+        @each $state, $t in ("", "normal"),
+                            (":hover", "hover"),
+                            (":hover:backdrop", "backdrop-hover"),
+                            (":active, &:checked", "active"),
+                            (":hover:checked", "active-hover"),
+                            (":disabled", "insensitive"),
+                            (":disabled:active, &:disabled:checked", "insensitive-active"),
+                            (":backdrop", "backdrop"),
+                            (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
+                            (":backdrop:disabled", 'backdrop-insensitive'),
+                            (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
+                              &#{$state} { @include button($t, $c, $tc); }
+        }
+        &:not(:hover) { background-color: $hb_pathbar_bg; }
+        &:backdrop { background-color: $hb_pathbar_bg_backdrop; border-color: $hb_pathbar_border_backdrop; }
+      }
+
     .stack-switcher.linked,
     buttonbox.linked {
       // round the stackswitcher corners by using border


### PR DESCRIPTION
Uses $hb_pathbar_bg variables
Issue #474 

![screenshot from 2018-07-26 21-34-38](https://user-images.githubusercontent.com/27529229/43296876-0d495daa-911c-11e8-967c-6af4a3b1b548.png)
