### PR TITLE
Let message tray use normal icons instead of symbolic icons

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1152,7 +1152,7 @@ StScrollBar {
           .message-icon-bin > StIcon {
             color: $inactive_element_color;
             icon-size: 1.09em;
-            -st-icon-style: symbolic;
+            -st-icon-style: normal;
           }
 
           .message-secondary-bin {


### PR DESCRIPTION
Because not all apps have a symbolic icon. This way the look is unified.

![screenshot from 2018-09-11 08-47-20](https://user-images.githubusercontent.com/15329494/45342907-97711c00-b59f-11e8-95ad-bda47df9ffb1.png)
![screenshot from 2018-09-11 08-46-35](https://user-images.githubusercontent.com/15329494/45342908-97711c00-b59f-11e8-8683-d9272105e451.png)
