### PR TITLE
Fix wrong settings icon in gnome shell 3.30+ status menu popup

### DIFF
--- a/icons/Suru/scalable/categories/gnome-control-center-symbolic.svg
+++ b/icons/Suru/scalable/categories/gnome-control-center-symbolic.svg
@@ -1,0 +1,1 @@
+preferences-system-symbolic.svg

--- a/icons/src/symlinks/symbolic/categories.list
+++ b/icons/src/symlinks/symbolic/categories.list
@@ -1,3 +1,4 @@
 preferences-desktop-online-accounts-symbolic.svg credentials-preferences-symbolic.svg
 preferences-desktop-online-accounts-symbolic.svg goa-panel-symbolic.svg
 preferences-system-symbolic.svg applications-system-symbolic.svg
+preferences-system-symbolic.svg gnome-control-center-symbolic.svg


### PR DESCRIPTION
gnome shell changed the icon name to gnome control center
Adding a new symlink fixes this

Closes https://github.com/ubuntu/yaru/issues/894

![image](https://user-images.githubusercontent.com/15329494/49761413-4f10e980-fcc7-11e8-8242-7725aa51210a.png)
