### PR TITLE
drawing/entries dark: fixed backdrop entry backdround color

### DIFF
--- a/gtk/src/gtk-3.0/_drawing.scss
+++ b/gtk/src/gtk-3.0/_drawing.scss
@@ -87,7 +87,7 @@
         $_bg: $hb_button_bg_hover;
         $_tc: $backdrop_headerbar_text_color;
     } @else {
-        $_bg: if($variant=='light',_backdrop_color($c),darken($c,1%));
+        $_bg: if($variant=='light', _backdrop_color($c), $c);
         $_tc: if($tc != $text_color, mix($tc, $c, 80%), $backdrop_text_color);
     }
 


### PR DESCRIPTION
In backdrop, dark entries background got darker by just 1%, however this
little change was enough to make the background the same as transparent,
loosing the difference from insensitive-background entries.

To fix it, this commit remove the background color change in backdrop
for dark entries, as keeping this same color in both normal and backdrop
state does seems to work fine as well.

![dark-entry-backdrop-background-766](https://user-images.githubusercontent.com/2883614/44955240-79752e80-aeb0-11e8-88d5-3ae2dadfbe7a.gif)

closes #766 
