### PR TITLE
Fix .default buttons in headerbar

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -1665,8 +1665,13 @@ headerbar {
       }
     }
 
-    .text-button:not(.suggested-action):not(:hover) {
-      border-color: $hb_button_bg_hover;
+    .text-button:not(.suggested-action) {
+      &:not(:hover) { border-color: $hb_button_bg_hover; }
+      &.default {
+        &, &:active, &:hover, &:focus {
+          color: white;
+        }
+      }
     }
 
     button, button.flat, button.titlebutton.appmenu {
@@ -1700,12 +1705,6 @@ headerbar {
                               (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
             &#{$state} { @include button($t, $b_color, white, $flat:true); }
           }
-        }
-      }
-
-      &.default {
-        &, &:hover {
-          color: $headerbar_fg_color;
         }
       }
     }


### PR DESCRIPTION
I have forgotten this in the last PR

Current:
![peek 2018-09-08 19-01](https://user-images.githubusercontent.com/15329494/45256637-adad8b00-b399-11e8-9cb0-76213ac8cdb5.gif)

This fix:
![peek 2018-09-08 19-02](https://user-images.githubusercontent.com/15329494/45256642-c9189600-b399-11e8-95a5-0ae81b40f199.gif)
