### PR TITLE
Change panel button's font weight to normal, adjust to suru's thin icons

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -828,7 +828,7 @@ StScrollBar {
   .panel-button {
     -natural-hpadding: 12px;
     -minimum-hpadding: 6px;
-    font-weight: 450;
+    font-weight: normal;
     color: $_fg;
     text-shadow: 0px 1px 4px rgba(0, 0, 0, 0.6);
     transition-duration: 100ms;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/15329494/43367446-4375078e-934d-11e8-8e9e-bfeee5fc3a1f.png)


After: 
![image](https://user-images.githubusercontent.com/15329494/43367439-290657e0-934d-11e8-8082-46f06461854b.png)

@clobrano @madsrh @luxamman @godlyranchdressing 
Minor change, I have the impression that this fits a tiny bit better to the thin suru symbolic icons.
If you think this is not needed then -> :wastebasket: 
:smile: 