### PR TITLE
Remove the uneven .counter-label margin because of the recent buttonbox changes

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -201,7 +201,7 @@ label {
 //Used as update count in GNOME software
 .counter-label {
   margin-top: 2px;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
   border-width: 0px;
   padding-left: 2px;
   padding-right: 2px;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/15329494/44201798-73f6b500-a14a-11e8-808b-dd56c336bb4c.png)

The margin is uneven at the moment, after we stopped to mimic the stackswitcher in buttonboxes.

After: 
![image](https://user-images.githubusercontent.com/15329494/44202523-8671ee00-a14c-11e8-92e7-2b07728f2cad.png)

