### PR TITLE
GNOME disks: Selected widgets should have the a light text color.

### DIFF
--- a/gtk/src/light/gtk-3.0/_common.scss
+++ b/gtk/src/light/gtk-3.0/_common.scss
@@ -90,6 +90,8 @@ $popover_shadow: 0 2px 5px transparentize(black, 0.75);
   }
 }
 
+widget:selected { color: $selected_fg_color; }
+
 .view,
 %view {
   color: $text_color;


### PR DESCRIPTION
**Testing** PR for gnome disks (https://github.com/ubuntu/yaru/issues/714#issuecomment-422325117) and every other widget that is selected (they should all have orange bg and bright fg)

Currently, gnome-disk(s-utility) has it's selected partitions colored with black text-color even if they are selected. Which makes the text hard to read with our default selected background color: orange
![peek 2018-09-18 12-44](https://user-images.githubusercontent.com/15329494/45682448-982a2500-bb40-11e8-8077-40596c1eb637.gif)


This change applies widget:selected { color: $selected_fg_color; } high up in _common.scss 
![peek 2018-09-18 11-34](https://user-images.githubusercontent.com/15329494/45682311-336eca80-bb40-11e8-8ddf-0e39708fe83d.gif)

I can not think of a selected widget which should not have a bright text color. But we should check carefully if this does not change anything else.

@madsrh @paz-it @clobrano please test this PR if you have time and check for all the selections of UI elements and if this has a negative effect

-->  does this overwrite any selected element which should NOT have a light text color/fg color?


