### PR TITLE
Removed background-position property from gnome-shell common

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -177,7 +177,6 @@ StScrollBar {
   width: 65px;
   height: 22px;
   background-size: contain;
-  background-position: right center;
 }
 
   @each $v in us, intl {


### PR DESCRIPTION
Removing background-position property since gnome-shell does not
support it

close #664