### PR TITLE
Testing PR - shell notification icons

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1692,14 +1692,15 @@ StScrollBar {
     }
     &:hover { background: $light_base_color; }
     .message-icon-bin > StIcon {
-     color: $dark_fg_color;
+      color: $dark_fg_color;
+      -st-icon-style: symbolic;
     }
 
     StEntry {
       @extend %light_entry
     }
 
-    .notification-icon { padding: 5px; -st-icon-style: symbolic; }
+    .notification-icon { padding: 5px; }
     .notification-content { padding: 5px; spacing: 5px; }
     .secondary-icon { icon-size: 1.14286em; }
     .notification-actions {

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1699,7 +1699,7 @@ StScrollBar {
       @extend %light_entry
     }
 
-    .notification-icon { padding: 5px; }
+    .notification-icon { padding: 5px; -st-icon-style: symbolic; }
     .notification-content { padding: 5px; spacing: 5px; }
     .secondary-icon { icon-size: 1.14286em; }
     .notification-actions {


### PR DESCRIPTION
Symbolic icons for notifications, because fullcolor icons are strechted
![screenshot from 2018-12-18 13-37-44](https://user-images.githubusercontent.com/15329494/50154871-dd3e2e80-02ca-11e9-8640-85c32b0bc251.png)

Need to test this on my host, not sure about this. Don't merge please.