### PR TITLE
Add backdrop hover underline for not checked pathbar buttons

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2008,6 +2008,10 @@ headerbar { // headerbar border rounding
     color: $backdrop_insensitive_color;
     border-color: transparent;
     box-shadow: inset 0 -2px transparent;
+    &:hover { 
+      box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5); 
+      color: $backdrop_insensitive_color;
+    }
   }
 
   &.text-button, &.image-button, & {


### PR DESCRIPTION
![peek 2018-12-08 19-58](https://user-images.githubusercontent.com/15329494/49689596-b9892480-fb23-11e8-97ab-836baeabbe56.gif)

I think I have forgotten the backdrop :blush: 
@madsrh @clobrano okay like this?