### PR TITLE
Updated url to pull gtk-common-themes from gitlab.gnome.org

### DIFF
--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -43,7 +43,7 @@ mkdir -p ../gtk-common-themes/snap
 cd ../gtk-common-themes
 
 # get top part of original snapcraft.yaml and complete with new content
-curl -o snap/snapcraft.yaml "https://raw.githubusercontent.com/snapcrafters/gtk-common-themes/master/snap/snapcraft.yaml"
+curl -o snap/snapcraft.yaml "https://gitlab.gnome.org/Community/Ubuntu/gtk-common-themes/raw/master/snap/snapcraft.yaml"
 sed -i '/parts:/,$d' snap/snapcraft.yaml
 sed -e "s,CHANNEL,$channel,g" -e "s,REPO,$TRAVIS_REPO_SLUG," -e "s,BRANCH,$YARU_BRANCH," "$TRAVIS_BUILD_DIR/build-helpers/gtk-common-themes-parts.yaml" >> snap/snapcraft.yaml
 


### PR DESCRIPTION
gtk-common-themes has moved from github to gitlab.gnome.org