### PR TITLE
shell/common: fixed auth dialog title style

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -255,7 +255,8 @@ StScrollBar {
   }
 
   .message-dialog-title {
-    font-weight: bold;
+    font-size: 135%;
+    font-weight: normal;
   }
 
   .message-dialog-subtitle {


### PR DESCRIPTION
Made Gnome shell _authorization dialog_ title the same as the one in _close session dialog_

closes #937 