### PR TITLE
Gnome shell upstream less diff

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -190,9 +190,14 @@ StScrollBar {
   width: 65px;
   height: 22px;
   background-size: contain;
-  background-image: url("toggle-off.svg");
-  &:checked { background-image: url("toggle-on.svg"); }
 }
+
+  @each $v in us, intl {
+    .toggle-switch-#{$v} {
+      background-image: url("toggle-off.svg");
+      &:checked { background-image: url("toggle-on.svg"); }
+    }
+  }
 
 /* links */
 .shell-link {

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -99,8 +99,8 @@ StEntry {
   border-width: 1px;
   min-height: 22px;
   padding: 4px;
-
   @include entry(normal);
+  //&:hover { @include entry(hover);}
   &:focus { @include entry(focus);}
   &:insensitive { @include entry(insensitive);}
   selection-background-color: $selected_bg_color;
@@ -214,14 +214,10 @@ StScrollBar {
 .modal-dialog {
   border-radius: $medium_radius;
   @extend %dialog_window;
-
   .modal-dialog-content-box {
     padding: 24px;
   }
-  .run-dialog-entry {
-    width: 20em;
-    margin-bottom: 6px;
-
+  .run-dialog-entry { width: 20em; margin-bottom: 6px;
     &:focus { border-color: $selected_bg_color; }
   }
   .run-dialog-error-box {
@@ -1094,6 +1090,7 @@ StScrollBar {
       }
       .calendar-today {
         font-weight: bold;
+        //color: lighten($fg_color,10%);
         background-color: lighten($bg_color,13%);
       }
       .calendar-day-with-events {
@@ -1142,7 +1139,7 @@ StScrollBar {
         .message {
           background-color: transparentize($osd_bg_color, 0.7);
           border: 1px solid $osd_borders_color;
-          &:hover, &:focus { background-color: opacify(mix($osd_bg_color, $base_hover_color), 1); }
+          &:hover,&:focus { background-color: opacify(mix($osd_bg_color, $base_hover_color), 1); }
           &:active { background-color: $base_active_color; }
           &:active { .message-title, .message-content { color: $active_fg_color; } }
           border-radius: $small_radius;
@@ -1244,13 +1241,13 @@ StScrollBar {
     border: none;
 
     &:hover, &:focus {
-      color: $fg_color;
       background-color: $base_hover_color;
+      color: $fg_color;
       border: none;
       padding: 13px;
     }
 
-    &:active { color: $active_fg_color; border: none; background-color: $base_active_color; }
+    &:active { background-color: $base_active_color; border: none; color: $active_fg_color; }
 
     & > StIcon { icon-size: 16px; }
   }
@@ -1618,6 +1615,7 @@ StScrollBar {
     spacing: 11px;
     padding: 8px;
     border-radius: $medium_radius 0 0 $medium_radius;
+    //border-width: 1px 0 1px 1px; //fixme: can't have non unoform borders :(
     &:rtl { border-radius: 0 $medium_radius $medium_radius 0;}
 
 
@@ -1626,7 +1624,6 @@ StScrollBar {
       background-size: contain;
       height: 24px;
     }
-
   }
   .workspace-thumbnail-indicator {
     border: 0px solid $selected_bg_color;
@@ -1695,33 +1692,25 @@ StScrollBar {
     StEntry {
       @extend %light_entry
     }
+
+    .notification-icon { padding: 5px; }
+    .notification-content { padding: 5px; spacing: 5px; }
+    .secondary-icon { icon-size: 1.14286em; }
+    .notification-actions {
+      padding-top: 0;
+      border-top: 1px solid lighten($light_borders_color,10%);
+      spacing: 0px;
+    }
+    .notification-button {
+      @extend %light_button;
+      padding: 0 16px;
+      background-color: transparent;
+      &:focus { box-shadow: none; }
+      min-height: 35px;
+      font-weight: 500;
+      border: none;
+    }
   }
-
-  .notification-icon { padding: 5px;}
-
-  .notification-content {
-    padding: 5px;
-    spacing: 5px;
-  }
-
-  .secondary-icon { icon-size: 1.14286em; }
-
-  .notification-actions {
-    padding-top: 0;
-    border-top: 1px solid lighten($light_borders_color,10%);
-    spacing: 0px;
-  }
-
-  .notification-button {
-    @extend %light_button;
-    background-color: transparent;
-    &:focus { box-shadow: none; }
-    min-height: 35px;
-    padding: 0 16px;
-    font-weight: 500;
-    border: none;
-  }
-
   .summary-source-counter {
     font-size: 10pt;
     font-weight: bold;
@@ -1732,7 +1721,7 @@ StScrollBar {
     color: $selected_fg_color;
     border: 2px solid $osd_fg_color;
     box-shadow: 0 2px 2px rgba(0,0,0,0.5);
-    border-radius: 0.9em;
+    border-radius: 0.9em; // should be 0.8 but whatever; wish I could do 50%;
   }
 
   .secondary-icon { icon-size: 1.09em; }
@@ -1999,10 +1988,7 @@ StScrollBar {
   .login-dialog-user-list {
     spacing: 12px;
     width: 23em;
-    &:expanded .login-dialog-user-list-item:selected {
-      background-color: $selected_bg_color;
-      color: $selected_fg_color;
-    }
+    &:expanded .login-dialog-user-list-item:selected { background-color: $selected_bg_color; color: $selected_fg_color; }
     &:expanded .login-dialog-user-list-item:logged-in { border-right: 2px solid $selected_bg_color; }
   }
   .login-dialog-user-list-item {
@@ -2028,8 +2014,8 @@ StScrollBar {
     padding-left: 15px;
   }
     .user-widget-label {
-      &:ltr { padding-left: 18px; }
-      &:rtl { padding-right: 18px; }
+      &:ltr { padding-left: 14px; }
+      &:rtl { padding-right: 14px; }
     }
 
   .login-dialog-prompt-layout {
@@ -2083,7 +2069,7 @@ StScrollBar {
   font-feature-settings: "tnum";
 }
 
-.screen-shield-clock-date {
+.screen-shield-clock-date { 
   font-size: 28pt;
   font-weight: normal;
 }


### PR DESCRIPTION
I've given meld another chance to check differences between upstream and yaru (@didrocks!) to reduce the diffs, and setting the values to default when possible (like `.user-widget-label` that was changed in g-s 3.29.30, but not reported here).