### PR TITLE
Lighten default button text color for the dark variant by 10%

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -566,7 +566,7 @@ button {
     }
 
     &.default {
-      $_default_color: $selected_bg_color;
+      $_default_color: if($variant=='light',$selected_bg_color,lighten($selected_bg_color,10%));
       &, &:hover {
         color: $_default_color;
       }


### PR DESCRIPTION
Closes https://github.com/ubuntu/yaru/issues/737

![screenshot-20180822141343-1073x573](https://user-images.githubusercontent.com/15329494/44462696-c5ed7e00-a615-11e8-8fa9-700d3649b1d5.png)

@madsrh please check