### PR TITLE
drawing/check+radio dark: use transparent background

### DIFF
--- a/gtk/src/gtk-3.0/_common.scss
+++ b/gtk/src/gtk-3.0/_common.scss
@@ -2967,7 +2967,7 @@ radio {
   & {
     // for unchecked
     border: 1px solid;
-    $_c: if($light, white, lighten($bg_color, 3%));
+    $_c: if($light, white, $bg_color);
 
     @each $state, $t in ("", "normal"),
                         (":hover", "hover"),

--- a/gtk/src/gtk-3.0/_drawing.scss
+++ b/gtk/src/gtk-3.0/_drawing.scss
@@ -600,7 +600,7 @@
   $_dim_background: if($light, $dark_fill, $slate);
 
   @if $t==normal  {
-    background-color: $c;
+    background-color: if($_checked, $c, if($variant=='light', $c, transparent));
     border-color: $_border_color;
     box-shadow: 0 1px transparentize(black, 0.95);
     color: $tc;


### PR DESCRIPTION
unchecked check/radio widget uses transparent background in dark variant