### PR TITLE
debian/gbp.conf: Enable multimaint-merge

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,2 +1,5 @@
 [DEFAULT]
 debian-tag=%(version)s
+
+[dch]
+multimaint-merge = True


### PR DESCRIPTION
We've started [setting this](https://wiki.debian.org/Gnome/Git#gbp.conf) in Debian GNOME projects now. It's very useful for a busy project like Yaru where multiple people are committing lots of things in a single Ubuntu upload.