### PR TITLE
Add solid bg to check and radio

### DIFF
--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -563,7 +563,7 @@
   $_dim_background: if($variant == 'light', $dark_fill, $slate);
 
   @if $t==normal  {
-    background-color: if($_checked, $c, if($variant == 'light', $c, transparent));
+    background-color: $c; //if($_checked, $c, if($variant == 'light', $c, transparent));
     border-color: $_border_color;
     box-shadow: 0 1px transparentize(black, 0.95);
     color: $tc;

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -563,7 +563,8 @@
   $_dim_background: if($variant == 'light', $dark_fill, $slate);
 
   @if $t==normal  {
-    background-color: $c; //if($_checked, $c, if($variant == 'light', $c, transparent));
+    background-clip: if($_checked, border-box, padding-box);
+    background-color: $c;
     border-color: $_border_color;
     box-shadow: 0 1px transparentize(black, 0.95);
     color: $tc;


### PR DESCRIPTION
Currently check/radio button background is transparent, so that on
bright backgrounds, these widgets are invisible (the borders are bright
as well).

Changing the background color to solid.

close #1054 

TODO
 - [x] fix glitches in check corners