### PR TITLE
Shell popup usability experiments

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -19,7 +19,7 @@ $selected_bg_color: $orange;
 $selected_borders_color: if($variant=='light', darken($selected_bg_color, 5%),
                                                darken($selected_bg_color, 15%));
 $text_selection: lighten($blue,35%);
-                                               
+
 $borders_color: if($variant =='light', darken($bg_color,30%), darken($bg_color,12%));
 $borders_edge: if($variant =='light', white, transparentize($fg_color, 0.9));
 $link_color: $blue;
@@ -39,7 +39,7 @@ $inactive_indication_bg_color: darken($ash,5%);
 $osd_fg_color: $fg_color;
 $osd_bg_color: $panel_bg_color;
 $button_bg_color: $osd_bg_color;
-$osd_borders_color: transparentize($fg_color, 0.91);
+$osd_borders_color: transparentize(white, 0.87);
 //
 $base_hover_color: transparentize(white, 0.8);
 $base_active_color: transparentize(white, 0.75);

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -591,13 +591,19 @@ StScrollBar {
   }
   .popup-menu-boxpointer,
   .candidate-popup-boxpointer {
-    -arrow-border-radius: $medium_radius;
-    -arrow-background-color: $_popover_bg_color;
-    -arrow-border-width: 1px;
-    -arrow-border-color: $osd_borders_color;
-    -arrow-base: 24px;
-    -arrow-rise: 11px;
+    -arrow-border-radius: 0;
+    -arrow-background-color: transparent;
+    -arrow-border-width: 0;
+    -arrow-border-color: transparent;
+    -arrow-base: 0;
+    -arrow-rise: 0;
     -arrow-box-shadow: 0 1px 3px black; //dreaming. bug #689995
+    margin: 2px 5px 2px;
+    background-color: $osd_bg_color;
+    border-radius: $medium_radius;
+    box-shadow: 0 3px 9px 1px transparentize(black, 0.5);
+    border: 1px sold $osd_borders_color;
+
   }
 
   .popup-separator-menu-item {
@@ -2067,7 +2073,7 @@ StScrollBar {
   font-feature-settings: "tnum";
 }
 
-.screen-shield-clock-date { 
+.screen-shield-clock-date {
   font-size: 28pt;
   font-weight: normal;
 }


### PR DESCRIPTION
Testing PR 
Eventually
Closes https://github.com/ubuntu/yaru/issues/847

@matthewpaulthomas @madsrh @clobrano  @paz-it please test it 

- remove the box-pointer to be able to draw a shadow
- use the same shadow as in OSD popups
- switch osd_border color from fg_color to white (transparentized)
- make the border more opaque

![screenshot from 2018-09-21 18-42-09](https://user-images.githubusercontent.com/15329494/45894352-64642f00-bdce-11e8-8281-9686c910ac2c.png)
![screenshot from 2018-09-21 18-42-30](https://user-images.githubusercontent.com/15329494/45894353-64fcc580-bdce-11e8-9659-cf1484664bd3.png)
