### PR TITLE
Remove opacity parameter from label in emoji-section

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -4658,7 +4658,7 @@ button.emoji-section {
 
   /* reset props inherited from the button style */
   background: none;
-  box-shadow: inset 0 1px $borders_color;;
+  box-shadow: inset 0 1px $borders_color;
 
   outline-offset: -5px;
 
@@ -4674,11 +4674,7 @@ button.emoji-section {
 
   label {
     padding: 0;
-    opacity: 0.55;
   }
-
-  &:hover label { opacity: 0.775; }
-  &:checked label { opacity: 1; }
 }
 
 .emoji {


### PR DESCRIPTION
Emoji-section's label uses the opacity parameter < 1 for unchecked
ones, but that makes those icons invisible (I suppose opacity parameter
is not supported in labels).

Removing opacity parameter to fix the issue.

closes #721