### PR TITLE
Visible scrollbar trough improve slider visibility

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -541,6 +541,14 @@ headerbar button image ~ window decoration ~ menu separator {
     background-color: transparent;
     border-color: transparent;
 
+    slider  {
+      background-color: darken($scrollbar_slider_color, 10%);
+      &:hover { background-color: darken($scrollbar_slider_hover_color, 10%); }
+      &:hover:active { background-color: $scrollbar_slider_active_color; }
+      &:backdrop { background-color: $backdrop_scrollbar_slider_color; }
+      &:disabled { background-color: transparent; }
+    }
+
     trough {
       background-color: transparentize($bg_color, 0.8);
     }

--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -540,6 +540,10 @@ headerbar button image ~ window decoration ~ menu separator {
   scrollbar {
     background-color: transparent;
     border-color: transparent;
+
+    trough {
+      background-color: transparentize($bg_color, 0.8);
+    }
   }
 }
 

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2679,10 +2679,6 @@ scrollbar {
   &.left { border-right: 1px solid $borders_color; }
   &.right { border-left: 1px solid $borders_color; }
 
-  trough {
-    background-color: transparentize($bg_color, 0.8);
-  }
-
   &:backdrop {
     background-color: $backdrop_scrollbar_bg_color;
     border-color: $backdrop_borders_color;

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2679,6 +2679,10 @@ scrollbar {
   &.left { border-right: 1px solid $borders_color; }
   &.right { border-left: 1px solid $borders_color; }
 
+  trough {
+    background-color: transparentize($bg_color, 0.8);
+  }
+
   &:backdrop {
     background-color: $backdrop_scrollbar_bg_color;
     border-color: $backdrop_borders_color;


### PR DESCRIPTION
On dark backgrounds the scrollbar slider visibility is very low.

Reenable trough's background color, but with high transparency
to fix this behavior without loosing the elegant effect in
light backgrounds

closes #1096 

Dark bg
![image](https://user-images.githubusercontent.com/2883614/50918938-ce6a1800-1441-11e9-9e2c-d1152aed2ddc.png)

Light bg
![image](https://user-images.githubusercontent.com/2883614/50919047-230d9300-1442-11e9-9e83-14f72f2e125f.png)

I double checked and the dark variant does not have the original issue and with this change it is good as well
