### PR TITLE
Revert "Style the Shell's virtual keyboard to match the rest of the theme"

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1826,47 +1826,45 @@ StScrollBar {
   }
 
   .keyboard-key {
-    background-color: $dark_fg_color;
+    background-color: #393f3f;
     min-height: 2em;
     min-width: 2em;
     font-size: 16pt;
     border-radius: 3px;
-    border: 1px solid $osd_borders_color;
-    color: $fg_color;
-    &:focus { @include button(focus, $dark_fg_color, $fg_color); }
-    &:hover,&:checked { @include button(hover, $dark_fg_color, $fg_color); }
-    &:active { @include button(active, $dark_fg_color, $fg_color);}
+    border: 1px solid #464d4d;
+    color: #e5e5e5;
+    &:focus { @include button(focus); }
+    &:hover,&:checked { @include button(hover); }
+    &:active { @include button(active);}
     &:grayed { //FIXME
       background-color: $osd_bg_color;
       color: $osd_fg_color;
       border-color: $osd_borders_color;
     }
     &.default-key {
-      border-color: $osd_borders_color;
-      background-color: darken($dark_fg_color, 5%);
-      background-size: 24px;
+      border-color: #2d3232;
+      background-color: #1d2020;
+      background-size: 20px;
     }
     &.enter-key {
-      @include button(normal, $success_color);
-      // border-color: _border_color(#00A2E4);
-      // background-color: #00A2E4;
-      background-image: url("key-enter.svg");
-      &:active { @include button(active, darken($success_color, 5%)); }
+      border-color: #005684;
+      background-color: #006098;
+      background-image: url("resource:///org/gnome/shell/theme/key-enter.svg");
     }
     &.shift-key-lowercase {
-      background-image: url("key-shift.svg");
+      background-image: url("resource:///org/gnome/shell/theme/key-shift.svg");
     }
     &.shift-key-uppercase {
-      background-image: url("key-shift-uppercase.svg");
+      background-image: url("resource:///org/gnome/shell/theme/key-shift-uppercase.svg");
     }
     &.shift-key-uppercase:latched {
-      background-image: url("key-shift-latched-uppercase.svg");
+      background-image: url("resource:///org/gnome/shell/theme/key-shift-latched-uppercase.svg");
     }
     &.hide-key {
-      background-image: url("key-hide.svg");
+      background-image: url("resource:///org/gnome/shell/theme/key-hide.svg");
     }
     &.layout-key {
-      background-image: url("key-layout.svg");
+      background-image: url("resource:///org/gnome/shell/theme/key-layout.svg");
     }
   }
 

--- a/gnome-shell/src/key-enter.svg
+++ b/gnome-shell/src/key-enter.svg
@@ -8,13 +8,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="30"
-   viewBox="0 0 30 26"
+   width="32"
+   viewBox="0 0 32 32"
    version="1.1"
    id="svg7384"
-   height="26"
+   height="32"
    sodipodi:docname="key-enter.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,18 +24,17 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="704"
+     inkscape:window-width="1744"
+     inkscape:window-height="866"
      id="namedview19"
      showgrid="false"
-     inkscape:zoom="10.429825"
-     inkscape:cx="3.9670882"
-     inkscape:cy="12.455512"
+     inkscape:zoom="14.75"
+     inkscape:cx="7.9322034"
+     inkscape:cy="14.554666"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="55"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg7384"
-     inkscape:pagecheckerboard="true" />
+     inkscape:current-layer="svg7384" />
   <metadata
      id="metadata90">
     <rdf:RDF>
@@ -63,95 +62,48 @@
     </linearGradient>
   </defs>
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer9" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer10" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      id="layer11" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer13" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      id="layer14" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer15" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="g71291" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="g4953" />
   <g
-     transform="translate(-1.0000001,-3.2499996)"
-     id="g871">
-    <g
-       id="layer9-6"
-       style="display:inline;fill:#ffffff"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="layer10-7"
-       style="display:inline;fill:#ffffff"
-       transform="translate(-141.0002,-791)" />
-    <g
-       style="fill:#ffffff"
-       id="layer11-5"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="layer13-3"
-       style="display:inline;fill:#ffffff"
-       transform="translate(-141.0002,-791)" />
-    <g
-       style="fill:#ffffff"
-       id="layer14-5"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="layer15-6"
-       style="display:inline;fill:#ffffff"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="g71291-2"
-       style="display:inline;fill:#ffffff"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="g4953-9"
-       style="display:inline;fill:#ffffff"
-       transform="translate(-141.0002,-791)" />
-    <g
-       transform="matrix(2.2,0,0,2.2,1.9401993,-3.8)"
-       style="color:#000000;fill:#ffffff"
-       id="g832" />
-    <g
-       id="g942">
-      <path
-         id="path828-3"
-         overflow="visible"
-         font-weight="400"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;stroke-width:2.5;marker:none"
-         d="m 29.140201,13.85 c 0,3.75 -1.6,6.2325 -3.895,7.435 -2.292502,1.205 -5.045002,1.315 -7.675002,1.315 h -7.514642 v -2.5 h 7.514642 c 2.5275,0 4.9375,-0.2 6.515002,-1.0275 1.575,-0.8275 2.555,-2.0975 2.555,-5.2225 V 5 h 2.5 z"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scsccscsccs" />
-      <g
-         id="g832-1"
-         style="color:#000000;fill:#ffffff"
-         transform="matrix(2.4,0,0,2.4,1.8565993,-26.1)">
-        <path
-           id="path830-2"
-           overflow="visible"
-           style="overflow:visible;fill:#ffffff;marker:none"
-           d="m 5,17.333333 v 5 a 36.958,36.958 0 0 1 -2.323,-1.166 c -0.78,-0.431 -1.534,-0.876 -2.259,-1.334 0.725,-0.449 1.478,-0.889 2.26,-1.32 a 43.09,43.09 0 0 1 2.322,-1.18 z"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
+     transform="matrix(2,0,0,2,-281.56285,-1615.0002)"
+     style="display:inline"
+     id="layer12">
+    <path
+       id="path16589"
+       d="m 148.00015,821.0002 h -1 c -0.26528,0 -0.53057,-0.093 -0.71875,-0.2812 l -3.71875,-3.7188 c 0,0 2.47917,-2.4792 3.71875,-3.7187 0.18817,-0.1882 0.45344,-0.2813 0.71875,-0.2813 h 1 v 1 c 0,0.2653 -0.0931,0.5306 -0.28125,0.7188 l -2.28125,2.2812 2.28125,2.2813 c 0.18811,0.1881 0.28129,0.4534 0.28125,0.7187 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:'Bitstream Vera Sans';-inkscape-font-specification:'Bitstream Vera Sans';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#bebebe;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 154.0002,810 v 4.5 c 0,1.3807 -1.11929,2.5 -2.5,2.5 h -6.50005"
+       id="path16591"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/gnome-shell/src/key-hide.svg
+++ b/gnome-shell/src/key-hide.svg
@@ -8,13 +8,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="26"
-   viewBox="0 0 26 26"
+   width="32"
+   viewBox="0 0 32 32"
    version="1.1"
    id="svg7384"
-   height="26"
+   height="32"
    sodipodi:docname="key-hide.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,18 +24,17 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="704"
+     inkscape:window-width="1919"
+     inkscape:window-height="1011"
      id="namedview19"
      showgrid="false"
      inkscape:zoom="14.75"
-     inkscape:cx="12.271187"
+     inkscape:cx="-12.338983"
      inkscape:cy="14.554666"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="55"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg7384"
-     inkscape:pagecheckerboard="true" />
+     inkscape:current-layer="svg7384" />
   <metadata
      id="metadata90">
     <rdf:RDF>
@@ -63,38 +62,53 @@
     </linearGradient>
   </defs>
   <g
-     transform="matrix(1.0833333,0,0,-1.0833333,-152.83355,890.1875)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer9" />
   <g
-     transform="matrix(1.0833333,0,0,-1.0833333,-152.83355,890.1875)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer10" />
   <g
-     transform="matrix(1.0833333,0,0,-1.0833333,-152.83355,890.1875)"
+     transform="translate(-141.0002,-791)"
      id="layer11" />
   <g
-     transform="matrix(1.0833333,0,0,-1.0833333,-152.83355,890.1875)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer13" />
   <g
-     transform="matrix(1.0833333,0,0,-1.0833333,-152.83355,890.1875)"
+     transform="translate(-141.0002,-791)"
      id="layer14" />
   <g
-     transform="matrix(1.0833333,0,0,-1.0833333,-152.83355,890.1875)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer15" />
   <g
-     transform="matrix(1.0833333,0,0,-1.0833333,-152.83355,890.1875)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="g71291" />
   <g
-     transform="matrix(1.0833333,0,0,-1.0833333,-152.83355,890.1875)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="g4953" />
-  <path
-     id="path828"
-     d="m 26,8.9375 c -1.42025,1.12125 -2.855125,2.270125 -4.316,3.263 -1.625,1.103375 -3.2045,2.091375 -4.732,2.965625 C 15.5415,15.97375 14.06925,16.579875 13,17.0625 11.93075,16.579875 10.4585,15.97375 9.048,15.166125 A 72.830875,72.830875 0 0 1 4.3159999,12.2005 C 2.8534999,11.20925 1.4202499,10.060375 -3.5000001e-8,8.9375 H 2.4212499 c 0.8515,0.65 1.72575,1.360125 2.640625,1.98575 1.15375,0.78975 2.335125,1.53075 3.5425,2.22625 a 63.701625,63.701625 0 0 0 4.0625001,2.088125 h 0.0016 l 0.3315,0.156 0.329875,-0.156 c 1.15375,-0.54275 2.838875,-1.3845 4.064125,-2.088125 1.209,-0.6955 2.38875,-1.4365 3.544125,-2.22625 0.91325,-0.625625 1.7875,-1.33575 2.640625,-1.98575 z"
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;stroke-width:1.625" />
+  <g
+     style="display:inline"
+     inkscape:label="go-down"
+     id="g11722"
+     transform="matrix(2,0,0,2,-362.0004,-1494)">
+    <rect
+       transform="rotate(90)"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new"
+       id="rect11718"
+       y="-197.0002"
+       x="747"
+       height="16"
+       width="16" />
+    <path
+       style="display:inline;fill:#e5e5e5;fill-opacity:1;stroke:none"
+       d="m 189.0002,759.4375 -5.71875,-5.7187 C 183.08558,753.5229 183.0002,753.2556 183.0002,753 v -1 h 1 c 0.25562,0 0.52288,0.085 0.71875,0.2813 l 4.28125,4.2812 4.28125,-4.2812 C 193.47732,752.0854 193.74458,752 194.0002,752 h 1 v 1 c 0,0.2556 -0.0854,0.5229 -0.28125,0.7188 z"
+       id="path11720"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscsccsscscc" />
+  </g>
 </svg>

--- a/gnome-shell/src/key-layout.svg
+++ b/gnome-shell/src/key-layout.svg
@@ -8,13 +8,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="24"
-   viewBox="0 0 24 24"
+   width="32"
+   viewBox="0 0 32 32"
    version="1.1"
    id="svg7384"
-   height="24"
+   height="32"
    sodipodi:docname="key-layout.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,18 +24,17 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="704"
+     inkscape:window-width="1919"
+     inkscape:window-height="1011"
      id="namedview19"
      showgrid="false"
      inkscape:zoom="14.75"
-     inkscape:cx="9.7627127"
-     inkscape:cy="14.554666"
+     inkscape:cx="1.220339"
+     inkscape:cy="11.842802"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="55"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg7384"
-     inkscape:pagecheckerboard="true" />
+     inkscape:current-layer="svg7384" />
   <metadata
      id="metadata90">
     <rdf:RDF>
@@ -63,40 +62,53 @@
     </linearGradient>
   </defs>
   <g
-     transform="translate(-141.0002,-799)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer9" />
   <g
-     transform="translate(-141.0002,-799)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer10" />
   <g
-     transform="translate(-141.0002,-799)"
+     transform="translate(-141.0002,-791)"
      id="layer11" />
   <g
-     transform="translate(-141.0002,-799)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer13" />
   <g
-     transform="translate(-141.0002,-799)"
+     transform="translate(-141.0002,-791)"
      id="layer14" />
   <g
-     transform="translate(-141.0002,-799)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer15" />
   <g
-     transform="translate(-141.0002,-799)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="g71291" />
   <g
-     transform="translate(-141.0002,-799)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="g4953" />
-  <path
-     id="path829"
-     style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;stroke-width:1.375;marker:none"
-     overflow="visible"
-     font-weight="400"
-     d="M 12,0.99999995 C 5.93075,0.99999995 1,5.93075 1,12 1,18.06925 5.93075,23 12,23 18.06925,23 23,18.06925 23,12 23,5.93075 18.06925,0.99999995 12,0.99999995 Z M 11.945,2.3777499 11.9175,3.226125 13.175625,3.4145 14.025375,2.5922499 a 9.5315,9.5315 0 0 1 2.3815,0.8593751 l -0.295625,0.47575 0.83875,0.7425 -0.83875,0.70125 0.32725,0.83875 1.8645,-0.8855 1.166,0.8855 0.0605,-0.191125 c 0.253,0.319 0.48125,0.6558752 0.693,1.0037502 l -1.175625,0.213125 -0.6985,-0.7466252 -2.14225,0.1402502 -1.30625,2.0515 0.886875,2.1889998 2.888875,0.8855 0.559625,3.403125 0.697125,1.769625 0.49225,-0.279125 A 9.62775,9.62775 0 0 1 12,21.625 c -5.31025,0 -9.625,-4.31475 -9.625,-9.625 0,-1.1165 0.199375,-2.1848749 0.55,-3.1817498 l 0.04675,0.1869999 1.4905,0.419375 1.956625,1.4437499 0.04675,2.09825 1.2595,1.72425 0.7425,4.66125 1.351625,0.83875 L 9.448,18.466625 11.7305,15.29725 12.7095,13.155 10.427,11.01 7.956125,9.8467501 6.93175,10.450375 5.719,8.6326252 5.0205,8.9598752 4.4155,7.9341251 5.488,7.3758752 6.511,7.9808752 8.283375,5.7905 10.845,4.2065 10.1465,2.90025 8.049625,3.64825 7.788375,3.358125 a 9.552125,9.552125 0 0 1 4.158,-0.9803751 z"
-     inkscape:connector-curvature="0" />
+  <g
+     inkscape:label="preferences-desktop-locale"
+     id="g11728"
+     transform="matrix(2,0,0,2,-522.0004,-1086)"
+     style="display:inline;stroke-width:1">
+    <rect
+       style="fill:none;stroke:none;stroke-width:1"
+       id="rect11724"
+       width="16"
+       height="16"
+       x="20"
+       y="326"
+       transform="translate(241.0002,217)" />
+    <path
+       style="fill:#e5e5e5;fill-opacity:1;stroke:none;stroke-width:1"
+       d="m 265.69612,545.23396 c -3.58218,0 -4.66582,1.39975 -4.66582,1.39975 v 10.04946 c 0,0 1.08364,-1.07673 4.66582,-1.07673 2.9161,0 4.47225,1.07673 7.17818,1.07673 2.08923,0 3.19429,-1.39975 3.19429,-1.39975 v -10.04946 c 0,0 -1.14095,1.04084 -3.23018,1.04084 -3.3734,0 -3.97619,-1.04084 -7.14229,-1.04084 z m 2.93145,2.77148 c 1.32876,0 2.375,1.08037 2.375,2.4375 0,1.35713 -1.04624,2.46875 -2.375,2.46875 -1.32876,0 -2.40625,-1.11162 -2.40625,-2.46875 0,-1.35713 1.07749,-2.4375 2.40625,-2.4375 z m -4.5625,0.96875 0.96875,1.03125 -0.9375,-0.0312 0.9375,1 -0.96875,-0.0312 0.96875,1.03125 -1,-0.0312 0.0312,-1 h -0.0312 l 0.0312,-0.9688 h -0.0312 z m 4.5625,0 c -0.794,0 -1.46875,0.6578 -1.46875,1.46875 0,0.81095 0.67475,1.46875 1.46875,1.46875 0.79399,0 1.4375,-0.6578 1.4375,-1.46875 0,-0.81095 -0.64351,-1.46875 -1.4375,-1.46875 z m 4.375,0 v 1 l 0.0312,0.96875 h -0.0312 l 0.0312,1 -1,0.0312 0.96875,-1.03125 -0.96875,0.0312 0.9375,-1 -0.9375,0.0312 z m -7.9375,2.96875 0.96875,1.03125 -1,-0.0312 z m 6.9375,0 0.0312,1 -1,0.0312 z m -5.9375,1 0.96875,1.03125 -1,-0.0312 z m 4.9375,0 0.0312,1 -1,0.0312 z"
+       id="path11726"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccssccsssssssccccccccccccsssssccccccccccccccccccccccccccc" />
+  </g>
 </svg>

--- a/gnome-shell/src/key-shift-latched-uppercase.svg
+++ b/gnome-shell/src/key-shift-latched-uppercase.svg
@@ -8,13 +8,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="26"
-   viewBox="0 0 26 26"
+   width="32"
+   viewBox="0 0 32 32"
    version="1.1"
    id="svg7384"
-   height="26"
+   height="32"
    sodipodi:docname="key-shift-latched-uppercase.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,15 +24,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="704"
+     inkscape:window-width="1791"
+     inkscape:window-height="984"
      id="namedview19"
      showgrid="false"
      inkscape:zoom="14.75"
-     inkscape:cx="0.881356"
-     inkscape:cy="10.711865"
+     inkscape:cx="-0.77966097"
+     inkscape:cy="18.847458"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="55"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg7384" />
   <metadata
@@ -62,127 +62,48 @@
     </linearGradient>
   </defs>
   <g
-     id="g920"
-     transform="translate(-3,-0.93985)">
-    <g
-       id="layer9"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="layer10"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="translate(-141.0002,-791)" />
-    <g
-       style="fill:#00a2e4;fill-opacity:1"
-       id="layer11"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="layer13"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="translate(-141.0002,-791)" />
-    <g
-       style="fill:#00a2e4;fill-opacity:1"
-       id="layer14"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="layer15"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="g71291"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="translate(-141.0002,-791)" />
-    <g
-       id="g4953"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="translate(-141.0002,-791)" />
-    <g
-       transform="translate(0,-4.7813)"
-       id="g871">
-      <g
-         transform="translate(-141.0002,-791)"
-         style="display:inline"
-         id="layer9-56" />
-      <g
-         transform="translate(-141.0002,-791)"
-         style="display:inline"
-         id="layer10-2" />
-      <g
-         transform="translate(-141.0002,-791)"
-         id="layer11-9" />
-      <g
-         transform="translate(-141.0002,-791)"
-         style="display:inline"
-         id="layer13-1" />
-      <g
-         transform="translate(-141.0002,-791)"
-         id="layer14-2" />
-      <g
-         transform="translate(-141.0002,-791)"
-         style="display:inline"
-         id="layer15-7" />
-      <g
-         transform="translate(-141.0002,-791)"
-         style="display:inline"
-         id="g71291-0" />
-      <g
-         transform="translate(-141.0002,-791)"
-         style="display:inline"
-         id="g4953-9" />
-      <g
-         id="g1410"
-         transform="translate(3,3)"
-         style="fill:#00a2e4;fill-opacity:1">
-        <g
-           id="layer9-5"
-           style="display:inline;fill:#00a2e4;fill-opacity:1"
-           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-        <g
-           id="layer10-6"
-           style="display:inline;fill:#00a2e4;fill-opacity:1"
-           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-        <g
-           style="fill:#00a2e4;fill-opacity:1"
-           id="layer11-2"
-           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-        <g
-           id="layer13-9"
-           style="display:inline;fill:#00a2e4;fill-opacity:1"
-           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-        <g
-           style="fill:#00a2e4;fill-opacity:1"
-           id="layer14-1"
-           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-        <g
-           id="layer15-2"
-           style="display:inline;fill:#00a2e4;fill-opacity:1"
-           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-        <g
-           id="g71291-7"
-           style="display:inline;fill:#00a2e4;fill-opacity:1"
-           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-        <g
-           id="g4953-0"
-           style="display:inline;fill:#00a2e4;fill-opacity:1"
-           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-        <path
-           sodipodi:nodetypes="cccccccc"
-           style="opacity:1;fill:#00a2e4;fill-opacity:1;stroke-width:1.99999988"
-           inkscape:connector-curvature="0"
-           id="path4"
-           d="m 13,4 c 0,0 2,2.0000001 9,12 H 18.000001 L 18,22 H 8 l 3e-7,-6 H 4 C 11,6.0000002 13,4 13,4 Z" />
-      </g>
-    </g>
-    <g
-       id="layer12-3"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="matrix(2,0,0,2,-281.9377,-1618.339)">
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00a2e4;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
-         d="m 146.46885,822 v -2 h 5 v 2 z"
-         id="path16534-6" />
-    </g>
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer10" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer11" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer13" />
+  <g
+     transform="translate(-141.0002,-791)"
+     id="layer14" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="layer15" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g71291" />
+  <g
+     transform="translate(-141.0002,-791)"
+     style="display:inline"
+     id="g4953" />
+  <g
+     transform="matrix(2,0,0,2,-282.0004,-1614.2187)"
+     style="display:inline;fill:#006098;fill-opacity:1"
+     id="layer12">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#006098;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       d="m 147,818 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
+       id="path16532"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path16534"
+       d="m 147,822 v -2 h 3.9377 v 2 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#006098;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/gnome-shell/src/key-shift-uppercase.svg
+++ b/gnome-shell/src/key-shift-uppercase.svg
@@ -8,13 +8,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="26"
-   viewBox="0 0 26 26"
+   width="32"
+   viewBox="0 0 32 32"
    version="1.1"
    id="svg7384"
-   height="26"
+   height="32"
    sodipodi:docname="key-shift-uppercase.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,18 +24,17 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="704"
+     inkscape:window-width="2160"
+     inkscape:window-height="1311"
      id="namedview18"
      showgrid="false"
      inkscape:zoom="14.75"
-     inkscape:cx="-4.677966"
-     inkscape:cy="13.423729"
+     inkscape:cx="-27.898305"
+     inkscape:cy="8"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="55"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg7384"
-     inkscape:pagecheckerboard="true" />
+     inkscape:current-layer="svg7384" />
   <metadata
      id="metadata90">
     <rdf:RDF>
@@ -63,75 +62,43 @@
     </linearGradient>
   </defs>
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer9" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer10" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      id="layer11" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer13" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      id="layer14" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="layer15" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="g71291" />
   <g
-     transform="translate(-141.0002,-797)"
+     transform="translate(-141.0002,-791)"
      style="display:inline"
      id="g4953" />
   <g
-     id="g1410"
-     style="fill:#00a2e4;fill-opacity:1">
-    <g
-       id="layer9-5"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-    <g
-       id="layer10-6"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-    <g
-       style="fill:#00a2e4;fill-opacity:1"
-       id="layer11-2"
-       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-    <g
-       id="layer13-9"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-    <g
-       style="fill:#00a2e4;fill-opacity:1"
-       id="layer14-1"
-       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-    <g
-       id="layer15-2"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-    <g
-       id="g71291-7"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
-    <g
-       id="g4953-0"
-       style="display:inline;fill:#00a2e4;fill-opacity:1"
-       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+     transform="matrix(2,0,0,2,-282.0008,-1614.2187)"
+     style="display:inline;fill:#006098;fill-opacity:1"
+     id="layer12">
     <path
-       sodipodi:nodetypes="cccccccc"
-       style="opacity:1;fill:#00a2e4;fill-opacity:1;stroke-width:1.99999988"
-       inkscape:connector-curvature="0"
-       id="path4"
-       d="m 13,4 c 0,0 2,2.0000001 9,12 h -3.999999 v 6 C 8.0000003,22 16.562803,22 8.0000003,22 V 16 H 4 C 11,6.0000002 13,4 13,4 Z" />
+       id="path16548"
+       d="m 147.0002,820 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#006098;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/gnome-shell/src/key-shift.svg
+++ b/gnome-shell/src/key-shift.svg
@@ -8,13 +8,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="26"
-   viewBox="0 0 26 26"
+   width="32"
+   viewBox="0 0 32 32"
    version="1.1"
    id="svg7384"
-   height="26"
+   height="32"
    sodipodi:docname="key-shift.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,8 +24,8 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="704"
+     inkscape:window-width="1400"
+     inkscape:window-height="1034"
      id="namedview4569"
      showgrid="false"
      fit-margin-top="0"
@@ -33,13 +33,12 @@
      fit-margin-right="0"
      fit-margin-bottom="0"
      inkscape:zoom="14.75"
-     inkscape:cx="3.1925966"
-     inkscape:cy="13.135593"
+     inkscape:cx="1.5993763"
+     inkscape:cy="5"
      inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg7384"
-     inkscape:pagecheckerboard="true" />
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
   <metadata
      id="metadata90">
     <rdf:RDF>
@@ -67,41 +66,43 @@
     </linearGradient>
   </defs>
   <g
-     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
-     style="display:inline;fill:#f7f7f7;fill-opacity:1"
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
      id="layer9" />
   <g
-     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
-     style="display:inline;fill:#f7f7f7;fill-opacity:1"
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
      id="layer10" />
   <g
-     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
-     id="layer11"
-     style="fill:#f7f7f7;fill-opacity:1" />
+     transform="translate(-143.8754,-788)"
+     id="layer11" />
   <g
-     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
-     style="display:inline;fill:#f7f7f7;fill-opacity:1"
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
      id="layer13" />
   <g
-     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
-     id="layer14"
-     style="fill:#f7f7f7;fill-opacity:1" />
+     transform="translate(-143.8754,-788)"
+     id="layer14" />
   <g
-     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
-     style="display:inline;fill:#f7f7f7;fill-opacity:1"
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
      id="layer15" />
   <g
-     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
-     style="display:inline;fill:#f7f7f7;fill-opacity:1"
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
      id="g71291" />
   <g
-     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
-     style="display:inline;fill:#f7f7f7;fill-opacity:1"
+     transform="translate(-143.8754,-788)"
+     style="display:inline"
      id="g4953" />
-  <path
-     d="m 13,4 c 0,0 2,2.0000001 9,12 h -3.999999 v 6 C 8.0000003,22 16.562803,22 8.0000003,22 V 16 H 4 C 11,6.0000002 13,4 13,4 Z"
-     id="path4"
-     inkscape:connector-curvature="0"
-     style="opacity:1;fill:#ffffff;stroke-width:1.99999988"
-     sodipodi:nodetypes="cccccccc" />
+  <g
+     transform="matrix(2,0,0,2,-282.0008,-1614.2187)"
+     style="display:inline"
+     id="layer12">
+    <path
+       id="path16548"
+       d="m 147.0002,820 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/gnome-shell/src/meson.build
+++ b/gnome-shell/src/meson.build
@@ -76,12 +76,6 @@ data_sources = [
   'ws-switch-arrow-up.svg',
   'activities.svg',
   'ubuntu-appgrid-icon.svg',
-  'key-enter.svg',
-  'key-hide.svg',
-  'key-layout.svg',
-  'key-shift.svg',
-  'key-shift-latched-uppercase.svg',
-  'key-shift-uppercase.svg'
 ]
 
 # install static data files


### PR DESCRIPTION
Reverts ubuntu/yaru#961 after which's merge the master fails to build the snap.

Only opened if we need the revert just in case. (Though it's prbly not caused by aarons css code... :) so we can hopefully close this one here )