### PR TITLE
Remove chrome styling from _apps

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -492,23 +492,6 @@ headerbar button image ~ window decoration ~ menu separator {
   }
 }
 
-/*********************
- * Chrome / Chromium *
- *********************/
-window.background.chromium {
-  button.titlebutton {
-    padding: 0;
-
-    &:not(.appmenu){
-      &:hover { @include draw_circle($headerbar_bg_color, $size:16px) ; }
-    }
-    &.close:not(:backdrop) {
-      @include draw_circle($selected_bg_color, $close:true, $size:16px);
-    }
-  }
-  menuitem { border-radius: 0; }
-}
-
 /****************
  * GNOME Photos *
  ****************/


### PR DESCRIPTION
Because the close button bug is fixed for the new released, and thus we 
don't need to make it bigger anymore

![peek 2018-09-08 23-38_2](https://user-images.githubusercontent.com/15329494/45258888-e4e36280-b3c0-11e8-8132-50a5fb1e5a0b.gif)

![peek 2018-09-08 23-38](https://user-images.githubusercontent.com/15329494/45258889-e4e36280-b3c0-11e8-8d1f-8f0ce4565aea.gif)

