### PR TITLE
Removes firefox headerbar bleed fix because ....

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -532,12 +532,6 @@ headerbar button image ~ window decoration ~ menu separator {
  * Firefox *
  ***********/
 #MozillaGtkWidget.background  {
-  headerbar.titlebar {
-    // Removes the round corners until firefox fixed the white border bleed at the top edges
-    // REMOVE THIS when firefox 65 is in the ubuntu repos on the end of Januar 2019
-    border-radius: 0;
-  }
-
   // Removes rounded menus because the border bleeds in firefox
   // REMOVE THIS when firefox supports rounded menus
   menu, .menu,.context-menu { border-radius: 0; }


### PR DESCRIPTION
... Firefox 64 landed in Ubuntu and fixed the headerbar border-radius bleed

![image](https://user-images.githubusercontent.com/15329494/49874977-2b14eb80-fe20-11e8-845f-7e9e5e02f2df.png)
