### PR TITLE
Remove top highlight for switches in headerbar

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1649,6 +1649,7 @@ headerbar {
 
     switch {
       @include switch(lighten($headerbar_bg_color, 25%));
+      &, &:hover, &:checked, &:checked:hover { border-top-color: transparent; box-shadow: none; }    
     }
 
     entry, %dark_entry {


### PR DESCRIPTION
All elements in the headerbar are completely flat and sharp except the switches.
The darker border-top and the box-shadow make the round corners a little bit unsharp.

Before/current:
![with](https://user-images.githubusercontent.com/15329494/51800232-8bbf8280-222c-11e9-90e0-98f8e8872e21.png)
![image](https://user-images.githubusercontent.com/15329494/51800244-cde8c400-222c-11e9-83f2-173ab9eeb8f5.png)


After flatness applied:
![without](https://user-images.githubusercontent.com/15329494/51800230-8bbf8280-222c-11e9-8fee-1a0cbe10818e.png)
![image](https://user-images.githubusercontent.com/15329494/51800249-dc36e000-222c-11e9-9e48-1dde7b3f6f19.png)
