### PR TITLE
Fixing entries to have a blue/dark blue selection for light/dark entries

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -102,7 +102,7 @@ StEntry {
   //&:hover { @include entry(hover);}
   &:focus { @include entry(focus);}
   &:insensitive { @include entry(insensitive);}
-  selection-background-color: $focus_color;
+  selection-background-color: darken($blue,10%);
   selected-color: $selected_fg_color;
   StIcon.capslock-warning {
     icon-size: 16px;
@@ -1658,8 +1658,8 @@ StScrollBar {
 }
 
 %light_entry {
-  selection-background-color: $focus_color;
-  selected-color: $fg_color;
+  selection-background-color: $text_selection;
+  selected-color: $dark_fg_color;
     $_bg: $light_base_color;
     $_fg: $dark_fg_color;
     @include entry(normal, $tc: $_fg, $c: $_bg);


### PR DESCRIPTION
Regression introduced by #971 

![image](https://user-images.githubusercontent.com/15329494/49305523-c9738980-f4cf-11e8-80f9-88573caff293.png)
![image](https://user-images.githubusercontent.com/15329494/49305531-cc6e7a00-f4cf-11e8-8713-daee932eb503.png)
