### PR TITLE
Remove headerbar and menubar side borders

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1593,7 +1593,8 @@ headerbar {
   border-color: transparentize(_border_color($headerbar_bg_color), 0.7);
   border-top-color: $inkstone;
   border-style: solid;
-  border-width: 1px 1px 0 1px;
+  border-width: 0;
+  border-top-width: 1px;
   border-radius: 0;
   background-color: $headerbar_bg_color;
   color: $headerbar_fg_color;
@@ -1639,10 +1640,6 @@ headerbar {
       }
     }
   }
-
-
-  &:not(:only-child):first-child { border-right-width: 0; }
-  &:not(:only-child):not(:first-child) { border-left-width: 0; };
 
   & {
     // style headerbar buttons and entries using the appropriate headerbar colors
@@ -2236,7 +2233,7 @@ menubar,
   background-color: $menubar_bg_color;
   border-color: transparentize($_border_color, 0.8);
   border-style: solid;
-  border-width: 0 1px;
+  border-width: 0px;
   box-shadow: inset 0 -1px transparentize($_border_color, 0.8);
   color: $headerbar_text_color;
   padding: 0px;


### PR DESCRIPTION
Set headerbar's left and right borders width to 0px, as windows' side borders are.

close #1049 

NOTE: with this change, we will lose some distinction between the edges of the headerbar and dark backgrounds.

before
![image](https://user-images.githubusercontent.com/2883614/50270756-f235d180-0432-11e9-9213-19629e7a9337.png)

after
![image](https://user-images.githubusercontent.com/2883614/50270697-c31f6000-0432-11e9-98d4-96f22cd99488.png)

For reference, this is adding a border color (inkstone) to the window view

![image](https://user-images.githubusercontent.com/2883614/50271893-6cb42080-0436-11e9-9cce-3ab3b355089b.png)

from my point of view, the result depends too much on the background (it's invisible in white bg, and looks bright on the wallpaper) and on the actual window view color
