### PR TITLE
Remove the headerbar border for geary new messages.

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -559,3 +559,9 @@ normal-button {
 }
 #warning_dialog.background { border: 1px solid $borders_color; }
 #dialog-action_area1 { padding-bottom: 5px; padding-right: 5px }
+
+/***********
+ * Geary *
+ ***********/
+
+.geary-expanded.geary-last headerbar { border: none; }


### PR DESCRIPTION
Carlo introduced the awesome "light from above" headerbar color

Geary uses the global headerbar styling for their inapp-reply feature.
This is a minor GEARY ONLY fix which removes the headerbar border

Before:
![screenshot from 2018-08-14 18-06-30](https://user-images.githubusercontent.com/15329494/44104267-b6262d46-9fee-11e8-9402-9907d6d5dd1c.png)

After:
![screenshot from 2018-08-14 18-07-02](https://user-images.githubusercontent.com/15329494/44104273-ba8c22be-9fee-11e8-829a-c066cbbb7d0c.png)
