### PR TITLE
Dark theme border improvements

### DIFF
--- a/gtk/src/gtk-3.0/_colors.scss
+++ b/gtk/src/gtk-3.0/_colors.scss
@@ -11,7 +11,7 @@ $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //
 $selected_fg_color: white;
 $selected_bg_color: $orange;
-$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 7%));
+$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 4%));
 $link_color: $blue;
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
 $borders_edge: if($variant == 'light',rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1555,7 +1555,7 @@ headerbar {
   color: $headerbar_fg_color;
   @if $variant=='dark' {
     &:backdrop {
-      border-bottom: 1px solid $backdrop_borders_color;
+      box-shadow: inset 0 -1px 0 0 transparentize($backdrop_borders_color,0.2);
     }
   }
 

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1553,6 +1553,11 @@ headerbar {
   border-radius: 0;
   background-color: $headerbar_bg_color;
   color: $headerbar_fg_color;
+  @if $variant=='dark' {
+    &:backdrop {
+      border-bottom: 1px solid $backdrop_borders_color;
+    }
+  }
 
   &:backdrop {
     background-color: $backdrop_headerbar_bg_color;


### PR DESCRIPTION
- added a backdrop_bordes_color border to the DARK  theme headerbar 
bottom  border
- reduced the dark theme darkness borders by 2%

Before:
![screenshot from 2018-08-10 14-07-41](https://user-images.githubusercontent.com/15329494/43957073-cf163c38-9ca6-11e8-8e83-eda534cb3d0c.png)
![screenshot from 2018-08-10 14-07-29](https://user-images.githubusercontent.com/15329494/43957074-cf43cffe-9ca6-11e8-89b3-28b802a03b46.png)

After:
![screenshot from 2018-08-10 14-03-24](https://user-images.githubusercontent.com/15329494/43957082-d4d47e78-9ca6-11e8-8154-fa6a42946d88.png)
![screenshot from 2018-08-10 14-02-43](https://user-images.githubusercontent.com/15329494/43957084-d50bb1b8-9ca6-11e8-8f5b-2ac0c9dc05f6.png)
![screenshot-20180810142730-1537x666](https://user-images.githubusercontent.com/15329494/43957868-affeabca-9ca9-11e8-9aa3-e4692b331eb3.png)

Otherwise borders of for example sidebars and treeviews crash into the backdrop headerbar bg color and it looks "opened" and unfinnished imho. That's why I attached the rhythmbox AFTER screenshot

@madsrh @clobrano please check if you like this or not.