### PR TITLE
view/check-radio: white border for selected in dark variant

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -109,8 +109,9 @@ $popover_shadow: 0 2px 5px transparentize(black, 0.75);
   &:selected {
     /* below 'border-color' actually targets check/radio
      * border in a selected (orange) row. I could not find
-     * a less generic way to target such widgets inside a .view */
-    border-color: $base_color;
+     * a less generic way to target such widgets inside a .view.
+     * NOTE: white is the right color for both light and dark variant. */
+    border-color: white;
 
     &:focus, & {
       @extend %selected_items;


### PR DESCRIPTION
check and radio buttons in a treeview.view (when unchecked) keep white
border when selected also in dark mode.

closes #725 

![image](https://user-images.githubusercontent.com/2883614/44955129-82650080-aeae-11e8-831b-a29cfb3b1cd0.png)
