### PR TITLE
gnome-shell: Don't use symbolic app icons in the top bar

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -859,7 +859,6 @@ StScrollBar {
     transition-duration: 100ms;
 
     .app-menu-icon {
-      -st-icon-style: symbolic;
       margin-left: 4px;
       margin-right: 4px;
       //dimensions of the icon are hardcoded


### PR DESCRIPTION
We prefer full-color app icons in the top bar, in part because many
third-party apps don't provide symbolic icons yet so it is more
consistent to use full-color icons for all apps.

This fixes a regression accidentally introduced in 050ddce6

[LP: #1787401](https://launchpad.net/bugs/1787401)