### PR TITLE
Selected text improvements

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -158,7 +158,7 @@ terminal-window {
     &:checked {
       color: $terminal_fg_color;
       border-color: $inkstone;
-      border-bottom: 2px solid darken($orange, 10%);
+      border-bottom: 2px solid darken($selected_bg_color, 10%);
     }
   }
 
@@ -222,7 +222,7 @@ terminal-window {
         &:hover:checked:not(:backdrop) {
           background-color: lighten($headerbar_bg_color, 6%);
           border-color: $inkstone;
-          border-bottom: 2px solid $orange;
+          border-bottom: 2px solid $selected_bg_color;
         }
 
         &:backdrop {

--- a/gtk/src/gtk-3.0/_colors.scss
+++ b/gtk/src/gtk-3.0/_colors.scss
@@ -35,7 +35,7 @@ $success_color: $green;
 $destructive_color: darken($red, 10%);
 $neutral_color: $blue;
 $focus_color: transparentize($selected_bg_color, 0.4);
-$text_selection: if($variant == 'light',lighten($blue,35%),#48b7de);
+$text_selection: if($variant == 'light',lighten($neutral_color,35%),darken($neutral_color, 10%));
 //
 $osd_fg_color: $porcelain;
 $osd_bg_color: transparentize($jet, 0.3);

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1632,9 +1632,18 @@ headerbar {
         &:hover { color: $backdrop_headerbar_text_color; }
       }
 
+      // Sadly, we need a dedicated styling here because
+      // the $variant is independant from the headerbar bg
       selection {
-        color: $headerbar_fg_color;
-        background-color: darken($text_selection, 45%);
+        $_bg: darken($text_selection, 45%);
+        $_c: $headerbar_fg_color;
+        background-color: $_bg;
+        color: $_c;
+
+        &:backdrop {
+          background-color: darken($_bg, 5%);
+          color: darken($_c,5%);
+        }
       }
     }
 

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1633,7 +1633,8 @@ headerbar {
       }
 
       selection {
-        @extend %selected_text;
+        color: $headerbar_fg_color;
+        background-color: darken($text_selection, 45%);
       }
     }
 

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1635,14 +1635,14 @@ headerbar {
       // Sadly, we need a dedicated styling here because
       // the $variant is independant from the headerbar bg
       selection {
-        $_bg: darken($text_selection, 45%);
+        $_bg: darken($neutral_color, 10%);
         $_c: $headerbar_fg_color;
         background-color: $_bg;
         color: $_c;
 
         &:backdrop {
-          background-color: darken($_bg, 5%);
-          color: darken($_c,5%);
+          background-color: _backdrop_color($_bg);
+          color: _backdrop_color($_c);
         }
       }
     }

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -190,7 +190,7 @@ label {
   &:backdrop {
     color: $backdrop_text_color;
 
-    selection { @extend %selected_items:backdrop; }
+    selection { @extend %selected_text:backdrop; }
   }
 }
 
@@ -1633,8 +1633,7 @@ headerbar {
       }
 
       selection {
-        background-color: #48b7de;
-        color: if($variant=='light', $text_color, darken(#2D2D2D,5%));
+        @extend %selected_text;
       }
     }
 
@@ -4539,15 +4538,15 @@ button.titlebutton {
 
 %selected_text {
   $c: $text_selection;
-  $tc: if($variant=='light',$text_color,darken(#2D2D2D,5%));
+  $tc: $text_color;
   background-color: $c;
   color: $tc;
 
   &:disabled { color: mix($tc, $c, 50%); }
 
   &:backdrop {
-    background-color: if($variant==light,lighten($c,5%),darken($c,5%));
-    color: $slate;
+    background-color: _backdrop_color($c);
+    color: $backdrop_text_color;
 
     &:disabled { color: mix($backdrop_selected_fg_color, $c, 30%); }
   }

--- a/gtk/src/gtk-3.0/_drawing.scss
+++ b/gtk/src/gtk-3.0/_drawing.scss
@@ -9,7 +9,7 @@
     @return if($c!=white, lighten($c, 5%), transparentize(white, 0.3));
   }
   @else {
-    @if $c==$orange or $c==$hb_pathbar_bg {
+    @if $c==$selected_bg_color or $c==$hb_pathbar_bg {
       @return lighten($c, 5%);
     } @else {
       @return darken($c, 2%);


### PR DESCRIPTION
This PR is also about organizing the code a bit more and using global styling instead of local styling so we can easily switch the colors. 

- replaced $orange with $selected_bg_color in the _backdrop_color 
function in _drawing
- replaced the local styling with %selected_text for dark entries
- use a darker blue for selected text in the dark variant
- use the text color for selected text in the dark variant, too
- use selected_text for the label in the backdrop

Todo:

- [x] Adjust dark_entries in headerbar to use the original color, but handle it in colors, not hardcoded in common

Also closes https://github.com/ubuntu/yaru/issues/733

![peek 2018-08-21 13-44](https://user-images.githubusercontent.com/15329494/44399995-e2bc7f80-a549-11e8-8460-796d1ccceee1.gif)

![screenshot-20180821140414-1539x946](https://user-images.githubusercontent.com/15329494/44400380-367b9880-a54b-11e8-9f37-8edfacebdb48.png)

![screenshot-20180821140432-1491x883](https://user-images.githubusercontent.com/15329494/44400389-3d0a1000-a54b-11e8-9bc4-79befd104d3f.png)

