### PR TITLE
Button hover and active refinements

### DIFF
--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -274,22 +274,18 @@
 
     $_bg: null;
     $_box_shadow: null;
-    $_border_top_color: null;
 
     @if $_headerbar {
       $_bg: lighten($c, 10%);
       $_border: $_bg;
-      $_border_top_color: $_bg;
       $_box_shadow: none;
     } @else if $c == $button_bg_color {
       $_bg: darken($c, if($variant=='light', 7%, 10%));
       $_border: $borders_color;
-      $_border_top_color: $_border;
       $_box_shadow: inset 0 1px 1px 0px rgba(0, 0, 0, 0.05);
     } @else {
       $_bg: darken($c, 10%);
       $_border: darken($c, 15%);
-      $_border_top_color: darken($_border, 5%);
       $_box_shadow: none;
 
       @if $flat {
@@ -300,7 +296,6 @@
 
     background-color: $_bg;
     border-color: $_border;
-    border-top-color: $_border_top_color;
     box-shadow: $_box_shadow;
   }
 
@@ -378,7 +373,6 @@
       box-shadow: none;
     } @else {
       border-color: $insensitive_borders_color;
-      border-top-color: darken($insensitive_borders_color, 10%);
       box-shadow: inset 0 1px 1px 0px rgba(0, 0, 0, if($c==$headerbar_bg_color, .15, 0.05));
     }
 
@@ -431,7 +425,7 @@
     @if $flat {
       background-color: $_bg;
     } @else {
-      border-bottom-color: darken($_border, if(is_special_color($c), 12%, 15%));
+      border-bottom-color: darken($_border, if(is_special_color($c), 12%, if($variant=='light', 15%, 6%)));
     }
   }
 
@@ -439,21 +433,14 @@
     // backdrop pushed button
 
     $_bg: null;
-    $_border_top_color: null;
 
-    @if $_headerbar {
-      $_bg: lighten($backdrop_headerbar_bg_color, 5%);
-      $_border_top_color: $_bg;
-    } @else {
-      $_bg: darken($c, if($variant == 'light', 12%, 7%));
-      $_border_top_color: darken($_border, if($variant == 'light', 10%, 2%));
-    }
+    @if $_headerbar { $_bg: lighten($backdrop_headerbar_bg_color, 5%); } 
+    @else { $_bg: darken($c, if($variant == 'light', 12%, 7%)); }
 
     $_bc: if($c == $button_bg_color, $backdrop_borders_color, _backdrop_color(_border_color($c)));
 
     background-color: $_bg;
     border-color: if($flat, $_bg, $_bc);
-    border-top-color: $_border_top_color;
     box-shadow: none;
 
     label, & { color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color); }
@@ -497,7 +484,6 @@
 
     $_bc: if($c == $button_bg_color, $backdrop_borders_color, _backdrop_color(_border_color($c)));
     border-color: if($flat, $_bg, $_bc);
-    border-top-color: darken($_border, $_perc);
 
     label { color: if($c == $button_bg_color, transparentize($backdrop_text_color, 0.5), mix($tc, $_bg, 35%)); }
   }

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -279,7 +279,7 @@
       $_border: $_bg;
     } @else if $c == $button_bg_color {
       $_bg: darken($c, if($variant=='light', 7%, 10%));
-      $_border: $borders_color;
+      $_border: if($variant=='light', $borders_color, darken($borders_color, 2%));
     } @else {
       $_bg: darken($c, 10%);
       $_border: darken($c, 15%);
@@ -428,7 +428,7 @@
     @if $_headerbar { $_bg: lighten($backdrop_headerbar_bg_color, 5%); } 
     @else { $_bg: darken($c, if($variant == 'light', 12%, 7%)); }
 
-    $_bc: if($c == $button_bg_color, $backdrop_borders_color, _backdrop_color(_border_color($c)));
+    $_bc: if($c == $button_bg_color, if($variant=='light', $backdrop_borders_color, darken($backdrop_borders_color, 2%)),_backdrop_color(_border_color($c)));
 
     background-color: $_bg;
     border-color: if($flat, $_bg, $_bc);

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -253,7 +253,7 @@
 
     @if $_headerbar               { $_perc: 15%;  }
     @else if is_special_color($c) { $_perc: 5%;  }
-    @else                         { $_perc: if($variant=='light', 25%, 1%); }
+    @else                         { $_perc: if($variant=='light', 25%, 2%); }
 
     $_bg: lighten($c, $_perc);
 
@@ -264,7 +264,7 @@
     box-shadow: if($flat, none,  0 1px transparentize(black, 0.85));
 
     @if $flat == false {
-      $_perc: if(is_special_color($c), 12%, 15%);
+      $_perc: if(is_special_color($c), 12%, if($variant=='light', 15%, 6%));
       border-bottom-color: darken($_border, $_perc);
     }
   }
@@ -284,7 +284,7 @@
     } @else if $c == $button_bg_color {
       $_bg: darken($c, if($variant=='light', 7%, 10%));
       $_border: $borders_color;
-      $_border_top_color: darken($_border, if($variant=='light', 25%, 8%));
+      $_border_top_color: $_border;
       $_box_shadow: inset 0 1px 1px 0px rgba(0, 0, 0, 0.05);
     } @else {
       $_bg: darken($c, 10%);

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -273,20 +273,16 @@
     // pressed button
 
     $_bg: null;
-    $_box_shadow: null;
 
     @if $_headerbar {
       $_bg: lighten($c, 10%);
       $_border: $_bg;
-      $_box_shadow: none;
     } @else if $c == $button_bg_color {
       $_bg: darken($c, if($variant=='light', 7%, 10%));
       $_border: $borders_color;
-      $_box_shadow: inset 0 1px 1px 0px rgba(0, 0, 0, 0.05);
     } @else {
       $_bg: darken($c, 10%);
       $_border: darken($c, 15%);
-      $_box_shadow: none;
 
       @if $flat {
         $_border: $_bg;
@@ -296,7 +292,7 @@
 
     background-color: $_bg;
     border-color: $_border;
-    box-shadow: $_box_shadow;
+    box-shadow: none;
   }
 
   @else if $t==active-hover {

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -364,13 +364,8 @@
     $_bg: darken($_mix, 8%);
     background-color: $_bg;
 
-    @if $flat {
-      border-color: $_bg;
-      box-shadow: none;
-    } @else {
-      border-color: $insensitive_borders_color;
-      box-shadow: inset 0 1px 1px 0px rgba(0, 0, 0, if($c==$headerbar_bg_color, .15, 0.05));
-    }
+    @if $flat { border-color: $_bg; } 
+    @else { border-color: $insensitive_borders_color; }
 
     label, & { color: if($c != $button_bg_color, mix($tc, $_bg, 60%), $insensitive_fg_color); }
   }


### PR DESCRIPTION
- The active state looks a bit detached from the surface + the border-color difference is too big
- The dark variant hover has it's bottom border color darkened too heavy

![before](https://user-images.githubusercontent.com/15329494/49370565-d4f3ca00-f6f4-11e8-8f28-d453983c0c9e.gif)
![before_dark](https://user-images.githubusercontent.com/15329494/49370566-d4f3ca00-f6f4-11e8-90f4-6b64185045c9.gif)
![before_double_dark](https://user-images.githubusercontent.com/15329494/49370567-d58c6080-f6f4-11e8-937c-aef1ff2e6a5a.gif)
![before_double_light](https://user-images.githubusercontent.com/15329494/49370568-d58c6080-f6f4-11e8-9249-ce532f590674.gif)


-> Light+Dark Variant: change the active state to be on the same level as the bg
-> Dark only: change the hover state to be 1% brighter but have a 9% less dark bottom-border-color

![after](https://user-images.githubusercontent.com/15329494/49370575-dcb36e80-f6f4-11e8-9536-bfd5c427deb1.gif)
![after_dark](https://user-images.githubusercontent.com/15329494/49370576-dcb36e80-f6f4-11e8-9ab5-cfa0181b615c.gif)
![after_double_dark](https://user-images.githubusercontent.com/15329494/49370577-dd4c0500-f6f4-11e8-9f87-cf5cecc45d8f.gif)
![after_double_light](https://user-images.githubusercontent.com/15329494/49370578-dd4c0500-f6f4-11e8-92c6-35f78f2c80ea.gif)

Also
Closes https://github.com/ubuntu/yaru/issues/1006