### PR TITLE
Make selected text orange again in gtk and shell themes

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -18,7 +18,6 @@ $selected_fg_color: #ffffff;
 $selected_bg_color: $orange;
 $selected_borders_color: if($variant=='light', darken($selected_bg_color, 5%),
                                                darken($selected_bg_color, 15%));
-$text_selection: lighten($blue,35%);
 $focus_color: $orange;
 
 $borders_color: if($variant =='light', darken($bg_color,30%), darken($bg_color,12%));

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -102,7 +102,7 @@ StEntry {
   //&:hover { @include entry(hover);}
   &:focus { @include entry(focus);}
   &:insensitive { @include entry(insensitive);}
-  selection-background-color: darken($blue,10%);
+  selection-background-color: $selected_bg_color;
   selected-color: $selected_fg_color;
   StIcon.capslock-warning {
     icon-size: 16px;
@@ -1658,8 +1658,6 @@ StScrollBar {
 }
 
 %light_entry {
-  selection-background-color: $text_selection;
-  selected-color: $dark_fg_color;
     $_bg: $light_base_color;
     $_fg: $dark_fg_color;
     @include entry(normal, $tc: $_fg, $c: $_bg);

--- a/gtk/src/light/gtk-3.20/_colors.scss
+++ b/gtk/src/light/gtk-3.20/_colors.scss
@@ -35,7 +35,6 @@ $success_color: $green;
 $destructive_color: darken($red, 10%);
 $neutral_color: $blue;
 $focus_color: $orange;
-$text_selection: if($variant == 'light',lighten($neutral_color,35%),darken($neutral_color, 10%));
 //
 $osd_fg_color: $porcelain;
 $osd_bg_color: transparentize($jet, 0.3);

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -130,7 +130,7 @@ widget:selected { color: $selected_fg_color; }
 textview {
   text {
     @extend %view;
-    selection { &:focus, & { @extend %selected_text; }}
+    selection { &:focus, & { @extend %selected_items; }}
   }
 }
 
@@ -184,7 +184,7 @@ label {
   &:selected { @extend %nobg_selected_items; }
 
   selection {
-    @extend %selected_text;
+    @extend %selected_items;
   }
   counter-label{background-color: $purple;}
 
@@ -199,7 +199,7 @@ label {
   &:backdrop {
     color: $backdrop_text_color;
 
-    selection { @extend %selected_text:backdrop; }
+    selection { @extend %selected_items:backdrop; }
   }
 }
 
@@ -322,7 +322,7 @@ entry {
     &:backdrop:disabled { @include entry(backdrop-insensitive); }
 
     selection {
-      @extend %selected_text;
+      @extend %selected_items;
     }
 
     // entry error and warning style
@@ -1664,20 +1664,6 @@ headerbar {
         color: $tc;
         &:hover { color: $backdrop_headerbar_text_color; }
       }
-
-      // Sadly, we need a dedicated styling here because
-      // the $variant is independant from the headerbar bg
-      selection {
-        $_bg: darken($neutral_color, 10%);
-        $_c: $headerbar_fg_color;
-        background-color: $_bg;
-        color: $_c;
-
-        &:backdrop {
-          background-color: _backdrop_color($_bg);
-          color: _backdrop_color($_c);
-        }
-      }
     }
 
     // default button and its labels needs dedicated styling in the headerbar
@@ -2429,7 +2415,6 @@ popover.background {
     separator { background-color: darken($menu_border,12%); &:backdrop { background-color: transparent; } }
     *:not(fill):not(highlight):not(trough):not(slider):not(switch) { background-color: transparent; }
     scrollbar slider { background-color: $scrollbar_slider_color; }
-    entry selection { background-color: $text_selection; color: $fg_color; }
     entry, button { border-color: darken($inkstone,1%); &:backdrop { border-color: transparent; } }
     button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
     switch { @include switch($dark_fill, $success_color); }
@@ -4231,7 +4216,7 @@ paned {
       background-color: $c;
       color: white;
       border-bottom: 1px solid $borders_color;
-      selection { @extend %selected_text; }
+      selection { @extend %selected_items; }
     }
   }
   button.close { color: white; &:backdrop { color: transparentize(white, 0.3); } }
@@ -4541,22 +4526,6 @@ button.titlebutton {
 
       &:disabled { color: mix($backdrop_selected_fg_color, $c, 30%); }
     }
-  }
-}
-
-%selected_text {
-  $c: $text_selection;
-  $tc: $text_color;
-  background-color: $c;
-  color: $tc;
-
-  &:disabled { color: mix($tc, $c, 50%); }
-
-  &:backdrop {
-    background-color: _backdrop_color($c);
-    color: $backdrop_text_color;
-
-    &:disabled { color: mix($backdrop_selected_fg_color, $c, 30%); }
   }
 }
 


### PR DESCRIPTION
@madsrh @clobrano 

: / Time to let go, gtk does not really support this.... or... since Gtk App devs focus on adwaita, they look up for selected_bg_color and don't support a difference between selected items and selected text

Please test and check if I have forgotten anything
Closes https://github.com/ubuntu/yaru/issues/1069