### PR TITLE
Use -2px offset and change outline color to white when selected

### DIFF
--- a/gtk/src/gtk-3.0/_apps.scss
+++ b/gtk/src/gtk-3.0/_apps.scss
@@ -113,8 +113,11 @@ list.tweak-categories separator {
 
   .nautilus-canvas-item {
     -gtk-outline-radius: $small_radius;
+    outline-offset: -2px;
+    &:selected {
+      outline-color: white;
+    }
   }
-
 }
 
 .nautilus-desktop-window {


### PR DESCRIPTION
Part two of https://github.com/ubuntu/yaru/pull/813#issuecomment-420400963

Using a -2px margin would work in the default case (no dim-label activated):

![image](https://user-images.githubusercontent.com/15329494/45384993-f5d5e300-b60f-11e8-95a3-74e867d21a16.png)

If one uses the dim-label option for more information it still works:
![image](https://user-images.githubusercontent.com/15329494/45385089-32094380-b610-11e8-9225-616dd02e01e5.png)

Only, in a corner case if you activate two or all three dim-labels the offset touches the lowest label:
![image](https://user-images.githubusercontent.com/15329494/45385178-64b33c00-b610-11e8-85cb-acb24589221f.png)
![image](https://user-images.githubusercontent.com/15329494/45385228-7d235680-b610-11e8-8241-ce51747fafff.png)

But the labels are only displayed if the zoom of the view is high enough:
![peek 2018-09-11 22-18](https://user-images.githubusercontent.com/15329494/45385273-9d531580-b610-11e8-8416-58d2ff10d0ea.gif)

Sadly, any padding or margin does not work here :man_shrugging: 
Sorry I'd say we are good to go, last decision to @madsrh @clobrano 

