### PR TITLE
Style circular button in Nautilus

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -27,6 +27,22 @@ list.tweak-categories separator {
     border: none;
     border-radius: $small_radius 0 0 0;
 
+    button.circular.flat.image-button {
+      // style both normal and hover at the same time is necessary
+      // otherwise gtk will take the style from somewhere else...
+      &, &:hover {
+        background-color: darken($slate, 2%);
+        border-color: darken($inkstone, 4%);
+        color: $bg_color;
+        margin: 2px;
+      }
+
+      // ...and here style just the difference from normal
+      &:hover {
+        color: $destructive_color;
+      }
+    }
+
     &:backdrop {
       @if $variant=='light' {
         background: transparentize(darken($backdrop_bg_color,10%),0.1);


### PR DESCRIPTION
Circular button is used in Nautilus as as stop button while Nautilus is
loading a folder. With new dark colors for the "loading" label the
button was barely visible.

Added brighter button background, some margin and a red hover color
(stop loading is not strongly destructive, but will prevent the folders
to be completely visible until refresh, so I think red color suits fine).

closes #705 

Result
![nautilus-stop-loading-circular-button](https://user-images.githubusercontent.com/2883614/44002620-f0da53b8-9e45-11e8-96dd-1ac963cc0193.gif)

Respect the mockup, I could not style the white background line when the icon turns red, because it's just transparent and shows button's color below which is inkstone