### PR TITLE
Make secondary nautilus icon labels less colorful

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -105,6 +105,11 @@ list.tweak-categories separator {
     }
   }
 
+  .nautilus-canvas-item.dim-label,
+  .nautilus-list-dim-label {
+      color: if($variant==light, lighten($text_color,25%), darken($text_color,25%));
+      &:selected { color: $silk }
+  }
 
 }
 

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -107,7 +107,7 @@ list.tweak-categories separator {
 
   .nautilus-canvas-item.dim-label,
   .nautilus-list-dim-label {
-      color: if($variant==light, lighten($text_color,25%), darken($text_color,25%));
+      color: if($variant==light, lighten($text_color,30%), darken($text_color,25%));
       &:selected { color: $silk }
   }
 


### PR DESCRIPTION
Closes https://github.com/ubuntu/yaru/issues/689

![screenshot from 2018-08-03 18-26-28](https://user-images.githubusercontent.com/15329494/43654278-f553cf0c-974a-11e8-9822-e11da7ca1f78.png)

![screenshot from 2018-08-03 18-27-34](https://user-images.githubusercontent.com/15329494/43654279-f5801742-974a-11e8-98c3-c22a8a85dd2b.png)