### PR TITLE
Infobar backdrop improvements

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -4213,6 +4213,8 @@ infobar {
       }
     }
   }
+  > revealer > box > box label:backdrop { color: $button_backdrop_bg_color; }
+  button:not(:insensitive):backdrop { background-color: darken($button_bg_color, 5%); }
   *:link { @extend %link_selected; }
 }
 


### PR DESCRIPTION
- make the label more greyish instead of black
- overwrite the default button backdrop bg color for infobars because the 
not(:insensitive) buttons merge their color with the purple then

Before:
![screenshot from 2018-08-10 17-29-27](https://user-images.githubusercontent.com/15329494/43968997-109260fc-9cc9-11e8-9fb9-5699ac4f6a4c.png)

After:
![screenshot from 2018-08-10 18-07-23](https://user-images.githubusercontent.com/15329494/43969010-15c5517e-9cc9-11e8-8dd5-c7c1e25c378c.png)

@madsrh @clobrano please check if you like it or not