### PR TITLE
Revert box-shadow removal for decoration.ssd in backdrop

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4421,7 +4421,7 @@ decoration {
 
   // server-side decorations as used by mutter
   //just doing borders, wm draws actual shadows
-  .ssd & { box-shadow: 0 0 0 1px $window_border; &:backdrop { box-shadow: none; }}
+  .ssd & { box-shadow: 0 0 0 1px $window_border; }
   //These shadows are applied to the context-menu!
   .csd.popup & {
     border-radius: $small_radius;    


### PR DESCRIPTION
Because it causes a bug with a black border for some apps. The backdrop is also settled in line 4407
![image](https://user-images.githubusercontent.com/15329494/51566188-36821a80-1e94-11e9-90d6-2ce59e40c50b.png)
![image](https://user-images.githubusercontent.com/15329494/51566229-4ef23500-1e94-11e9-8513-be7cf31b5858.png)
