### PR TITLE
Remove the declaration, which let's the icon style fallback

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1152,7 +1152,6 @@ StScrollBar {
           .message-icon-bin > StIcon {
             color: $inactive_element_color;
             icon-size: 1.09em;
-            -st-icon-style: normal;
           }
 
           .message-secondary-bin {


### PR DESCRIPTION
to normal icons