### PR TITLE
Improve menu, popover and window borders

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4420,8 +4420,8 @@ decoration {
   .popup & { box-shadow: none; }
 
   // server-side decorations as used by mutter
-  .ssd & { box-shadow: 0 0 0 1px $window_border; } //just doing borders, wm draws actual shadows
-
+  //just doing borders, wm draws actual shadows
+  .ssd & { box-shadow: 0 0 0 1px $window_border; &:backdrop { box-shadow: none; }}
   //These shadows are applied to the context-menu!
   .csd.popup & {
     border-radius: $small_radius;    

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2335,7 +2335,7 @@ menu,
       border-color: transparent ;
     }
   }
-  separator { background-color: if($variant=='light', darken($menu_color,9%), lighten($menu_color,6%)); }
+  @if $variant=='dark' { separator { background-color: lighten($menu_color, 6%); } }
 }
 
 menuitem {
@@ -2360,7 +2360,10 @@ popover.background {
   border-radius: $medium_radius;
   background-color: $menu_color;
 
-  .csd &, & { border: 1px solid if($variant=='light', transparentize(black,0.75), transparentize(white, 0.8)); }
+  .csd &, & {
+    border: 1px solid if($variant=='light', transparentize(black,0.75), transparentize(white, 0.8));
+    &:backdrop { @if $variant=='light' { border-color: $backdrop_borders_color; } }
+  }
 
   box-shadow: $popover_shadow;
 
@@ -2407,9 +2410,9 @@ popover.background {
 
   @if $variant=='dark' {
     *:not(fill):not(highlight):not(trough):not(slider):not(switch):not(selection) { background-color: transparent; }
-    separator { background-color: $inkstone; &:backdrop { background-color: transparent; } }
+    separator { background-image: image(darken($menu_border,13%)); }
     scrollbar slider { background-color: $scrollbar_slider_color; }
-    entry:not(:focus), button { border-color: darken($inkstone,1%); &:backdrop { border-color: transparent; } }
+    entry:not(:focus), button { border-color: darken($inkstone,1%); &:backdrop { border-color: lighten($inkstone,5%); } }
     button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
     switch { @include switch($dark_fill, $success_color); }
   }
@@ -3705,7 +3708,7 @@ scrolledwindow {
 
 //vbox and hbox separators
 separator {
-  background: if($variant=='light', transparentize($borders_color, 0.7), $inkstone);
+  background: transparentize($borders_color, 0.7);
   min-width: 1px;
   min-height: 1px;
 }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4422,9 +4422,9 @@ decoration {
 
   //These shadows are applied to the context-menu!
   .csd.popup & {
-    border-radius: $small_radius;
-    box-shadow: $popover_shadow,
-                0 0 0 1px $menu_border;
+    border-radius: $small_radius;    
+    box-shadow: 0 1px 2px transparentize(black, 0.8),
+                0 0 0 1px transparentize($_wm_border, 0.1);
   }
 
   tooltip.csd & {

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4423,8 +4423,14 @@ decoration {
   //These shadows are applied to the context-menu!
   .csd.popup & {
     border-radius: $small_radius;    
-    box-shadow: 0 1px 2px transparentize(black, 0.8),
-                0 0 0 1px transparentize($_wm_border, 0.1);
+    @if $variant=='light' {
+      box-shadow: 0 1px 2px transparentize(black, 0.8),
+                  0 0 0 1px transparentize($_wm_border, 0.1);
+    }
+    @else {
+          box-shadow: $popover_shadow,
+                      0 0 0 1px $menu_border;
+    }
   }
 
   tooltip.csd & {

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -41,8 +41,10 @@ $medium_radius: 6px;
 $large_radius: 12px;
 $backdrop_transition: all 200ms ease-out;
 $button_transition: all 0.4s ease-out;
-$popover_shadow: 0 2px 5px transparentize(black, 0.75);
-$menu_border: if($variant=='light', transparentize($borders_color, 0.2) , transparentize(white, 0.88));
+$menu_shadow: 0 1px 2px transparentize(black, 0.8);
+$popover_shadow: 0 2px 5px transparentize(black, 0.8);
+$window_border: if($variant == 'light', transparentize(black, 0.96), transparentize(black, 0.8));
+$menu_border: if($variant=='light', transparentize(black, 0.8), transparentize(white, 0.88));
 
 /***************
  * Base States *
@@ -2256,7 +2258,7 @@ menu,
   padding: 8px 0;
   background-color: $menu_color;
   color: $text_color;
-  border: 1px solid if($variant=='light', $borders_color, $menu_border);
+  border: 1px solid $menu_border;
   border-radius: $small_radius;
 
   .csd & { border: none; }  // axes borders in a composited env
@@ -2333,7 +2335,7 @@ menu,
       border-color: transparent ;
     }
   }
-  @if $variant=='dark' { separator { background-color: darken($menu_border, 12%); } }
+  separator { background-color: if($variant=='light', darken($menu_color,9%), lighten($menu_color,6%)); }
 }
 
 menuitem {
@@ -2358,7 +2360,7 @@ popover.background {
   border-radius: $medium_radius;
   background-color: $menu_color;
 
-  .csd &, & { border: 1px solid if($variant=='light', $menu_border, transparentize(white, 0.8)); }
+  .csd &, & { border: 1px solid if($variant=='light', transparentize(black,0.75), transparentize(white, 0.8)); }
 
   box-shadow: $popover_shadow;
 
@@ -2404,8 +2406,8 @@ popover.background {
   }
 
   @if $variant=='dark' {
-    separator { background-color: darken($menu_border,12%); &:backdrop { background-color: transparent; } }
     *:not(fill):not(highlight):not(trough):not(slider):not(switch):not(selection) { background-color: transparent; }
+    separator { background-color: $inkstone; &:backdrop { background-color: transparent; } }
     scrollbar slider { background-color: $scrollbar_slider_color; }
     entry:not(:focus), button { border-color: darken($inkstone,1%); &:backdrop { border-color: transparent; } }
     button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
@@ -3703,7 +3705,7 @@ scrolledwindow {
 
 //vbox and hbox separators
 separator {
-  background: transparentize($borders_color, 0.7);
+  background: if($variant=='light', transparentize($borders_color, 0.7), $inkstone);
   min-width: 1px;
   min-height: 1px;
 }
@@ -4385,12 +4387,9 @@ decoration {
   // lamefun trick to get rounded borders regardless of CSD use
   border-width: 0px;
 
-  // this needs to be transparent
-  // see bug #722563
-  $_wm_border: if($variant == 'light',transparentize(black, 0.77),transparentize(black, 0.5));
-
   $window_decoration_shadow: 0 3px 9px 1px;
-  box-shadow: $window_decoration_shadow transparentize(black, 0.5);
+  box-shadow: 0 3px 9px 1px transparentize(black, 0.5),
+              0 0 0 1px $window_border; //doing borders with box-shadow
 
   // FIXME rationalize shadows
 
@@ -4418,19 +4417,13 @@ decoration {
   .popup & { box-shadow: none; }
 
   // server-side decorations as used by mutter
-  .ssd & { box-shadow: none; }
+  .ssd & { box-shadow: 0 0 0 1px $window_border; } //just doing borders, wm draws actual shadows
 
   //These shadows are applied to the context-menu!
   .csd.popup & {
     border-radius: $small_radius;    
-    @if $variant=='light' {
-      box-shadow: 0 1px 2px transparentize(black, 0.8),
-                  0 0 0 1px transparentize($_wm_border, 0.1);
-    }
-    @else {
-          box-shadow: $popover_shadow,
-                      0 0 0 1px $menu_border;
-    }
+    box-shadow: $menu_shadow,
+                0 0 0 1px $menu_border;
   }
 
   tooltip.csd & {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/15329494/51444328-83c88580-1cf6-11e9-9a27-676a862db87e.png)
![image](https://user-images.githubusercontent.com/15329494/51444359-cab67b00-1cf6-11e9-8a66-d5df4fefac2e.png)


After
![image](https://user-images.githubusercontent.com/15329494/51444307-49f77f00-1cf6-11e9-8bda-ca732872314f.png)
![image](https://user-images.githubusercontent.com/15329494/51444367-df930e80-1cf6-11e9-9c26-27528271a340.png)


@madsrh @clobrano look closely at the edge between the menubar and when the menu pops up
There is a super small overlapping of the box-shadow
Looks a bit blurry

Please test this if you have time ;)

Closes https://github.com/ubuntu/yaru/issues/1117