### PR TITLE
Reduce dock icons padding to 1px 2px

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -181,10 +181,15 @@
   &.dashtodock.right #dash {
     // don't let the first icon be too close to the shadow + panel
     background: $dash_bg_color;
-    padding-top: 2px;
-    padding-bottom: 2px;
+    padding-top: 1px;
+    padding-bottom: 1px;
   }
-
+  
+  &.shrink .dash-item-container > StButton,
+  &.dashtodock .dash-item-container > StButton {
+    padding: 1px 2px !important;
+  }
+  
   .show-apps {
     .overview-icon {
       border-radius: $small_radius;


### PR DESCRIPTION
![gifmaker org_7psssm](https://user-images.githubusercontent.com/40228953/47258031-8a9ced80-d4a6-11e8-9ab3-c42aa48b4758.gif)

In Unity 8, an icons padding sought to be less.
I reduced them. Now the dock no longer seems so fat.
Especially at 1366x768.