### PR TITLE
Make focus border for entries always the same color in dark and light

### DIFF
--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -34,8 +34,7 @@
  * Entries *
  ***********/
 @function entry_focus_border($fc:$focus_color) {
-  @if $variant == 'light' { @return $fc; }
-  @else { @return if($fc==$focus_color, _border_color($focus_color), $fc); }
+  @return $fc;
 }
 
 @function entry_focus_shadow($fc:$focus_color) { @return 0 0 2px 2px transparentize($fc, .8); }
@@ -76,7 +75,7 @@
   @if $t==focus {
     // selected entry
     @include _shadows($_entry_edge);
-    border-color: entry_focus_border($fc);
+    border-color: $fc;
   }
   @if $t==insensitive {
     // insensitive entry


### PR DESCRIPTION
@clobrano @madsrh @godlyranchdressing please test and say if you like it/agree

Imho that dark orange looks strange in the dark theme
That function may work in adwaita with their blue, but it looks washed out in our color theme (imho)

Makes not much sense to provide screenshots as PEEK always changes the color a tiny bit :man_shrugging: 