### PR TITLE
Fix infobar branch merge

### DIFF
--- a/gtk/src/light/gtk-3.0/_common.scss
+++ b/gtk/src/light/gtk-3.0/_common.scss
@@ -2742,7 +2742,7 @@ GtkProgressBar {
         box-shadow: none;
       }
     }
-    @include block_highlight($neutral_color)
+    @include block_highlight($neutral_color);
 
     &.indicator-discrete {
       &.horizontal { margin: 0 1px; }
@@ -3246,31 +3246,6 @@ GtkPaned.wide { // this is for the paned with wide separator
  **************/
 GtkInfoBar {
   border-style: none;
-}
-
-infobar {
-  $_generic_bg: $bg_color;
-  @each $t, $c in ("", $_generic_bg),
-                  (".info", $_generic_bg),
-                  (".question", $_generic_bg),
-                  (".warning", $warning_color),
-                  ('.error', $error_color) {
-    &#{$t} {
-      background-color: $c;
-      color: white;
-      border-bottom: 1px solid $borders_color;
-      selection { @extend %selected_text; } 
-    }
-  }
-  button.close { color: white; &:backdrop { color: transparentize(white, 0.3); } }
-  > revealer > box > box label:backdrop { color: transparentize(white, 0.3); }
-  &:not(.warning):not(.error) { 
-    > revealer > box > box label { 
-      color: $text_color; 
-      &:backdrop { color: $backdrop_text_color; }
-    }
-  }
-  *:link { @extend %link_selected; }
 }
 
 /************

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4266,6 +4266,9 @@ paned {
       color: $text_color; 
       &:backdrop { color: $backdrop_text_color; }
     }
+    &:backdrop {
+      background-color: $backdrop_bg_color;
+    }
   }
   *:link { @extend %link_selected; }
 }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4245,88 +4245,28 @@ paned {
  * GtkInfoBar *
  **************/
 
-infobar {
-  @each $t, $c in ("", $purple),
-                  (".info", $purple),
-                  (".question", $purple),
+ infobar {
+  $_generic_bg: $bg_color;
+  @each $t, $c in ("", $_generic_bg),
+                  (".info", $_generic_bg),
+                  (".question", $_generic_bg),
                   (".warning", $warning_color),
                   ('.error', $error_color) {
     &#{$t} {
       background-color: $c;
       color: white;
-      border-bottom: none;
-      selection { background-color: darken($c, 10%); }
-
-      // The following extensive local styling of buttons in infobars
-      // should be replaced by smarter functions in drawing after 18.10 UI-Freeze
-      $_active_amount: if($variant=='light', 10%, 8%);
-      $_hover_amount: 5%;
-      $_bg: if($variant=='light', $button_bg_color, lighten($button_bg_color, $_hover_amount));
-      $_c: $fg_color;
-      $_active_bg: darken($_bg, $_active_amount);
-      $_hover_bg: if($variant=='light', darken($_bg, $_hover_amount), lighten($_bg, $_hover_amount));
-      $_insensitive_bg: mix($c, $_bg, 20%);
-
-      button.close {
-        &, &:backdrop {
-          color: white;
-          border-color: transparent;
-          box-shadow: none;
-        }
-        &:hover {
-          background-color: darken($c, $_hover_amount);
-        }
-        &:active {
-          color: transparentize(white, 0.3);
-          background-color: darken($c, $_active_amount);
-        }
-      }
-
-      button:not(.close) {
-        border-color: $_bg;
-        box-shadow: none;
-        background-color: $_bg;
-        color: $_c;
-        &:hover {
-          background-color: $_hover_bg;
-          border-color: $_hover_bg;
-        }
-        &:active {
-          border-color: $_active_bg;
-          background-color: $_active_bg;
-          color: lighten($_c, $_active_amount);
-        }
-        &:disabled {
-          background-color: $_insensitive_bg;
-          border-color: $_insensitive_bg;
-          label { color: $insensitive_fg_color; }
-        }
-        &:backdrop {
-          background-color: _backdrop_color($_bg);
-          border-color: _backdrop_color($_bg);
-          &:disabled {
-            background-color: $_insensitive_bg;
-            border-color: $_insensitive_bg;
-            label { color: _backdrop_color($insensitive_fg_color); }
-          }
-          &:hover {
-            background-color: $_hover_bg;
-            border-color: $_hover_bg;
-          }
-          &:active {
-            background-color: $_active_bg;
-            border-color: $_active_bg;
-          }
-        }
-      }
-
-      &:backdrop {
-        background-color: _backdrop_color($c);
-        color: $selected_fg_color;
-      }
+      border-bottom: 1px solid $borders_color;
+      selection { @extend %selected_text; } 
     }
   }
+  button.close { color: white; &:backdrop { color: transparentize(white, 0.3); } }
   > revealer > box > box label:backdrop { color: transparentize(white, 0.3); }
+  &:not(.warning):not(.error) { 
+    > revealer > box > box label { 
+      color: $text_color; 
+      &:backdrop { color: $backdrop_text_color; }
+    }
+  }
   *:link { @extend %link_selected; }
 }
 


### PR DESCRIPTION
- the infobar file changes got applied onto the "old" folders i.e. 3.18 now after the merge of https://github.com/ubuntu/yaru/pull/935
- this is a damage control to get a stable master now and leaves infobars unstyled for gtk 3.18, this needs further investigation @jhenstridge
- also fixes a semicolon miss
- fixes backdrop

![image](https://user-images.githubusercontent.com/15329494/48005246-37b46e80-e113-11e8-96c2-00bada728466.png)

![image](https://user-images.githubusercontent.com/15329494/48005280-54e93d00-e113-11e8-89fd-9583c0457d2d.png)
