### PR TITLE
Enforce integer sizes when rendering bitmaps

### DIFF
--- a/icons/src/fullcolor/render-bitmaps.py
+++ b/icons/src/fullcolor/render-bitmaps.py
@@ -150,8 +150,8 @@ def main(args, SRC):
                 print (self.context, self.icon_name)
                 for rect in self.rects:
                     for dpi_factor in DPIS:
-                        width = rect['width']
-                        height = rect['height']
+                        width = int(rect['width'])
+                        height = int(rect['height'])
                         id = rect['id']
                         dpi = 96 * dpi_factor
 

--- a/icons/src/fullcolor/render-bitmaps.py
+++ b/icons/src/fullcolor/render-bitmaps.py
@@ -150,8 +150,8 @@ def main(args, SRC):
                 print (self.context, self.icon_name)
                 for rect in self.rects:
                     for dpi_factor in DPIS:
-                        width = int(rect['width'])
-                        height = int(rect['height'])
+                        width = int(float(rect['width']))
+                        height = int(float(rect['height']))
                         id = rect['id']
                         dpi = 96 * dpi_factor
 


### PR DESCRIPTION
`render-bitmaps.py` script does not manage SVG files whose `height` and `width` are not integers. Making the script more robust parsing those values as float first and then converting them to integers. 