### PR TITLE
Define a proper buttonbox style

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -316,6 +316,26 @@ terminal-window {
     box-shadow: inset 0 0 100px 100px $base_color;
 }
 
+// Emulate the stackswitchers look for this buttons
+.toolbar-primary-buttons-software {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background-color: $hb_pathbar_bg;
+
+  &:hover {
+    background-color: $hb_pathbar_bg;
+  }
+
+  &:checked {
+      background-color: $hb_pathbar_bg;
+      box-shadow: inset 0 -2px 0 0 $selected_bg_color;
+      &:hover {
+        background-color: $hb_pathbar_bg;
+      }
+  }
+}
+
 /*********
  * Gedit *
  *********/

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -316,26 +316,6 @@ terminal-window {
     box-shadow: inset 0 0 100px 100px $base_color;
 }
 
-// Emulate the stackswitchers look for this buttons
-.toolbar-primary-buttons-software {
-  margin: 0;
-  padding: 0;
-  border: none;
-  background-color: $hb_pathbar_bg;
-
-  &:hover {
-    background-color: $hb_pathbar_bg;
-  }
-
-  &:checked {
-      background-color: $hb_pathbar_bg;
-      box-shadow: inset 0 -2px 0 0 $selected_bg_color;
-      &:hover {
-        background-color: $hb_pathbar_bg;
-      }
-  }
-}
-
 /*********
  * Gedit *
  *********/
@@ -562,3 +542,4 @@ normal-button {
 
   &:disabled {@include button(insensitive);}
 }
+

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1717,19 +1717,20 @@ headerbar {
 
     buttonbox.linked button,
     buttonbox.linked button.text-button ~ button {
-        border-style: solid;
-        border-color: $inkstone;
+      border-style: solid;
+      border-color: $inkstone;
 
-        &:not(:only-child) { border-width: 1px 0; }
-        &:first-child { border-width: 1px 0 1px 1px; }
-        &:last-child { border-width: 1px 1px 1px 0; }
+      &:not(:only-child) { border-width: 1px 0; }
+      &:first-child { border-width: 1px 0 1px 1px; }
+      &:last-child { border-width: 1px 1px 1px 0; }
 
-        &:checked {
-            box-shadow: inset 0 1px rgba(0 , 0, 0, 0.6);
-        }
-        &:backdrop {
-            &, &:checked { border-color: lighten($inkstone, 3%); }
-        }
+      &:checked {
+          box-shadow: inset 0 1px rgba(0 , 0, 0, 0.6);
+      }
+
+      &:backdrop {
+        &, &:checked { border-color: lighten($inkstone, 3%); }
+      }
     }
 
     .stack-switcher.linked {

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1715,8 +1715,13 @@ headerbar {
       }
     }
 
-    .stack-switcher.linked,
-    buttonbox.linked {
+    buttonbox  {
+      #recent-button, #save-as-button {
+        border: 1px solid $inkstone;
+      }
+    }
+
+    .stack-switcher.linked {
       // round the stackswitcher corners by using border
       border-width: 0 8px;
       border-style: solid;

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1715,10 +1715,9 @@ headerbar {
       }
     }
 
-    buttonbox  {
-      #recent-button, #save-as-button {
-        border: 1px solid $inkstone;
-      }
+    buttonbox button,
+    buttonbox button.text-button ~ button {
+        &, &.backdrop { border: 1px solid $inkstone; }
     }
 
     .stack-switcher.linked {

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1723,6 +1723,10 @@ headerbar {
         &:not(:only-child) { border-width: 1px 0; }
         &:first-child { border-width: 1px 0 1px 1px; }
         &:last-child { border-width: 1px 1px 1px 0; }
+
+        &:checked {
+            box-shadow: inset 0 1px rgba(0 , 0, 0, 0.6);
+        }
     }
 
     .stack-switcher.linked {

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1715,9 +1715,14 @@ headerbar {
       }
     }
 
-    buttonbox button,
-    buttonbox button.text-button ~ button {
-        &, &.backdrop { border: 1px solid $inkstone; }
+    buttonbox.linked button,
+    buttonbox.linked button.text-button ~ button {
+        border-style: solid;
+        border-color: $inkstone;
+
+        &:not(:only-child) { border-width: 1px 0; }
+        &:first-child { border-width: 1px 0 1px 1px; }
+        &:last-child { border-width: 1px 1px 1px 0; }
     }
 
     .stack-switcher.linked {

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1727,6 +1727,9 @@ headerbar {
         &:checked {
             box-shadow: inset 0 1px rgba(0 , 0, 0, 0.6);
         }
+        &:backdrop {
+            &, &:checked { border-color: lighten($inkstone, 3%); }
+        }
     }
 
     .stack-switcher.linked {

--- a/gtk/src/gtk-3.0/_drawing.scss
+++ b/gtk/src/gtk-3.0/_drawing.scss
@@ -418,7 +418,7 @@
     $_bc: if($c != $button_bg_color, _backdrop_color(_border_color($c)), $backdrop_borders_color);
 
     @if $c==$headerbar_bg_color {
-      $_bg: mix($c, $headerbar_bg_color, 85%);
+      $_bg: lighten($backdrop_headerbar_bg_color, 5%);
     } @else if $c!=$headerbar_bg_color and $variant=='light'{
       $_bg: darken($c, 12%);
     }


### PR DESCRIPTION
Stop mimic stackswitcher with buttonbox

TODO
- [x] (gnome-software) hover on central button, when first is selected changes button size
- [x] backdrop background turns black
- [x] pressed effect is barely visible
- [x] (in glade) backdrop, last-child button border disappear (actually is just hard to see)

closes  #482 