### PR TITLE
Adapt selection-mode buttons in headerbar to the new headerbar styling

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1865,15 +1865,7 @@ headerbar {
         }
 
       &.text-button:not(:hover) {
-        border-color: $success_color;
-      }
-
-      &:active, &:checked {
-        $c: darken($success_color, 10%);
-        background-color: $c;
-        box-shadow: inset 0 1px 1px 0px darken($c, 3%);
-        border-color: darken($c, 7%);
-        border-top-color: darken($c, 17%);
+        border-color: transparentize(white, 0.7);
       }
 
       &.flat, &.selection-menu {


### PR DESCRIPTION
Also add a transparent white border for text-buttons like we did with 
the other text-buttons

![image](https://user-images.githubusercontent.com/15329494/45088402-2944d900-b109-11e8-8082-b45d3c5041f1.png)

![image](https://user-images.githubusercontent.com/15329494/45088441-44afe400-b109-11e8-9a37-265192be4bf1.png)

![image](https://user-images.githubusercontent.com/15329494/45088455-54c7c380-b109-11e8-9c9b-f16d7b21b7be.png)


![peek 2018-09-05 12-39](https://user-images.githubusercontent.com/15329494/45088325-eb47b500-b108-11e8-9852-58d503859787.gif)

@clobrano @madsrh are you okay with this?