### PR TITLE
Adapt flat suggested action buttons

### DIFF
--- a/gtk/src/gtk-3.0/_drawing.scss
+++ b/gtk/src/gtk-3.0/_drawing.scss
@@ -282,6 +282,12 @@
       $_bg: darken($c, 10%);
       $_border: darken($c, 15%);
       $_border_top_color: darken($_border, 5%);
+      @if $flat {
+        $_bg: darken($c, 10%);
+        $_border: $_bg;
+        $_border_top_color: $_bg;
+        $_box_shadow: none;
+      }
     }
 
     box-shadow: $_box_shadow;


### PR DESCRIPTION
I have forgotten suggested and destructive action buttons with $flat==true

@clobrano I just checked if there are any suggested action btns with flat==true outside of the headerbar and didn't find any - did I miss something?