### PR TITLE
Fixed osd button hover in light variant

### DIFF
--- a/gtk/src/light/gtk-3.20/_colors.scss
+++ b/gtk/src/light/gtk-3.20/_colors.scss
@@ -41,7 +41,7 @@ $osd_button_bg_color: opacify($osd_bg_color, 1);
 $osd_borders_color: lighten(opacify($osd_bg_color, 1), 15%);
 $osd_text_color: transparentize($osd_fg_color, .1);
 $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_color, 1), 10%), 0.5);
-$osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
+$osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), if($variant=='light', 65%, 50%));
 //
 $sidebar_bg_color: if($variant == 'light', white, $base_color);
 $base_hover_color: transparentize($fg_color, 0.85);

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -484,7 +484,7 @@
   }
 
   @else if $t==osd {
-    $_bg: if($c == $button_bg_color, $osd_button_bg_color, transparentize($c, 0.5));
+    $_bg: $osd_button_bg_color;
 
     color: $osd_fg_color;
     border-color: _border_color($_bg);
@@ -494,7 +494,7 @@
   }
 
   @else if $t==osd-hover {
-    $_bg: if($c == $button_bg_color, lighten($button_bg_color, 10%), transparentize($c, 0.3));
+    $_bg: lighten($osd_button_bg_color, 10%);
 
     color: white;
     border-color: _border_color($_bg);
@@ -504,7 +504,7 @@
   }
 
   @else if $t==osd-active {
-    $_bg: $c;
+    $_bg: lighten($osd_button_bg_color, 15%);
 
     color: white;
     border-color: _border_color($_bg);


### PR DESCRIPTION
- removed dependency from variant in background colors, specifically
hover and active

- added dependency from variant to $osd_insensitive_fg_color, since
original color did not fit well with a light window background.

closes #1104 

![peek 2019-01-12 21-14](https://user-images.githubusercontent.com/2883614/51078047-abdd3680-16af-11e9-93c3-4585f6dca9ec.gif)
![peek 2019-01-12 21-12](https://user-images.githubusercontent.com/2883614/51078053-b5ff3500-16af-11e9-896a-77c3d16d72c7.gif)
