### PR TITLE
Removes margin for toolbar toolitem box .linked.horizontal button

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1498,6 +1498,7 @@ toolbar {
       margin-bottom: 1px;
     }
   }
+  toolitem > box.linked.horizontal button { margin: 0; }
 }
 
 //searchbar, location-bar & inline-toolbar


### PR DESCRIPTION
Closes https://github.com/ubuntu/yaru/issues/1011

Explicitly styling for buttons inside horizontal linked boxes inside toolitems inside toolbars so we do not destroy a styling elsewhere
