### PR TITLE
Fix infobar backdrop

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4211,17 +4211,6 @@ paned {
       selection { @extend %selected_items; }
     }
   }
-  button.close { color: white; &:backdrop { color: transparentize(white, 0.3); } }
-  > revealer > box > box label:backdrop { color: transparentize(white, 0.3); }
-  &:not(.warning):not(.error) {
-    > revealer > box > box label {
-      color: $text_color;
-      &:backdrop { color: $backdrop_text_color; }
-    }
-    &:backdrop {
-      background-color: $backdrop_bg_color;
-    }
-  }
   *:link { @extend %link_selected; }
 }
 

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4206,7 +4206,7 @@ paned {
                   ('.error', $error_color) {
     &#{$t} {
       background-color: $c;
-      color: white;
+      color: $text_color;
       border-bottom: 1px solid $borders_color;
       selection { @extend %selected_items; }
     }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4211,7 +4211,6 @@ paned {
       selection { @extend %selected_items; }
     }
   }
-  &:not(.warning):not(.error):backdrop { background-color: $backdrop_bg_color; }
   *:link { @extend %link_selected; }
 }
 

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4211,6 +4211,7 @@ paned {
       selection { @extend %selected_items; }
     }
   }
+  &:not(.warning):not(.error):backdrop { background-color: $backdrop_bg_color; }
   *:link { @extend %link_selected; }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15329494/51090566-ce3d8580-177d-11e9-97b1-abb10377f938.png)

![image](https://user-images.githubusercontent.com/15329494/51090596-51f77200-177e-11e9-9136-bd7e7502cd5a.png)

![image](https://user-images.githubusercontent.com/15329494/51090604-75222180-177e-11e9-9408-7f9d57b2682b.png)

![image](https://user-images.githubusercontent.com/15329494/51090626-fbd6fe80-177e-11e9-937e-36785c2b7a0c.png)


@madsrh please test it

I found that the strange color jumps I made there introduced too much crap. Removed basically all of the old notupstream styling and now light theme has a dark fg in backdrop just like everywhere else. See if you like it, I think this way it's more in line with the rest of the theme