### PR TITLE
apps/nautilus: fix circular button backdrop border color

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -38,6 +38,8 @@ list.tweak-categories separator {
         margin: 2px;
       }
 
+      &:backdrop { border-color: transparent; }
+
       // ...and here style just the difference from normal
       &:hover {
         color: $destructive_color;


### PR DESCRIPTION
Backdrop border color of nautilus' circular button (stop loading button)
stays dark in backdrop. This commit makes it transparent in backdrop