### PR TITLE
Color the .default button's text-color black/white for light/dark theme

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -572,8 +572,8 @@ button {
       }
     }
 
-    &.default {
-        font-weight: 500;
+    &.default:not(.suggested-action) {
+        color: if($variant=='light', black, white);
     }
 
     &:hover {


### PR DESCRIPTION
Closes https://github.com/ubuntu/yaru/issues/769

As seen here: https://github.com/ubuntu/yaru/issues/769#issuecomment-418080454

This replaces the previous bold font with black/white for light/dark theme
Because the buttons increase in size as you can see here:
https://github.com/ubuntu/yaru/issues/769#issuecomment-419586399