### PR TITLE
Build gtk-common-themes using bionic docker image

### DIFF
--- a/build-helpers/gtk-common-themes-parts.yaml
+++ b/build-helpers/gtk-common-themes-parts.yaml
@@ -12,7 +12,8 @@ parts:
       cp -a squashfs-root/share $SNAPCRAFT_PART_INSTALL/
       rm -rf $SNAPCRAFT_PART_INSTALL/share/gnome-shell/
   yaru:
-    source: .
+    source: https://github.com/REPO.git
+    source-branch: BRANCH
     plugin: meson
     meson-parameters: [--prefix=/]
     build-packages: [sassc]

--- a/build-helpers/gtk-common-themes-parts.yaml
+++ b/build-helpers/gtk-common-themes-parts.yaml
@@ -3,11 +3,11 @@ parts:
     plugin: nil
     build-packages: [snapd]
     # note: at this date (13/04/18), build-snaps gives a segfault in docker image
-    build: |
+    override-pull: |
       set -eu
       snap download communitheme --channel=CHANNEL
       unsquashfs communitheme*.snap
-    install: |
+    override-build: |
       set -eu
       cp -a squashfs-root/share $SNAPCRAFT_PART_INSTALL/
       rm -rf $SNAPCRAFT_PART_INSTALL/share/gnome-shell/
@@ -18,6 +18,7 @@ parts:
     meson-parameters: [--prefix=/]
     build-packages: [sassc]
     override-build: |
+      set -eu
       snapcraftctl build
       # remove unused artefacts in the snap (sessions and schemas)
       rm -rf $SNAPCRAFT_PART_INSTALL/share/*sessions $SNAPCRAFT_PART_INSTALL/share/glib-2.0
@@ -27,11 +28,11 @@ parts:
   gtk-common-themes-others:
     plugin: nil
     build-packages: [snapd]
-    build: |
+    override-pull: |
       set -eu
       snap download gtk-common-themes --edge
       unsquashfs gtk-common-themes*.snap
-    install: |
+    override-build: |
       set -eu
       [ -d squashfs-root/ ] || exit 1
       cp -a squashfs-root/* $SNAPCRAFT_PART_INSTALL/

--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -47,6 +47,9 @@ curl -o snap/snapcraft.yaml "https://raw.githubusercontent.com/snapcrafters/gtk-
 sed -i '/parts:/,$d' snap/snapcraft.yaml
 sed -e "s,CHANNEL,$channel,g" -e "s,REPO,$TRAVIS_REPO_SLUG," -e "s,BRANCH,$YARU_BRANCH," "$TRAVIS_BUILD_DIR/build-helpers/gtk-common-themes-parts.yaml" >> snap/snapcraft.yaml
 
+echo "####################################"
+cat snap/snapcraft.yaml
+
 # build and push gtk-common-themes snap
 cmd="sed -i s/xenial/bionic/g /etc/apt/sources.list && apt update -qq && cd $(pwd) && snapcraft"
 cmd="$cmd && echo \"$SNAP_COMMON_THEMES_TOKEN\" | snapcraft login --with - && snapcraft push *.snap --release=$channel"

--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -46,7 +46,7 @@ sed -i '/parts:/,$d' snap/snapcraft.yaml
 sed -e "s,CHANNEL,$channel,g" "$TRAVIS_BUILD_DIR/build-helpers/gtk-common-themes-parts.yaml" >> snap/snapcraft.yaml
 
 # build and push gtk-common-themes snap
-cmd="cd $(pwd) && snapcraft"
+cmd="sed -i s/xenial/bionic/g /etc/apt/sources.list && apt update -qq && cd $(pwd) && snapcraft"
 cmd="$cmd && echo \"$SNAP_COMMON_THEMES_TOKEN\" | snapcraft login --with - && snapcraft push *.snap --release=$channel"
 docker run -v $(pwd):$(pwd) -t snapcore/snapcraft:stable sh -c "$cmd"
 

--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -11,11 +11,13 @@ cmd="sed -i s/xenial/bionic/g /etc/apt/sources.list && apt update -qq && cd $(pw
 # Notes that the tokens are only available when the source repo is under ubuntu/ project.
 REPO="${TRAVIS_REPO_SLUG%%/*}"
 SOURCE_REPO="${TRAVIS_PULL_REQUEST_SLUG%%/*}"
+YARU_BRANCH="$TRAVIS_BRANCH"
 channel=""
 if [ "$REPO" == "ubuntu" ] && ([ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "$SOURCE_REPO" == "ubuntu" ]) ; then
         # if it's a PR event from
         if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
                 channel="edge/${TRAVIS_REPO_SLUG#*/}-pr$TRAVIS_PULL_REQUEST"
+                YARU_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
                 echo "PR to main ubuntu repo: will release to $channel"
         # only push build to master are released, the rest will be as PR via dedicated channel
         elif [ "$TRAVIS_BRANCH" == "master" ]; then
@@ -43,7 +45,7 @@ cd ../gtk-common-themes
 # get top part of original snapcraft.yaml and complete with new content
 curl -o snap/snapcraft.yaml "https://raw.githubusercontent.com/snapcrafters/gtk-common-themes/master/snap/snapcraft.yaml"
 sed -i '/parts:/,$d' snap/snapcraft.yaml
-sed -e "s,CHANNEL,$channel,g" "$TRAVIS_BUILD_DIR/build-helpers/gtk-common-themes-parts.yaml" >> snap/snapcraft.yaml
+sed -e "s,CHANNEL,$channel,g" -e "s,REPO,$TRAVIS_REPO_SLUG," -e "s,BRANCH,$YARU_BRANCH," "$TRAVIS_BUILD_DIR/build-helpers/gtk-common-themes-parts.yaml" >> snap/snapcraft.yaml
 
 # build and push gtk-common-themes snap
 cmd="sed -i s/xenial/bionic/g /etc/apt/sources.list && apt update -qq && cd $(pwd) && snapcraft"


### PR DESCRIPTION
As we now need sassc for gtk-common-themes, ensure we upgrade the image
to bionic as well for it.