### PR TITLE
notebooks refinements

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -89,7 +89,7 @@ list.tweak-categories separator {
   }
 
   notebook > header > tabs {
-    background: if($variant==light, $porcelain, $headerbar_bg_color);
+    background: if($variant==light, $porcelain, $bg_color);
     &:backdrop { background-color: $backdrop_bg_color; }
 
     & > tab {
@@ -118,7 +118,8 @@ list.tweak-categories separator {
   paned > separator {
     // separator between sidebar and main window view
     &, &:backdrop {
-      background-image: image(image(rgba(0, 0, 0, 0.06)));
+      $_alpha: if($variant=='light', 0.06, 0.2);
+      background-image: image(image(rgba(0, 0, 0, $_alpha)));
     }
   }
 
@@ -336,12 +337,15 @@ terminal-window {
 /*********
  * Gedit *
  *********/
+.gedit-bottom-panel-paned notebook > header {
+    background: if($variant==light, $porcelain, $bg_color);
+}
 
 .gedit-bottom-panel-paned ~ statusbar {
   // give gedit's bottom panel a border
   border-top: 1px solid $borders_color;
 
-    &:backdrop { border-color: $backdrop_borders_color; }
+  &:backdrop { border-color: $backdrop_borders_color; }
 }
 
 .gedit-search-slider {
@@ -369,6 +373,7 @@ terminal-window {
 
 .gedit-document-panel { // 'documents' pane
 
+    background-color: $bg_color;
     row.activatable { padding: 6px; }
 
     row button { // 'close' button

--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -90,35 +90,17 @@ list.tweak-categories separator {
 
   notebook > header > tabs {
     background: if($variant==light, $porcelain, $bg_color);
-    &:backdrop { background-color: $backdrop_bg_color; }
 
     & > tab {
-      border-bottom: 1px solid if($light, transparentize($borders_color, 0.5), darken($slate, 8%));
+      border-bottom-color:if($light, transparentize($borders_color, 0.2), darken($slate, 8%));
       margin: 0px;
-
-      &:checked {
-        border-color: if($light, transparentize($borders_color, 0.5), darken($slate, 8%));
-        border-bottom: none;
-
-        &:backdrop { background-color: if($variant==light, #EEEFF0, $backdrop_base_color); }  // It should be _backdrop_color(white); but that does not work.
-      }
-
-      &:not(:checked) {
-        & label { color: transparentize($text_color, 0.5); }
-      }
-
-      > box{ padding: 0 8px };
-      & > box:drop(active):focus,
-      & > box:drop(active) {
-        border-radius: $small_radius;
-      }
     }
   }
 
   paned > separator {
     // separator between sidebar and main window view
     &, &:backdrop {
-      $_alpha: if($variant=='light', 0.06, 0.2);
+      $_alpha: if($variant=='light', 0.08, 0.16);
       background-image: image(image(rgba(0, 0, 0, $_alpha)));
     }
   }

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -3952,7 +3952,7 @@ filechooser {
       &, & label { color: $text_color; }
       &:checked label { font-weight: 500; }
       &:backdrop {
-        background: transparent; 
+        background: transparent;
         label { color: $backdrop_text_color; }
       }
     }

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -2466,7 +2466,7 @@ popover.background {
  *************/
 notebook {
   > header {
-    $_borders_color: if($light, $borders_color, darken($slate, 8%));
+    $_borders_color: if($light, transparentize($borders_color, 0.2), darken($slate, 8%));
     background: if($light, $porcelain, $headerbar_bg_color);
     border-color: $_borders_color;
     border-width: 1px;
@@ -2604,7 +2604,7 @@ notebook {
       outline-offset: -5px;
       outline-style: dashed;
       -gtk-outline-radius: $small_radius;
-      color: if($light, $text_color, $silk);
+      color: transparentize($text_color, 0.3);
       border: 1px solid transparent;
 
       &:hover:not(:active):not(:backdrop):not(:checked) {


### PR DESCRIPTION
In applications with a sidebar and status-bar (e.g. Nautilus and Gedit),
having unchecked notebok tabs with the same color as headerbar creates
a unpleasant effect of disconnection between the notebook and the
sidebar/status-bar.

To fix that this PR
- changes the sidebar color in Gedit to bg_color (Nautilus already uses it)
- changes the color for unchecked tabs in Gedit and Nautilus to bg_color
  (the one used by the sidebar and status bar)

Note: general notebook tabs, like the ones in gnome-terminal, keep the
previous headerbar_bg_color

Also, clean ups to let Nautilus use styling from _common.scss

closes #786 