### PR TITLE
Style labels inside default buttons inside headerbar

### DIFF
--- a/gtk/src/light/gtk-3.0/_common.scss
+++ b/gtk/src/light/gtk-3.0/_common.scss
@@ -1665,6 +1665,7 @@ headerbar {
       }
     }
 
+    // default button and its labels needs dedicated styling in the headerbar
     .text-button:not(.suggested-action) {
       &:not(:hover) { border-color: $hb_button_bg_hover; }
       &.default {
@@ -1673,6 +1674,7 @@ headerbar {
         }
       }
     }
+    button.default { label { color: white; } }
 
     button, button.flat, button.titlebutton.appmenu {
       @each $state, $t in ("", "normal"),


### PR DESCRIPTION
Some filechosers use a label, within a box, within the headerbar 
buttons. This makes them white, when styled with .default

Closes https://github.com/ubuntu/yaru/issues/823

![image](https://user-images.githubusercontent.com/15329494/45484000-f3c86d00-b752-11e8-87b3-a51d849cba51.png)
