### PR TITLE
Make .inline-toolbar.horizontal.sidebar-toolbar transparent in backdrop

### DIFF
--- a/gtk/src/light/gtk-3.0/_common.scss
+++ b/gtk/src/light/gtk-3.0/_common.scss
@@ -1539,6 +1539,7 @@ toolbar {
   border-width: 0 1px 1px;
   border-radius: 0  0 5px 5px;
 }
+.inline-toolbar.horizontal.sidebar-toolbar:backdrop { background-color: transparent; }
 
 searchbar,
 .location-bar {


### PR DESCRIPTION
We have forgotten to style this in backdrop

Before:
![image](https://user-images.githubusercontent.com/15329494/45744540-19e08800-bbff-11e8-8ca1-8c31b0318e7e.png)


After:
![image](https://user-images.githubusercontent.com/15329494/45744466-e9005300-bbfe-11e8-9720-165d3563988b.png)
