### PR TITLE
WIP: Fix nautilus 3.30+ pathbar styling

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1815,8 +1815,8 @@ headerbar {
     }
 
     .path-bar.linked button {
-      // style the pathbar buttons
-      @extend %underline_focus_headerbar;
+      background-color: transparent;
+      border-radius: 0;
 
       &.slider-button {
         box-shadow: none;


### PR DESCRIPTION
"Work in progress"- and "eventually closed"-PR. Mostly to test this design on nautilus 3.26 on our hosts

Removes the background and the border-radius to avoid a stretched underline

![image](https://user-images.githubusercontent.com/15329494/48922626-5a32df80-eea8-11e8-808c-874bfc44e4c7.png)

![peek 2018-11-22 22-48](https://user-images.githubusercontent.com/15329494/48922672-bac21c80-eea8-11e8-9f09-251a18e306a3.gif)

This way we could keep the orange underline in this widget.
Opinions @madsrh @clobrano @godlyranchdressing  ?
