### PR TITLE
Improved visibility of destructive-action button icon

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -802,6 +802,13 @@ button {
     }
   }
 
+  &.destructive-action image {
+    icon-shadow: 0 0 2px darken($destructive_color, 25%);
+    &:backdrop {
+      icon-shadow: 0 0 2px darken($destructive_color, 10%);
+    }
+  }
+
   .stack-switcher > & {
     // to position the needs attention dot, padding is added to the button
     // child, a label needs just lateral padding while an icon needs vertical


### PR DESCRIPTION
The red destructive-color is so similar to media-record-symbolic
icon that the icon itself is barely visible (see Sound Recorder).

Added a icon-shadow layer of a darker red to improve icon visibility.

closes #708 

Result
![image](https://user-images.githubusercontent.com/2883614/44035111-fa6a47f2-9f0e-11e8-9f7f-586b37f8c167.png)
