### PR TITLE
snap: Removed version-script target from yaml

### DIFF
--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -44,6 +44,8 @@ cd ../gtk-common-themes
 
 # get top part of original snapcraft.yaml and complete with new content
 curl -o snap/snapcraft.yaml "https://gitlab.gnome.org/Community/Ubuntu/gtk-common-themes/raw/master/snap/snapcraft.yaml"
+# remove version-script target
+sed -i '/version-script:/,+1 d' snap/snapcraft.yaml
 sed -i '/parts:/,$d' snap/snapcraft.yaml
 sed -e "s,CHANNEL,$channel,g" -e "s,REPO,$TRAVIS_REPO_SLUG," -e "s,BRANCH,$YARU_BRANCH," "$TRAVIS_BUILD_DIR/build-helpers/gtk-common-themes-parts.yaml" >> snap/snapcraft.yaml
 


### PR DESCRIPTION
Removed `version-script` target to fix snap build failures

According to the discussion on snapcraft forum, yaml has either "version: git" or "version-script".

see: https://forum.snapcraft.io/t/how-we-disable-to-automatically-look-for-the-version-number-in-our-yaru-snap-build/8528