### PR TITLE
shell/common: Made dialog background brighter

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -782,7 +782,7 @@ StScrollBar {
 }
 
 %dialog_window {
-  $dialog_bg_color: transparentize($light_bg_color, $popover-alpha-value);
+  $dialog_bg_color: transparentize($light_base_color, $popover-alpha-value);
   color: $dark_fg_color;
   background-color: $dialog_bg_color;
   border: 1px solid $light_borders_color;


### PR DESCRIPTION
Use $light_base_color (#FFFFFF) in place of $light_bg_color (#FAFAFA)
keeping the same transparency level.

closes #938 