### PR TITLE
Emoji Picker Buttons: Style button active, hover and checked

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -4753,9 +4753,18 @@ button.emoji-section {
     background-color: $base_hover_color;
   }
 
-  &:active, &:checked {
+  &:active {
     box-shadow: inset 0 2px $selected_bg_color;
     background-color: $base_active_color;
+  }
+
+  &:checked {
+    box-shadow: inset 0 2px $selected_bg_color;
+    background-color: transparent;
+    &:hover {
+      box-shadow: inset 0 2px $selected_bg_color;
+      background-color: $base_hover_color;
+    }
   }
 
   label {

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -4753,14 +4753,9 @@ button.emoji-section {
     background-color: $base_hover_color;
   }
 
-  &:active {
+  &:active, &:checked {
     box-shadow: inset 0 2px $selected_bg_color;
     background-color: $base_active_color;
-  }
-
-  &:checked {
-    box-shadow: inset 0 2px $selected_bg_color;
-    background-color: transparent;
   }
 
   label {

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -4761,6 +4761,9 @@ button.emoji-section {
   label {
     padding: 0;
   }
+
+  &:first-child { border-bottom-left-radius: $small_radius; }
+  &:last-child { border-bottom-right-radius: $small_radius; }
 }
 
 .emoji {

--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -4748,14 +4748,19 @@ button.emoji-section {
 
   outline-offset: -5px;
 
-  &:hover { box-shadow: inset 0 2px $borders_color; }
+  &:hover {
+    box-shadow: inset 0 2px $borders_color;
+    background-color: $base_hover_color;
+  }
 
   &:active {
     box-shadow: inset 0 2px $selected_bg_color;
+    background-color: $base_active_color;
   }
 
   &:checked {
     box-shadow: inset 0 2px $selected_bg_color;
+    background-color: transparent;
   }
 
   label {


### PR DESCRIPTION
Currently the checked button has a background, I think this looks a bit strange.
This changes the checked to have no bg and active to use base_active_color for the second you press and hover base_hover_color


Current:
![peek 2018-09-08 17-45](https://user-images.githubusercontent.com/15329494/45255973-e8122a80-b38f-11e8-80c4-78edee09c307.gif)


This PR:
![peek 2018-09-08 18-43](https://user-images.githubusercontent.com/15329494/45256487-3545ca80-b397-11e8-943d-366caf5252a0.gif)

![peek 2018-09-08 17-49](https://user-images.githubusercontent.com/15329494/45255975-ec3e4800-b38f-11e8-96f0-c9f88477242b.gif)

@madsrh @clobrano decide please