### PR TITLE
Use small radius for nautilus widgets/canvas items

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -111,6 +111,10 @@ list.tweak-categories separator {
       &:selected { color: transparentize($selected_fg_color, 0.3); }
   }
 
+  .nautilus-canvas-item {
+    -gtk-outline-radius: $small_radius;
+  }
+
 }
 
 .nautilus-desktop-window {


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/15329494/45359622-5b54b000-b5cd-11e8-8a62-ea9d4899f3f2.png)

![peek 2018-09-11 14-13](https://user-images.githubusercontent.com/15329494/45359507-0f097000-b5cd-11e8-8d37-5e9297deb4dd.gif)


After: 
![image](https://user-images.githubusercontent.com/15329494/45359586-437d2c00-b5cd-11e8-928a-b3b7717cc6ba.png)


![peek 2018-09-11 14-14](https://user-images.githubusercontent.com/15329494/45359497-031dae00-b5cd-11e8-92ff-05eaf6690e1a.gif)

