### PR TITLE
Change the no-notification and no-events icons

### DIFF
--- a/gnome-shell/src/no-events.svg
+++ b/gnome-shell/src/no-events.svg
@@ -13,8 +13,8 @@
    height="64px"
    id="svg3471"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="New document 5">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="no-events.svg">
   <defs
      id="defs3473" />
   <sodipodi:namedview
@@ -24,18 +24,19 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.5"
-     inkscape:cx="32"
-     inkscape:cy="32"
+     inkscape:zoom="3.8890873"
+     inkscape:cx="-16.596871"
+     inkscape:cy="34.311032"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:document-units="px"
      inkscape:grid-bbox="true"
-     inkscape:window-width="1461"
-     inkscape:window-height="772"
-     inkscape:window-x="37"
-     inkscape:window-y="64"
-     inkscape:window-maximized="0" />
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:snap-page="true" />
   <metadata
      id="metadata3476">
     <rdf:RDF>
@@ -44,7 +45,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -53,67 +54,23 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer">
     <g
-       transform="matrix(4,0,0,4,1.9999997,2.3636364)"
-       id="g19145"
-       style="fill:#bebebe;fill-opacity:1;display:inline">
-      <g
-         id="g19147"
-         inkscape:label="status"
-         style="fill:#bebebe;fill-opacity:1;display:inline"
-         transform="translate(-541.0002,-301)" />
-      <g
-         style="fill:#bebebe;fill-opacity:1"
-         id="g19149"
-         inkscape:label="devices"
-         transform="translate(-541.0002,-301)" />
-      <g
-         style="fill:#bebebe;fill-opacity:1"
-         id="g19151"
-         inkscape:label="apps"
-         transform="translate(-541.0002,-301)" />
-      <g
-         style="fill:#bebebe;fill-opacity:1"
-         id="g19153"
-         inkscape:label="places"
-         transform="translate(-541.0002,-301)" />
-      <g
-         style="fill:#bebebe;fill-opacity:1"
-         id="g19155"
-         inkscape:label="mimetypes"
-         transform="translate(-541.0002,-301)">
-        <path
-           inkscape:connector-curvature="0"
-           d="m 543.0002,301 c -1.05237,0 -2,0.84508 -2,1.9375 l 0,11.125 c 0,1.09242 0.94763,1.9375 2,1.9375 l 11,0 c 1.05237,0 2,-0.84508 2,-1.9375 l 0,-11.125 c 0,-1.09242 -0.94763,-1.9375 -2,-1.9375 l -11,0 z m 0,5 3.03125,0 0,2 -3.03125,0 0,-2 z m 4.03125,0 2.96875,0 0,2 -2.96875,0 0,-2 z m 3.96875,0 3,0 0,2 -3,0 0,-2 z m -8,3 3.03125,0 0,2 -3.03125,0 0,-2 z m 4.03125,0 2.96875,0 0,2 -2.96875,0 0,-2 z m 3.96875,0 3,0 0,2 -3,0 0,-2 z m -8,3 3.03125,0 0,2 -3.03125,0 0,-2 z m 4.03125,0 2.96875,0 0,2 -2.96875,0 0,-2 z m 3.96875,0 3,0 0,2 -3,0 0,-2 z"
-           id="path19157"
-           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new;font-family:Sans;-inkscape-font-specification:Sans" />
-        <rect
-           height="1.9999993"
-           id="rect19159"
-           style="opacity:0.35;color:#000000;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-           width="2.9999993"
-           x="551.00018"
-           y="309" />
-      </g>
-      <g
-         id="g19161"
-         inkscape:label="emblems"
-         style="fill:#bebebe;fill-opacity:1;display:inline"
-         transform="translate(-541.0002,-301)" />
-      <g
-         id="g19163"
-         inkscape:label="emotes"
-         style="fill:#bebebe;fill-opacity:1;display:inline"
-         transform="translate(-541.0002,-301)" />
-      <g
-         id="g19165"
-         inkscape:label="categories"
-         style="fill:#bebebe;fill-opacity:1;display:inline"
-         transform="translate(-541.0002,-301)" />
-      <g
-         id="g19167"
-         inkscape:label="actions"
-         style="fill:#bebebe;fill-opacity:1;display:inline"
-         transform="translate(-541.0002,-301)" />
+       id="g3756"
+       transform="matrix(4.0000011,0,0,4.0000011,-1767.9997,-495.99907)"
+       inkscape:label="appointment">
+      <rect
+         transform="rotate(90)"
+         y="-457.99979"
+         x="123.99973"
+         height="16"
+         width="16"
+         id="rect4782-91"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920917;marker:none;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="cccccccccccccscscccccccccscscccccccccccccccccccscscccccccccscscccc"
+         inkscape:connector-curvature="0"
+         id="path4410"
+         d="m 447.99965,123.99973 -1,0.25 v 0.75 h 1 z m 0,1 L 448,126 h -1 l -3.5e-4,-1.00027 h -0.004 -0.002 c -1.25819,0.0145 -2.17883,-0.0306 -2.93164,0.38477 -0.3764,0.20768 -0.67518,0.55942 -0.83984,0.99804 -0.16451,0.43862 -0.22252,0.95961 -0.22252,1.61719 v 5 3 c 0,0.65759 0.058,1.17856 0.22266,1.61719 0.16466,0.43862 0.46344,0.78841 0.83984,0.99609 0.75281,0.41535 1.67345,0.37218 2.93164,0.38672 h 0.002 4.00391 2.00195 0.004 c 1.25819,-0.0145 2.17883,0.0286 2.93164,-0.38672 0.37641,-0.20768 0.67324,-0.55747 0.83789,-0.99609 0.16451,-0.43863 0.22447,-0.98942 0.22447,-1.61719 v -3 -5 c 0,-0.65759 -0.06,-1.17857 -0.22461,-1.61719 -0.16465,-0.43862 -0.46148,-0.79036 -0.83789,-0.99804 -0.75281,-0.41535 -1.67345,-0.37023 -2.93164,-0.38477 h -0.004 -0.002 L 452.99986,126 h -1 l -3.5e-4,-1.00027 z m 4,0 h 1 v -1 l -1,0.25 z m -4.99414,4 h 3.99414 2 c 1.25957,0.0147 2.08705,0.0598 2.45312,0.26172 0.18338,0.10118 0.28914,0.21271 0.38672,0.47266 0.0976,0.25994 0.16016,1.26562 0.16016,1.26562 v 2 3 c 0,0.59241 -0.0626,1.00567 -0.16016,1.26562 -0.0976,0.25995 -0.20334,0.37148 -0.38672,0.47266 -0.36606,0.20198 -1.19355,0.24703 -2.45312,0.26172 h -0.006 -1.994 -3.99414 -0.006 c -1.2599,-0.0147 -2.087,-0.0597 -2.45312,-0.26172 -0.18338,-0.10118 -0.28915,-0.21271 -0.38672,-0.47266 -0.0976,-0.25995 -0.16016,-0.67321 -0.16016,-1.26562 v -3 -2 c 0,-0.59241 0.0626,-1.00568 0.16016,-1.26562 0.0976,-0.25996 0.20334,-0.37148 0.38672,-0.47266 0.36675,-0.20236 1.19544,-0.2471 2.45898,-0.26172 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00079155;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/gnome-shell/src/no-notifications.svg
+++ b/gnome-shell/src/no-notifications.svg
@@ -13,8 +13,8 @@
    height="64px"
    id="svg3393"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="New document 2">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="no-notifications.svg">
   <defs
      id="defs3395" />
   <sodipodi:namedview
@@ -24,18 +24,19 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.5"
-     inkscape:cx="32"
-     inkscape:cy="32"
+     inkscape:zoom="0.6875"
+     inkscape:cx="-352.74014"
+     inkscape:cy="-119.54596"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:document-units="px"
      inkscape:grid-bbox="true"
-     inkscape:window-width="697"
-     inkscape:window-height="613"
-     inkscape:window-x="100"
-     inkscape:window-y="77"
-     inkscape:window-maximized="0" />
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-page="true" />
   <metadata
      id="metadata3398">
     <rdf:RDF>
@@ -44,7 +45,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -53,62 +54,33 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer">
     <g
+       transform="matrix(4,0,0,4,-2288,-640)"
        style="display:inline"
-       transform="matrix(4,0,0,4,0.29733827,-0.35415646)"
-       id="g19245">
-      <g
-         id="g19247"
-         inkscape:label="status"
-         style="display:inline"
-         transform="translate(-323.02908,-649.02581)" />
-      <g
-         id="g19249"
-         inkscape:label="devices"
-         transform="translate(-323.02908,-649.02581)" />
-      <g
-         id="g19251"
-         inkscape:label="apps"
-         transform="translate(-323.02908,-649.02581)">
-        <path
-           inkscape:connector-curvature="0"
-           d="m 331.9377,653 c 0.0187,0.16677 0.0625,0.32822 0.0625,0.5 0,2.48528 -2.01472,4.5 -4.5,4.5 -0.11769,0 -0.22834,-0.0224 -0.34375,-0.0312 l 0,2.21875 c 0,1.00412 0.80838,1.8125 1.8125,1.8125 l 1.54511,-5e-5 2,2.04688 2.0625,-2.04688 1.61114,0 c 1.00413,0 1.8125,-0.80838 1.8125,-1.8125 l 0,-5.375 c 0,-1.00412 -0.80837,-1.8125 -1.8125,-1.8125 z"
-           id="path19253"
-           sodipodi:nodetypes="csscsscccssssc"
-           style="opacity:0.5;color:#000000;fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-        <path
-           inkscape:connector-curvature="0"
-           d="m 327.5002,650 c -1.933,0 -3.5,1.567 -3.5,3.5 0,1.933 1.567,3.5 3.5,3.5 1.933,0 3.5,-1.567 3.5,-3.5 0,-1.933 -1.567,-3.5 -3.5,-3.5 z m -0.53125,1 1.03125,0 -0.0625,1.375 a 0.19951718,0.19951718 0 0 0 0,0.0625 0.19951718,0.19951718 0 0 0 0,0.0312 0.19951718,0.19951718 0 0 0 0.125,0.125 0.19951718,0.19951718 0 0 0 0.0312,0 0.19951718,0.19951718 0 0 0 0.0625,0 0.19951718,0.19951718 0 0 0 0.0625,0 0.19951718,0.19951718 0 0 0 0.0312,-0.0312 l 1.15625,-0.75 0.5,0.90625 -1.21875,0.625 a 0.19951718,0.19951718 0 0 0 -0.0312,0 0.19951718,0.19951718 0 0 0 -0.0312,0.0312 0.19951718,0.19951718 0 0 0 -0.0312,0.0937 0.19951718,0.19951718 0 0 0 0,0.0625 0.19951718,0.19951718 0 0 0 0,0.0312 0.19951718,0.19951718 0 0 0 0.0312,0.0625 0.19951718,0.19951718 0 0 0 0.0312,0.0312 0.19951718,0.19951718 0 0 0 0.0312,0.0312 l 1.25,0.625 -0.53125,0.90625 -1.15625,-0.781 a 0.19951718,0.19951718 0 0 0 -0.0312,0 0.19951718,0.19951718 0 0 0 -0.0625,-0.0312 0.19951718,0.19951718 0 0 0 -0.0625,0 0.19951718,0.19951718 0 0 0 -0.125,0.0937 0.19951718,0.19951718 0 0 0 -0.0312,0.0312 0.19951718,0.19951718 0 0 0 0,0.0312 0.19951718,0.19951718 0 0 0 0,0.0625 l 0.0625,1.3751 -1.03125,0 0.0937,-1.375 a 0.19951718,0.19951718 0 0 0 -0.0312,-0.0937 0.19951718,0.19951718 0 0 0 -0.0312,-0.0625 0.19951718,0.19951718 0 0 0 -0.0625,-0.0312 0.19951718,0.19951718 0 0 0 -0.0625,-0.0312 0.19951718,0.19951718 0 0 0 -0.0312,0 0.19951718,0.19951718 0 0 0 -0.0937,0.0312 l -1.1875,0.78125 -0.5,-0.90625 1.25,-0.625 a 0.19951718,0.19951718 0 0 0 0.0312,-0.0312 0.19951718,0.19951718 0 0 0 0.0312,-0.0312 0.19951718,0.19951718 0 0 0 0.0312,-0.0625 0.19951718,0.19951718 0 0 0 0,-0.0312 0.19951718,0.19951718 0 0 0 0,-0.0625 0.19951718,0.19951718 0 0 0 0,-0.0312 0.19951718,0.19951718 0 0 0 -0.0312,-0.0625 0.19951718,0.19951718 0 0 0 -0.0312,-0.0312 0.19951718,0.19951718 0 0 0 -0.0312,0 l -1.25,-0.625 0.5,-0.90625 1.1875,0.75 a 0.19951718,0.19951718 0 0 0 0.0312,0.0312 0.19951718,0.19951718 0 0 0 0.0625,0 0.19951718,0.19951718 0 0 0 0.0625,0 0.19951718,0.19951718 0 0 0 0.0312,0 0.19951718,0.19951718 0 0 0 0.0312,-0.0312 0.19951718,0.19951718 0 0 0 0.0312,-0.0312 0.19951718,0.19951718 0 0 0 0.0312,-0.0312 0.19951718,0.19951718 0 0 0 0,-0.0312 0.19951718,0.19951718 0 0 0 0.0312,-0.0625 0.19951718,0.19951718 0 0 0 0,-0.0312 L 326.96895,651 z"
-           id="path19255"
-           style="color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      </g>
-      <g
-         id="g19257"
-         inkscape:label="places"
-         transform="translate(-323.02908,-649.02581)" />
-      <g
-         id="g19259"
-         inkscape:label="mimetypes"
-         transform="translate(-323.02908,-649.02581)" />
-      <g
-         id="g19261"
-         inkscape:label="emblems"
-         style="display:inline"
-         transform="translate(-323.02908,-649.02581)" />
-      <g
-         id="g19263"
-         inkscape:label="emotes"
-         style="display:inline"
-         transform="translate(-323.02908,-649.02581)" />
-      <g
-         id="g19265"
-         inkscape:label="categories"
-         style="display:inline"
-         transform="translate(-323.02908,-649.02581)" />
-      <g
-         id="g19267"
-         inkscape:label="actions"
-         style="display:inline"
-         transform="translate(-323.02908,-649.02581)" />
+       id="g2229"
+       inkscape:label="preferences-system-notifications">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.99980223;marker:none;enable-background:accumulate"
+         id="rect1379"
+         width="16"
+         height="16"
+         x="160"
+         y="-588"
+         transform="rotate(90)" />
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.25"
+         d="m 580,161 a 1,1 0 0 0 -1,1 1,1 0 0 0 0.01,0.13867 c -1.72793,0.44251 -3.01,1.9959 -3.01,3.86133 6.6e-4,0.11019 0.006,0.22032 0.0156,0.33008 v 3.23633 c 0,0.3597 -0.0337,0.6898 -0.10156,0.98828 -0.0679,0.29862 -0.18774,0.55134 -0.35742,0.76172 -0.16288,0.21718 -0.38382,0.38462 -0.66211,0.5 -0.2712,0.11906 -0.611,0.17693 -1.01758,0.17968 V 172 h 2.13867 3.98438 3.98438 2.13671 v -0.004 c -0.40658,-0.003 -0.74637,-0.0606 -1.01757,-0.17968 -0.27829,-0.11538 -0.49923,-0.28283 -0.66211,-0.5 -0.16968,-0.21039 -0.28761,-0.4631 -0.35547,-0.76172 -0.0679,-0.29848 -0.10161,-0.62859 -0.10156,-0.98828 v -3.24805 -0.002 c 0.009,-0.10522 0.0146,-0.21078 0.0156,-0.31641 0,-1.86608 -1.28333,-3.41946 -3.01172,-3.86133 A 1,1 0 0 0 581,162 a 1,1 0 0 0 -1,-1 z m 0,2 c 1.65685,0 3,1.34315 3,3 v 5 h -6 v -5 c 0,-1.65685 1.34315,-3 3,-3 z m -3.9082,8.7168 -0.0156,0.0195 c 0.003,-0.003 0.004,-0.008 0.006,-0.0117 0.002,-0.003 0.008,-0.004 0.01,-0.008 z m 7.8164,0 c 0.002,0.003 0.008,0.004 0.01,0.008 0.003,0.003 0.004,0.008 0.006,0.0117 z M 578,173 c 0.0125,1.10862 0.91475,2 2.02344,2 1.10868,0 2.01094,-0.89138 2.02344,-2 z"
+         id="path1381"
+         inkscape:connector-curvature="0" />
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.24995056"
+         d="m 584.06608,172.3138 c 0.003,0.004 0.007,0.006 0.009,0.009 0.003,0.004 0.005,0.01 0.008,0.0137 z"
+         id="path1383"
+         inkscape:connector-curvature="0" />
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.24995056"
+         d="m 575.92676,172.31607 -0.0179,0.0231 c 0.003,-0.004 0.005,-0.009 0.008,-0.0137 0.003,-0.004 0.007,-0.006 0.009,-0.009 z"
+         id="path1385"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
Changed the no-notification and no-events icons to preferences-system-notifications-symbolic and appointment-symbolic icons respectively from Suru.
But in the notification bar remained old icons. Help wanted.
![2018-08-15 12-18-31](https://user-images.githubusercontent.com/40228953/44138620-8a5d8b18-a085-11e8-87ee-3aa75c651f7f.png)
