### PR TITLE
Use background property to set insertion-cursor icon

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4561,7 +4561,11 @@ cursor-handle {
 
     &.insertion-cursor#{$s}:dir(ltr), &.insertion-cursor#{$s}:dir(rtl) {
       $_url: 'assets/slider-horz-scale-has-marks-above#{$as}#{$asset_suffix}';
-      -gtk-icon-source: -gtk-scaled(url('#{$_url}.png'),
+      -gtk-icon-source: none;
+      background-repeat: no-repeat;
+      background-size: 16px 24px;
+      background-position: top 2px;
+      background-image: -gtk-scaled(url('#{$_url}.png'),
                                     url('#{$_url}@2.png'));
     }
   }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4566,7 +4566,7 @@ cursor-handle {
       -gtk-icon-source: none;
       background-repeat: no-repeat;
       background-size: 16px 24px;
-      background-position: top 2px;
+      background-position: center -2px;
       background-image: -gtk-scaled(url('#{$_url}.png'),
                                     url('#{$_url}@2.png'));
     }


### PR DESCRIPTION
-gtk-icon-source uses the same properties (-GtkWidget-text-handle-width/height)
to set both text-selection icons and insertion-cursor icons, but since the two
kind of icons differ in size in Yaru, the latter looks stretched.

Using background-* CSS properties instead, to set the proper icon sizes.

closes #945