### PR TITLE
Firefox theming

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -531,21 +531,15 @@ headerbar button image ~ window decoration ~ menu separator {
  * Firefox *
  ***********/
 #MozillaGtkWidget.background  {
-  > widget {
-    > scrolledwindow > textview {
-      text {
-        &:selected { @extend %selected_text; border-color: $selected_bg_color;}
-      }
-    }
-  }
-
   headerbar.titlebar {
-    // Remove the round corners until firefox fixed the white border bleed at the top edges
+    // Removes the round corners until firefox fixed the white border bleed at the top edges
+    // REMOVE THIS when firefox 65 is in the ubuntu repos on the end of Januar 2019
     border-radius: 0;
   }
 
-  > menu, .menu { border: none; } // Removed menu borders
-  > menu > menuitem { border-radius: 0; } // Removed rounded menu corners
+  // Removes rounded menus because the border bleeds in firefox
+  // REMOVE THIS when firefox supports rounded menus
+  menu, .menu,.context-menu { border-radius: 0; }
 
   // Adapt scrollbars a bit more to the GTK Scrollbar styling
   scrollbar {
@@ -602,4 +596,4 @@ normal-button {
    // checkbox is clipped but this is undetectable till it gets keyboard focus
    // so we're pushing it to the right to have the focus ring be displayed properly
    margin-left: 1px 
-  }
+}


### PR DESCRIPTION
- remove the dedicated text selection color, because it also changes the whole accent color of firefox and thundebrird to blue
- remove the border-radius of menus without removing the shadow
- add comment reminders to remove the dedicated styling when the fixes will happen

@madsrh @clobrano 
are you okay with the first point? Thunderbird and firefox are completely blue now, since the mozilla window sucks up one color and takes it as the accent color :cry: 