### PR TITLE
Remove border-top change and box-shadow also in backdrop for hb switches

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1649,7 +1649,7 @@ headerbar {
 
     switch {
       @include switch(lighten($headerbar_bg_color, 25%));
-      &, &:hover, &:checked, &:checked:hover { border-top-color: transparent; box-shadow: none; }    
+      &, &:backdrop { &, &:hover, &:checked, &:checked:hover { border-top-color: transparent; box-shadow: none; } }
     }
 
     entry, %dark_entry {


### PR DESCRIPTION

![peek 2019-01-27 13-47](https://user-images.githubusercontent.com/15329494/51801129-0f33a080-223a-11e9-8bda-6247ceec5f5c.gif)

:angel: should be 
![peek 2019-01-27 13-44](https://user-images.githubusercontent.com/15329494/51801123-fa570d00-2239-11e9-926f-59413253b89c.gif)
