### PR TITLE
Made notebook tabs more similar to gnome-terminal's ones

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -89,7 +89,7 @@ list.tweak-categories separator {
   }
 
   notebook > header > tabs {
-    background: if($variant==light, $porcelain, lighten($headerbar_bg_color, 6%));
+    background: if($variant==light, $porcelain, $headerbar_bg_color);
     &:backdrop { background-color: $backdrop_bg_color; }
 
     & > tab {

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -88,7 +88,7 @@ list.tweak-categories separator {
   }
 
   notebook > header > tabs {
-    background: if($variant==light,$porcelain,$base_color);
+    background: if($variant==light, $porcelain, lighten($headerbar_bg_color, 6%));
     &:backdrop { background-color: $backdrop_bg_color; }
 
     & > tab {

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -14,7 +14,7 @@ list.tweak-categories separator {
   // keep details box visible
   // details box looks ugly when many items are selected and it floats above the orange
   background-image: none;
-  background-color: if($variant==light,white,$base_color);
+  background-color: if($light, white, $base_color);
   &:backdrop { background-color: $backdrop_base_color }
 
   // Makes icons less bright in backdrop
@@ -61,13 +61,13 @@ list.tweak-categories separator {
   }
 
   treeview.view header button {
-    background-color: if($variant==light,white,$base_color);
+    background-color: if($light, $base_color, $base_color);
     background-image: none;
     border-color: transparentize($borders_color, 0.6);
     border-left: 1px;
 
     &:hover {background-color: $bg_color;}
-    &:backdrop { background-color: if($variant==light,#EEEFF0,$backdrop_base_color);} // It should be _backdrop_color(white); but that does not work.
+    &:backdrop { background-color: if($light, #EEEFF0, $backdrop_base_color);} // It should be _backdrop_color(white); but that does not work.
   }
 
   @at-root %remove_folder_icon_tint,
@@ -158,7 +158,7 @@ terminal-window {
     &:checked {
       color: $terminal_fg_color;
       border-color: $inkstone;
-      border-bottom: 2px solid darken($orange, 10%);
+      border-bottom: 2px solid darken($selected_bg_color, 10%);
     }
   }
 
@@ -180,7 +180,7 @@ terminal-window {
           (':disabled', 'insensitive') {
             &#{$state} {
               @include button($t, $headerbar_bg_color, $headerbar_bg_color, $flat:true);
-              color: white;
+              color: $base_color;
             }
           }
 

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -22,7 +22,7 @@ list.tweak-categories separator {
   *scrolledwindow:backdrop { opacity: 0.9; }
 
   paned box.floating-bar {
-    background: transparentize($jet,0.1);
+    background: transparentize($jet, 0.1);
     color: $porcelain;
     border: none;
     border-radius: $small_radius 0 0 0;
@@ -46,10 +46,10 @@ list.tweak-categories separator {
 
     &:backdrop {
       @if $variant=='light' {
-        background: transparentize(darken($backdrop_bg_color,10%),0.1);
+        background: transparentize(darken($backdrop_bg_color, 10%), 0.1);
       }
       @else {
-        background: transparentize(lighten($jet,10%),0.1);
+        background: transparentize(lighten($jet, 10%), 0.1);
       }
     }
   }
@@ -100,7 +100,7 @@ list.tweak-categories separator {
         border-color: if($light, transparentize($borders_color, 0.5), darken($slate, 8%));
         border-bottom: none;
 
-        &:backdrop { background-color: if($variant==light,#EEEFF0,$backdrop_base_color); }  // It should be _backdrop_color(white); but that does not work.
+        &:backdrop { background-color: if($variant==light, #EEEFF0, $backdrop_base_color); }  // It should be _backdrop_color(white); but that does not work.
       }
 
       &:not(:checked) {

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -118,7 +118,7 @@ list.tweak-categories separator {
   paned > separator {
     // separator between sidebar and main window view
     &, &:backdrop {
-      background-image: image(if($light, image(rgba(0, 0, 0, 0.06)), darken($slate, 8%)));
+      background-image: image(image(rgba(0, 0, 0, 0.06)));
     }
   }
 

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -27,6 +27,7 @@ list.tweak-categories separator {
     border: none;
     border-radius: $small_radius 0 0 0;
 
+    /* stop upload folder button */
     button.circular.flat.image-button {
       // style both normal and hover at the same time is necessary
       // otherwise gtk will take the style from somewhere else...
@@ -92,11 +93,11 @@ list.tweak-categories separator {
     &:backdrop { background-color: $backdrop_bg_color; }
 
     & > tab {
-      border-bottom: 1px solid transparentize($borders_color, 0.5);
+      border-bottom: 1px solid if($light, transparentize($borders_color, 0.5), darken($slate, 8%));
       margin: 0px;
 
       &:checked {
-        border-color: transparentize($borders_color, 0.5);
+        border-color: if($light, transparentize($borders_color, 0.5), darken($slate, 8%));
         border-bottom: none;
 
         &:backdrop { background-color: if($variant==light,#EEEFF0,$backdrop_base_color); }  // It should be _backdrop_color(white); but that does not work.

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -118,7 +118,7 @@ list.tweak-categories separator {
   paned > separator {
     // separator between sidebar and main window view
     &, &:backdrop {
-      background-image: image(if($light, image(rgba(0, 0, 0, 0.06)), darken($slate, 8%));
+      background-image: image(if($light, image(rgba(0, 0, 0, 0.06)), darken($slate, 8%)));
     }
   }
 

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -118,7 +118,7 @@ list.tweak-categories separator {
   paned > separator {
     // separator between sidebar and main window view
     &, &:backdrop {
-      background-image: image(rgba(0, 0, 0, 0.06));
+      background-image: image(if($light, image(rgba(0, 0, 0, 0.06)), darken($slate, 8%));
     }
   }
 

--- a/gtk/src/gtk-3.0/_colors.scss
+++ b/gtk/src/gtk-3.0/_colors.scss
@@ -11,10 +11,10 @@ $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //
 $selected_fg_color: white;
 $selected_bg_color: $orange;
-$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($slate, 8%));
+$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 4%));
 $link_color: $blue;
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
-$borders_edge: if($variant == 'light',rgba(0, 0, 0, 0.1), transparent($borders_color, 0.6));
+$borders_edge: if($variant == 'light',rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));
 $top_hilight: $borders_edge;
 $dark_fill: if($variant == 'light',#CDCDCD, $ash);
 $menu_color: if($variant == 'light', $base_color, darken($base_color,5%));

--- a/gtk/src/gtk-3.0/_colors.scss
+++ b/gtk/src/gtk-3.0/_colors.scss
@@ -11,10 +11,10 @@ $text_color: if($variant == 'light', #2D2D2D, $porcelain);
 //
 $selected_fg_color: white;
 $selected_bg_color: $orange;
-$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 4%));
+$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($slate, 8%));
 $link_color: $blue;
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
-$borders_edge: if($variant == 'light',rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));
+$borders_edge: if($variant == 'light',rgba(0, 0, 0, 0.1), transparent($borders_color, 0.6));
 $top_hilight: $borders_edge;
 $dark_fill: if($variant == 'light',#CDCDCD, $ash);
 $menu_color: if($variant == 'light', $base_color, darken($base_color,5%));

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -2460,14 +2460,15 @@ popover.background {
  *************/
 notebook {
   > header {
-    padding: 1px;
-    border-color: $borders_color;
+    $_borders_color: if($light, $borders_color, darken($slate, 8%));
+    background: if($light, $porcelain, lighten($headerbar_bg_color, 6%));
+    border-color: $_borders_color;
     border-width: 1px;
-    background: if($variant==light, $porcelain, $base_color);
+    padding: 1px;
 
     &:backdrop {
+      background-color: if($light, $backdrop_bg_color, $backdrop_headerbar_bg_color);
       border-color: $backdrop_borders_color;
-      background-color: $backdrop_bg_color;
     }
 
     tabs { margin: -1px; }
@@ -2480,7 +2481,7 @@ notebook {
 
         > tab {
           border-radius: 4px 4px 0 0;
-          &:checked { border-bottom-color: transparent; }
+          &:checked { border-bottom-style: none; }
         }
       }
     }
@@ -2493,7 +2494,7 @@ notebook {
 
         > tab {
           border-radius: 0 0 4px 4px;
-          &:checked { border-top-color: transparent; }
+          &:checked { border-top-style: none; }
         }
       }
     }
@@ -2597,12 +2598,17 @@ notebook {
       outline-offset: -5px;
       outline-style: dashed;
       -gtk-outline-radius: $small_radius;
-      color: $text_color;
+      color: if($light, $text_color, $silk);
       border: 1px solid transparent;
 
       &:hover:not(:active):not(:backdrop):not(:checked) {
-        background-color: mix($insensitive_bg_color, $base_color, 25%);
-        border-color: mix($borders_color, $base_color, 60%);
+        @if $light {
+          background-color: mix($insensitive_bg_color, $base_color, 25%);
+          border-color: mix($_borders_color, $base_color, 60%);
+        } @else {
+          background-color: $base_color;
+          border-color: $_borders_color;
+        }
       }
 
       &:backdrop {
@@ -2616,7 +2622,7 @@ notebook {
         color: $fg_color;
         font-weight: 500;
         background-color: $base_color;
-        border-color: $borders_color;
+        border-color: $_borders_color;
       }
 
       &:backdrop:checked {
@@ -2627,7 +2633,10 @@ notebook {
 
       // colors the button like the label, overridden otherwise
       button.flat {
-        &:hover { color: currentColor; }
+        &:hover {
+          color: currentColor;
+          border-color: if($light, $base_color, $slate);
+        }
 
         &, &:backdrop { color: gtkalpha(currentColor, 0.3); }
 

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -2461,7 +2461,7 @@ popover.background {
 notebook {
   > header {
     $_borders_color: if($light, $borders_color, darken($slate, 8%));
-    background: if($light, $porcelain, lighten($headerbar_bg_color, 6%));
+    background: if($light, $porcelain, $headerbar_bg_color);
     border-color: $_borders_color;
     border-width: 1px;
     padding: 1px;

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -2648,7 +2648,8 @@ notebook {
       button.flat {
         &:hover {
           color: currentColor;
-          border-color: if($light, $base_color, $slate);
+          background-color: $base_color;
+          border-color: $base_color;
         }
 
         &, &:backdrop { color: gtkalpha(currentColor, 0.3); }


### PR DESCRIPTION
In dark variant, notebook tabs are similar to gnome-terminal's tabs, but
they are style differently. Since gnome-terminal's tabs seems to be
appreciated, this commit style generic notebook tabs in a similar way.

NOTE: generic notebook tabs do not get the orange underline
gnome-terminal has. In fact, while the orange looks good in the
particular usage of gnome-terminal, in the wider variety of usage of
generic notebook tabs, this is not always true and instead orange make
those tabs look heavier.

![notebook-tabs 1](https://user-images.githubusercontent.com/2883614/44633169-890fe700-a987-11e8-9ab6-3239972f44fc.gif)
![notebook-tabs 2](https://user-images.githubusercontent.com/2883614/44633171-8d3c0480-a987-11e8-9004-cb6373e10db7.gif)
![notebook-tabs 3](https://user-images.githubusercontent.com/2883614/44633173-90cf8b80-a987-11e8-91c5-7a1155004d11.gif)

**TODO**
- [x] revert bright borders_color attempt
- [x] test bright borders only on separation lines (e.g. sidebar)

