### PR TITLE
Use the same purple bg color for GDM as Grub uses in Ubuntu

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -2123,11 +2123,7 @@ StScrollBar {
 }
 
 #lockDialogGroup {
-  background: none;
-  background-color: none;
-  background-gradient-direction: vertical;
-  background-gradient-start: #6D2169;
-  background-gradient-end: #370026;
+  background-color: #2C001E;
 }
 
 #screenShieldNotifications {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15329494/49287777-01aea400-f49f-11e8-8d34-3df1d05bc3c1.png)

Closes https://github.com/ubuntu/yaru/issues/964