### PR TITLE
shell common+dock: Fix dock opaque color and revert badge color

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -8,7 +8,7 @@ $panel-corner-radius: 0; // 6px;
 $panel-alpha-value: 0.6;
 $panel_opaque_value: 0.0;
 
-$dash-alpha-value: 0.8;
+$dash-alpha-value: 0.6;
 $dash-opaque-alpha-value: $panel_opaque_value;
 
 $popover-alpha-value: 0.025;

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -101,15 +101,13 @@
   }
 
   &.opaque {
-    /* Only alpha value is used */
-    background-color: rgba(0, 0, 0, (1 - $dash-opaque-alpha-value));
+    background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
     border-color: rgba(0, 0, 0, 0.4);
     transition-duration: 500ms;
   }
 
   &.transparent {
-    /* Only alpha value is used */
-    background-color: rgba(0, 0, 0, (1 - $dash-alpha-value));
+    background-color: transparentize($dash_bg_color, $dash-alpha-value);
     border-color: rgba(0, 0, 0, 0.1);
     transition-duration: 500ms;
   }
@@ -122,10 +120,10 @@
 
   .notification-badge {
     color: rgba(255, 255, 255, 1);
-    background-color: $red;
+    background-color: $green;
     padding: 0.2em 0.5em;
     border-radius: 1em;
-    border: 1px solid darken($red,10%);
+    border: 1px solid darken($green,10%);
     box-shadow: -1px 1px 5px 0px transparentize(black, 0.5);
     font-weight: bold;
     text-align: center;


### PR DESCRIPTION
The dash-to-dock v64 now applies both transparency values (as
it was before) and background color (this is new). Because of this,
Yaru's dock customization needs to set both values now.

Also, revert notification-badge background and border color to green.

see #928