### PR TITLE
Usb creator margin and geary fix

### DIFF
--- a/gtk/src/light/gtk-3.0/_apps.scss
+++ b/gtk/src/light/gtk-3.0/_apps.scss
@@ -565,4 +565,10 @@ normal-button {
  * Geary *
  ***********/
 
-.geary-expanded.geary-last headerbar { border: none; }
+.geary-expanded headerbar { border: none; }
+
+/***********
+ * usb-creator-gtk *
+ ***********/
+
+ #dialog-action_area3 { margin: 5px; }


### PR DESCRIPTION
- Add a margin to usb-creator's dialog
Closes https://github.com/ubuntu/yaru/issues/853

- Correct geary headerbar (had a mistake in my commit back then which limited this to headerbar to a specific style class)