### PR TITLE
Don't include entry:focus and entry selection in the jetpopoverwildcard

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2405,9 +2405,9 @@ popover.background {
 
   @if $variant=='dark' {
     separator { background-color: darken($menu_border,12%); &:backdrop { background-color: transparent; } }
-    *:not(fill):not(highlight):not(trough):not(slider):not(switch) { background-color: transparent; }
+    *:not(fill):not(highlight):not(trough):not(slider):not(switch):not(selection) { background-color: transparent; }
     scrollbar slider { background-color: $scrollbar_slider_color; }
-    entry, button { border-color: darken($inkstone,1%); &:backdrop { border-color: transparent; } }
+    entry:not(:focus), button { border-color: darken($inkstone,1%); &:backdrop { border-color: transparent; } }
     button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
     switch { @include switch($dark_fill, $success_color); }
   }


### PR DESCRIPTION
Closes https://github.com/ubuntu/yaru/issues/1122

![peek 2019-01-17 07-20](https://user-images.githubusercontent.com/15329494/51299319-62327a00-1a28-11e9-8297-862591e742f3.gif)

@madsrh and/or @clobrano please test