### PR TITLE
Dim headerbar text button labels

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1559,12 +1559,14 @@ headerbar {
   label:backdrop { color: inherit; } // make sure to inherit the backdrop label color
 
   .title {
+    color: $headerbar_text_color;
     font-weight: 500;
     padding-left: 12px;
     padding-right: 12px;
   }
 
   .subtitle {
+    color: $headerbar_text_color;
     font-size: smaller;
     padding-left: 12px;
     padding-right: 12px;
@@ -1633,7 +1635,7 @@ headerbar {
                           (":backdrop:disabled", 'backdrop-insensitive'),
                           (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
                             @if $t == "normal" {
-                              &#{$state} { @include button($t, $c, $headerbar_text_color, $flat:true); }  
+                              &#{$state} { @include button($t, $c, $headerbar_fg_color, $flat:true); }  
                             }
                             
                             @else {
@@ -4455,7 +4457,6 @@ button.titlebutton {
   }
 
   &.close {
-    color: white;
     @include draw_circle($selected_bg_color, $close:true);
     &:hover {
       @include draw_circle($selected_bg_color, $close:true);

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1620,10 +1620,6 @@ headerbar {
       }
     }
 
-    .text-button:not(.suggested-action):not(:hover) {
-      border-color: $hb_button_bg_hover;
-    }
-
     button, button.flat, button.titlebutton.appmenu {
       @each $state, $t in ("", "normal"),
                           (":hover", "hover"),
@@ -1636,7 +1632,13 @@ headerbar {
                           (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
                           (":backdrop:disabled", 'backdrop-insensitive'),
                           (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-                            &#{$state} { @include button($t, $c, $tc, $flat:true); }
+                            @if $t == "normal" {
+                              &#{$state} { @include button($t, $c, $headerbar_text_color, $flat:true); }  
+                            }
+                            
+                            @else {
+                              &#{$state} { @include button($t, $c, $tc, $flat:true); }
+                            }
       }
 
       @each $b_type, $b_color in (suggested-action, $success_color),
@@ -4453,6 +4455,7 @@ button.titlebutton {
   }
 
   &.close {
+    color: white;
     @include draw_circle($selected_bg_color, $close:true);
     &:hover {
       @include draw_circle($selected_bg_color, $close:true);


### PR DESCRIPTION
Uses $headerbar_text_color so headerbar text buttons won't be as bright as a window's title, kind of like how pop os does it.

alternative to adding a border to text buttons to distinguish them

Issue #474

![screenshot from 2018-07-26 21-36-39](https://user-images.githubusercontent.com/27529229/43296866-0120d95e-911c-11e8-9b33-e2432d1a8823.png)
