### PR TITLE
Bring back normal switches for dark popovers

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2435,6 +2435,7 @@ popover.background {
     entry selection { background-color: $text_selection; color: $fg_color; }    
     entry, button { border-color: darken($inkstone,1%); &:backdrop { border-color: transparent; } }
     button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
+    switch { @include switch($dark_fill, $success_color); }
   }
 }
 


### PR DESCRIPTION
I've forgotten to style the switches in the dark popovers, this is the fix
![peek 2018-12-17 10-53](https://user-images.githubusercontent.com/15329494/50079813-ec4daf80-01ea-11e9-966f-32adfeb922fd.gif)
![peek 2018-12-17 10-54](https://user-images.githubusercontent.com/15329494/50079815-ec4daf80-01ea-11e9-93d2-d6e3f0d344ac.gif)
