### PR TITLE
align active notebook tab labels

### DIFF
--- a/gtk/src/light/gtk-3.0/_common.scss
+++ b/gtk/src/light/gtk-3.0/_common.scss
@@ -2630,12 +2630,14 @@ notebook {
         font-weight: 500;
         background-color: $base_color;
         border-color: $_borders_color;
+        & label {padding-bottom: 1px};
       }
 
       &:backdrop:checked {
         background-color: $backdrop_base_color;
         border-color: $backdrop_borders_color;
         color: $backdrop_fg_color;
+        & label {padding-bottom: 1px};
       }
 
       // colors the button like the label, overridden otherwise


### PR DESCRIPTION
When active, the notebook tab's label gets bold, this increases its
size and, since labels seem center aligned, the label starts one pixel
below the other non-active labels.

This PR add a 1px bottom padding to this label to fix the alignment.

closes #854

![tab-label-align](https://user-images.githubusercontent.com/2883614/45930299-9dcba480-bf5e-11e8-88b6-b67258eb3b94.png)
