### PR TITLE
Gnome-ToDo: Remove the border radius of the taskrow button and the outline

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -469,11 +469,11 @@ headerbar button image ~ window decoration ~ menu separator {
 
 .org-gnome-Todo {
   taskrow.activatable.new-task-row button.popup.toggle {
-   border-radius: 0px $small_radius $small_radius 0px ;
+   border-radius: 0px;
    border: none;
    border-left: 1px solid $borders-color;
    padding-left: 10px; padding-right: 10px;
-   -gtk-outline-radius: 0px $small_radius $small_radius 0px;
+   -gtk-outline-radius: 0px;
 
   }
 


### PR DESCRIPTION
Because the border radius of the taskrow is hardcoded.

![image](https://user-images.githubusercontent.com/15329494/43453321-17850250-94ba-11e8-8e03-b4a2a8a3b81e.png)
