### PR TITLE
Fix linked entry+button combobox in error and warning state

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -384,7 +384,15 @@ entry {
   .linked:not(.vertical) > & { @extend %linked; }
   .linked:not(.vertical) > &:focus + &,
   .linked:not(.vertical) > &:focus + button,
-  .linked:not(.vertical) > &:focus + combobox > box > button.combo { transition: $button_transition; border-left-color: $focus_color; }
+  .linked:not(.vertical) > &:focus + combobox > box > button.combo { transition: $button_transition; border-left-color: entry_focus_border(); }
+
+  .linked:not(.vertical) > &:focus.error + &,
+  .linked:not(.vertical) > &:focus.error + button,
+  .linked:not(.vertical) > &:focus.error + combobox > box > button.combo { transition: $button_transition; border-left-color: entry_focus_border($error_color); }
+
+  .linked:not(.vertical) > &:focus.warning + &,
+  .linked:not(.vertical) > &:focus.warning + button,
+  .linked:not(.vertical) > &:focus.warning + combobox > box > button.combo { transition: $button_transition; border-left-color: entry_focus_border($warning_color); }
 
   .linked:not(.vertical) > &:drop(active) + &,
   .linked:not(.vertical) > &:drop(active) + button,
@@ -410,7 +418,13 @@ entry {
     // color back the top border of a linked focused entry following another entry.
     // :not(:only-child) is a specificity bump hack.
     + %entry:focus:not(:only-child),
-    + entry:focus:not(:only-child) { border-top-color: $focus_color; }
+    + entry:focus:not(:only-child) { border-top-color: entry_focus_border(); }
+
+    + %entry:focus.error:not(:only-child),
+    + entry:focus.error:not(:only-child) { border-top-color: entry_focus_border($error_color); }
+
+    + %entry:focus.warning:not(:only-child),
+    + entry:focus.warning:not(:only-child) { border-top-color: entry_focus_border($warning_color); }
 
     + %entry:drop(active):not(:only-child),
     + entry:drop(active):not(:only-child) { border-top-color: $drop_target_color; }
@@ -421,7 +435,21 @@ entry {
       + %entry,
       + entry,
       + button,
-      + combobox > box > button.combo { border-top-color: $focus_color; }
+      + combobox > box > button.combo { border-top-color: entry_focus_border(); }
+    }
+
+    &:focus.error:not(:only-child) {
+      + %entry,
+      + entry,
+      + button,
+      + combobox > box > button.combo { border-top-color: entry_focus_border($error_color); }
+    }
+
+    &:focus.warning:not(:only-child) {
+      + %entry,
+      + entry,
+      + button,
+      + combobox > box > button.combo { border-top-color: entry_focus_border($warning_color); }
     }
 
     &:drop(active):not(:only-child) {

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -35,7 +35,7 @@
  ***********/
 @function entry_focus_border($fc:$focus_color) {
   @if $variant == 'light' { @return $fc; }
-  @else { @return if($fc==$focus_color, _border_color($focus_color), darken($fc, 35%)); }
+  @else { @return if($fc==$focus_color, _border_color($focus_color), $fc); }
 }
 
 @function entry_focus_shadow($fc:$focus_color) { @return 0 0 2px 2px transparentize($fc, .8); }


### PR DESCRIPTION
Added instructions for color of linked entry + button in combobox
when the entry is in error and warning state

closes #1031 

![entry-combobox-error-state](https://user-images.githubusercontent.com/2883614/49764786-baab8480-fcd0-11e8-8a84-543a93b075b3.gif)
