### PR TITLE
treeview expander invert hover colors

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2114,9 +2114,9 @@ treeview.view {
 
     &:dir(rtl) { -gtk-icon-source: -gtk-icontheme('pan-end-symbolic-rtl'); }
 
-    color: $text_color;
+    color: lighten($text_color, 20%);
 
-    &:hover { color: lighten($text_color, 25%); }
+    &:hover { color: $text_color; }
 
     &:selected {
       color: mix($selected_fg_color, $selected_bg_color, 70%);


### PR DESCRIPTION
Made treeview expander (pan-end-symbolic) icon paler in normal mode
and darker on hover.

closes #1016

![treeview-pan-hover](https://user-images.githubusercontent.com/2883614/49645132-ffa69100-fa1a-11e8-9c99-d25f9a618372.gif)
