### PR TITLE
Make the badge border temporarly dark red

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -125,7 +125,7 @@
     background-color: $green;
     padding: 0.2em 0.5em;
     border-radius: 1em;
-    border: 1px solid darken($green,10%);
+    border: 1px solid darken($red,10%);
     box-shadow: -1px 1px 5px 0px transparentize(black, 0.5);
     font-weight: bold;
     text-align: center;

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -122,7 +122,7 @@
 
   .notification-badge {
     color: rgba(255, 255, 255, 1);
-    background-color: $green;
+    background-color: $red;
     padding: 0.2em 0.5em;
     border-radius: 1em;
     border: 1px solid darken($red,10%);


### PR DESCRIPTION
**This should not be merged into master but instead into a new branch "Cosmic" or something
to not break the bionic snap theming**

Currently there is a bug in Cosmic, which prioritizes the stylesheet.css from /usr/share/gnome-shell/extensions/ubuntu-dock@ubuntu.com/ over our dock theming  in the yaru shell theme (https://github.com/ubuntu/yaru/issues/928)
And we end up with a color overlay of red on our green badge which looks really messy and buggy

![screenshot from 2018-10-22 12-32-01](https://user-images.githubusercontent.com/2883614/47288702-79afc180-d5f7-11e8-8276-026633cc3834.png)

This commit changes the badge border to a dark red to remove this "bugged" look. (the dashtodock css only overrides the background and does not style the border, thus our border style is used)

@didrocks I would call this rather important because currently it looks very broken in cosmic. 
We should revert this ASAP when a fix is applied in either dash to dock or ubuntu-dock

After:
![image](https://user-images.githubusercontent.com/15329494/47496963-c6de9e00-d858-11e8-8392-579eb0077d0b.png)


