### PR TITLE
Fixed speed of combobox selection ring transition

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -273,7 +273,6 @@ entry {
     padding: 2px 6px;
     border: 1px solid;
     border-radius: $small_radius;
-    transition: $button_transition;
     caret-color: currentColor;
 
     @include entry(normal);
@@ -298,7 +297,10 @@ entry {
       }
     }
 
-    &:focus { @include entry(focus); }
+    &:focus {
+      @include entry(focus);
+      transition: $button_transition;
+    }
 
     &:disabled { @include entry(insensitive); }
 
@@ -372,7 +374,7 @@ entry {
   .linked:not(.vertical) > & { @extend %linked; }
   .linked:not(.vertical) > &:focus + &,
   .linked:not(.vertical) > &:focus + button,
-  .linked:not(.vertical) > &:focus + combobox > box > button.combo { border-left-color: $selected_bg_color; }
+  .linked:not(.vertical) > &:focus + combobox > box > button.combo { transition: $button_transition; border-left-color: $selected_bg_color; }
 
   .linked:not(.vertical) > &:drop(active) + &,
   .linked:not(.vertical) > &:drop(active) + button,


### PR DESCRIPTION
In combobox made of entry + button, the entry selection ring appears and
disappears at different speed on the right side, that is, the side
"shared" with the button.

Fixed
- applied "button_transition" on buttons that belong to such a combobox,
to fix the delay in selection ring appearance.
- applied "button_transition" on the entry widget only in case of focus,
to fix the disappearing delay.

closes #533

Result

![combobox-entry-selection-ring-animation](https://user-images.githubusercontent.com/2883614/44003462-4187a966-9e53-11e8-8ec0-0689ee94efd2.gif)
