### PR TITLE
Actually release Yaru-dark in debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,8 +11,6 @@ override_dh_install:
 	rm -r debian/tmp/usr/share/glib-2.0
 	rm -r debian/tmp/usr/share/xsessions
 	rm -r debian/tmp/usr/share/wayland-sessions
-	# don't support dark variant until it's ready
-	rm -r debian/tmp/usr/share/themes/Yaru-dark
 	dh_install
 
 override_dh_missing:


### PR DESCRIPTION
closes #1106 