### PR TITLE
Fix transparent scale in jet popover

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2427,9 +2427,9 @@ popover.background {
 
   @if $variant=='dark' {
     separator { background-color: darken($menu_border,12%); &:backdrop { background-color: transparent; } }
-    * { background-color: transparent; }
-    scrollbar slider { background-color: $scrollbar_slider_color; }    
-    entry selection { background-color: $text_selection; color: $fg_color; }    
+    *:not(fill):not(highlight):not(trough):not(slider) { background-color: transparent; }
+    scrollbar slider { background-color: $scrollbar_slider_color; }
+    entry selection { background-color: $text_selection; color: $fg_color; }
     entry, button { border-color: darken($inkstone,1%); &:backdrop { border-color: transparent; } }
     button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
     switch { @include switch($dark_fill, $success_color); }


### PR DESCRIPTION
Jet popover uses a wildcard to set transparency for all widgets, however
the elements of the scale widget, that is slider, trough and highlight do
not require to be transparent or are invisible otherwise.

This change limit the wildcard for these elements.
NOTE: this same fix can be used if other widgets present the same issue

closes #1067