### PR TITLE
Darken border_bottom_color less in the dark variant for btn hover

### DIFF
--- a/gtk/src/gtk-3.0/_drawing.scss
+++ b/gtk/src/gtk-3.0/_drawing.scss
@@ -251,7 +251,19 @@
       box-shadow: none;
     } @else {
       border-color: $_border;
-      border-bottom-color: darken($_border, if($c == $headerbar_bg_color or $c == $button_bg_color, 15%, 12%));
+      $_amount: 12%;
+      @if $c==$headerbar_bg_color {
+        $_amount: 15%;
+      }
+      @else if $c==$button_bg_color {
+        @if $variant=='light' {
+          $_amount: 15%;
+        }
+        @else {
+          $_amount: 4%;
+        }
+      }
+      border-bottom-color: darken($_border, $_amount);
       box-shadow: 0 1px transparentize(black, 0.85);
     }
   }


### PR DESCRIPTION
![peek 2018-08-29 11-33](https://user-images.githubusercontent.com/15329494/44779322-7d871080-ab7f-11e8-8744-34838894f74b.gif)

Closes https://github.com/ubuntu/yaru/issues/755

@ya-d like this?