### PR TITLE
Remove red/yellow border of error/warning entries when ...

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -333,6 +333,8 @@ entry {
 
         &:focus { @include entry(focus, $e_color); }
 
+        &:not(:focus) { border-color: $borders_color; }
+        &:backdrop { border-color: $backdrop_borders_color; }
         selection { background-color: $e_color; }
       }
     }


### PR DESCRIPTION
.. out of focus or in backdrop

Before:
![peek 2018-12-09 17-29](https://user-images.githubusercontent.com/15329494/49699974-59a08580-fbd8-11e8-9d41-e84fcbb9e881.gif)
After:
![peek 2018-12-09 17-31](https://user-images.githubusercontent.com/15329494/49699975-5a391c00-fbd8-11e8-9ee0-43b57526c61a.gif)
