### PR TITLE
WIP: entries, added dashed style focus ring

### DIFF
--- a/gtk/src/light/gtk-3.0/_common.scss
+++ b/gtk/src/light/gtk-3.0/_common.scss
@@ -382,7 +382,7 @@ entry {
   .linked:not(.vertical) > & { @extend %linked; }
   .linked:not(.vertical) > &:focus + &,
   .linked:not(.vertical) > &:focus + button,
-  .linked:not(.vertical) > &:focus + combobox > box > button.combo { transition: $button_transition; border-left-color: $selected_bg_color; }
+  .linked:not(.vertical) > &:focus + combobox > box > button.combo { transition: $button_transition; border-left-color: $selected_bg_color; border-left-style: dashed; }
 
   .linked:not(.vertical) > &:drop(active) + &,
   .linked:not(.vertical) > &:drop(active) + button,

--- a/gtk/src/light/gtk-3.0/_drawing.scss
+++ b/gtk/src/light/gtk-3.0/_drawing.scss
@@ -79,6 +79,7 @@
   @if $t==focus {
     @include _shadows($_entry_edge);
     border-color: entry_focus_border($fc);
+    border-style: dashed;
   }
   @if $t==insensitive {
     background-color: if($c != $base_color, mix($c, if($c == $headerbar_bg_color, $headerbar_bg_color, $base_color), 85%), transparent);


### PR DESCRIPTION
In Gtk3 focus ring has a dashed line style in all the widgets, except entries.

Uniforming the Entry to a dashed line style as well

see #844

![entry-dashed-border](https://user-images.githubusercontent.com/2883614/46813855-c1248b00-cd77-11e8-8a72-13d22a2a41e4.gif)
