### PR TITLE
Added missing dependency in yaru part yaml

### DIFF
--- a/build-helpers/gtk-common-themes-parts.yaml
+++ b/build-helpers/gtk-common-themes-parts.yaml
@@ -16,7 +16,7 @@ parts:
     source-branch: BRANCH
     plugin: meson
     meson-parameters: [--prefix=/]
-    build-packages: [sassc]
+    build-packages: ["sassc", "libglib2.0-dev"]
     override-build: |
       set -eu
       snapcraftctl build


### PR DESCRIPTION
If the "theme" part yaml requires libglib2.0-dev dependency, the "yaru" part in gtk-common-themes-parts.yaml should need it too.