### PR TITLE
apps/nautilus: removed custom notebook code

### DIFF
--- a/gtk/src/light/gtk-3.0/_apps.scss
+++ b/gtk/src/light/gtk-3.0/_apps.scss
@@ -90,6 +90,10 @@ list.tweak-categories separator {
     &.dnd { border-style: none; }
   }
 
+  notebook > header {
+    background: if($variant==light, $porcelain, $bg_color);
+  }
+
   paned > separator {
     // separator between sidebar and main window view
     &, &:backdrop {

--- a/gtk/src/light/gtk-3.0/_apps.scss
+++ b/gtk/src/light/gtk-3.0/_apps.scss
@@ -90,15 +90,6 @@ list.tweak-categories separator {
     &.dnd { border-style: none; }
   }
 
-  notebook > header > tabs {
-    background: if($variant==light, $porcelain, $bg_color);
-
-    & > tab {
-      border-bottom-color:if($light, transparentize($borders_color, 0.2), darken($slate, 8%));
-      margin: 0px;
-    }
-  }
-
   paned > separator {
     // separator between sidebar and main window view
     &, &:backdrop {


### PR DESCRIPTION
Custom notebook code in Nautilus is not needed anymore and moreover it
causes #829 or at least makes it very hard to fix.

closes #829

![screenshot from 2018-09-14 23-39-00](https://user-images.githubusercontent.com/2883614/45576424-6a5e8b00-b877-11e8-898c-f0688fcf4c1c.png)
![screenshot from 2018-09-14 23-45-51](https://user-images.githubusercontent.com/2883614/45576663-6bdc8300-b878-11e8-9412-943a953574af.png)


TODO
- [x] fix dark variant

