### PR TITLE
Let selected labels keep bright color in backdrop

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -2111,14 +2111,15 @@ treeview.view {
 
   &:selected {
     &:focus, & {
-      border-radius: 0;
-
       @extend %selected_items;
+      border-radius: 0;
     }
 
     &:backdrop, & {
+      color: $selected_fg_color;
+      /* TODO: What the following lines actually do? */
       border-left-color: mix($selected_fg_color, $selected_bg_color, 50%);
-      border-top-color: transparentize($borders_color, 0.8); // doesn't work unfortunatelly
+      border-top-color: transparentize($borders_color, 0.8); // doesn't work unfortunately
     }
   }
 


### PR DESCRIPTION
Currently some labels in a treeview.view keep the selected_fg_color in
backdrop and some other don't.
Since keeping this color results in a clearer label, this commit makes
all the selected labels in treeview.view:backdrop to use selected_fg_color.

closes #743