### PR TITLE
Add path-bar buttons without the .linked class to the new styling

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1978,63 +1978,65 @@ headerbar { // headerbar border rounding
 }
 
 .path-bar button {
-  @extend %underline_focus_effect;
-  background-color: $button_bg_color;
-  color: $insensitive_fg_color;
-  border-style: none;
-
-  &:hover { 
-    box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5); 
-    color: $insensitive_fg_color; 
-  }
-  
-  &:active { box-shadow: inset 0 -2px $insensitive_fg_color; }
-
-  &:checked, &:checked:active {
-    color: $fg_color;
-    &:hover { box-shadow: inset 0 -2px $insensitive_fg_color; }
-  }
-
-  &:backdrop {
+  &, &.flat {
+    @extend %underline_focus_effect;
     background-color: $button_bg_color;
-    color: $backdrop_insensitive_color;
-    border-color: transparent;
-    box-shadow: inset 0 -2px transparent;
+    color: $insensitive_fg_color;
+    border-style: none;
+
     &:hover { 
       box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5); 
-      color: $backdrop_insensitive_color;
+      color: $insensitive_fg_color; 
     }
-  }
+    
+    &:active { box-shadow: inset 0 -2px $insensitive_fg_color; }
 
-  &.text-button, &.image-button, & {
-    padding-left: 4px;
-    padding-right: 4px;
-  }
+    &:checked, &:checked:active {
+      color: $fg_color;
+      &:hover { box-shadow: inset 0 -2px $insensitive_fg_color; }
+    }
 
-  &.text-button.image-button label {
-    padding-left: 0;
-    padding-right: 0;
-  }
+    &:backdrop {
+      background-color: $button_bg_color;
+      color: $backdrop_insensitive_color;
+      border-color: transparent;
+      box-shadow: inset 0 -2px transparent;
+      &:hover { 
+        box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5); 
+        color: $backdrop_insensitive_color;
+      }
+    }
 
-  &.text-button.image-button, & {
-    label:last-child { padding-right: 8px; }
-    label:first-child { padding-left: 8px; }
-  }
+    &.text-button, &.image-button, & {
+      padding-left: 4px;
+      padding-right: 4px;
+    }
 
-  image {
-    padding-left: 4px;
-    padding-right: 4px;
-  }
+    &.text-button.image-button label {
+      padding-left: 0;
+      padding-right: 0;
+    }
 
-  &.slider-button {
-    padding-left: 0;
-    padding-right: 0;
-    box-shadow: none;
+    &.text-button.image-button, & {
+      label:last-child { padding-right: 8px; }
+      label:first-child { padding-left: 8px; }
+    }
 
-    &:hover { color: $selected_bg_color; }
-    &:disabled image {
-      // make disabled arrows less prominent
-      opacity: 0.3;
+    image {
+      padding-left: 4px;
+      padding-right: 4px;
+    }
+
+    &.slider-button {
+      padding-left: 0;
+      padding-right: 0;
+      box-shadow: none;
+
+      &:hover { color: $selected_bg_color; }
+      &:disabled image {
+        // make disabled arrows less prominent
+        opacity: 0.3;
+      }
     }
   }
 }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1747,7 +1747,7 @@ headerbar {
       }
     }
 
-    .path-bar.linked button {
+    .path-bar.linked button, .path-bar button {
       background-color: transparent;
       border-radius: 0;
       &:checked, &checked:active { 
@@ -3915,7 +3915,7 @@ filechooser {
     border-bottom: 1px solid $borders_color;
     &:backdrop { background: if($variant==light, darken($backdrop_bg_color, 5%), $backdrop_bg_color);}
 
-    .path-bar.linked button {
+    .path-bar.linked button, .path-bar button  {
       background: if($variant==light, darken($_bg, 10%), darken($_bg, 5%));
       &, & label { color: $text_color; }
       &:checked label { font-weight: 500; }


### PR DESCRIPTION
Don't remove it to keep 18.04 and gnome-staging 18.10 compatibility

_____

Eventually
Closes https://github.com/ubuntu/yaru/issues/1086

@iainlane could you please test this branch on your disco installation?