### PR TITLE
shell/colors: made osd_borders_color brighter

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -19,7 +19,7 @@ $selected_bg_color: $orange;
 $selected_borders_color: if($variant=='light', darken($selected_bg_color, 5%),
                                                darken($selected_bg_color, 15%));
 $text_selection: lighten($blue,35%);
-                                               
+
 $borders_color: if($variant =='light', darken($bg_color,30%), darken($bg_color,12%));
 $borders_edge: if($variant =='light', white, transparentize($fg_color, 0.9));
 $link_color: $blue;
@@ -39,7 +39,7 @@ $inactive_indication_bg_color: darken($ash,5%);
 $osd_fg_color: $fg_color;
 $osd_bg_color: $panel_bg_color;
 $button_bg_color: $osd_bg_color;
-$osd_borders_color: transparentize($fg_color, 0.91);
+$osd_borders_color: transparentize(white, 0.87);
 //
 $base_hover_color: transparentize(white, 0.8);
 $base_active_color: transparentize(white, 0.75);

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -2067,7 +2067,7 @@ StScrollBar {
   font-feature-settings: "tnum";
 }
 
-.screen-shield-clock-date { 
+.screen-shield-clock-date {
   font-size: 28pt;
   font-weight: normal;
 }


### PR DESCRIPTION
With current shell popover/popups border color, it might be hard to
see the boundaries of the widget on dark backgrounds (see #847).

This PR makes the borders brighter to help with the issue above.

![image](https://user-images.githubusercontent.com/2883614/45917876-6ab1e400-be7e-11e8-8df7-eb05beef4416.png)

closes #847