### PR TITLE
Adapt gtk tooltips border to shell

### DIFF
--- a/gtk/src/light/gtk-3.20/_colors.scss
+++ b/gtk/src/light/gtk-3.20/_colors.scss
@@ -38,7 +38,7 @@ $neutral_color: $blue;
 $osd_fg_color: $porcelain;
 $osd_bg_color: transparentize($jet, 0.3);
 $osd_button_bg_color: opacify($osd_bg_color, 1);
-$osd_borders_color: lighten(opacify($osd_bg_color, 1), 15%);
+$osd_borders_color: transparentize(white, 0.87);
 $osd_text_color: transparentize($osd_fg_color, .1);
 $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_color, 1), 10%), 0.5);
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), if($variant=='light', 65%, 50%));


### PR DESCRIPTION
GtkTheme's tooltips look blurry and not sharp at the edges:
![gtk_tooltip](https://user-images.githubusercontent.com/15329494/51857607-fa870380-2332-11e9-8058-3059d7530b31.png)

The shell theme's tooltips look sharper:
![shell_tooltip](https://user-images.githubusercontent.com/15329494/51857623-0377d500-2333-11e9-9b35-a2bd1a750748.png)

This adapts gtk tooltips border to shell:
![after](https://user-images.githubusercontent.com/15329494/51857642-0e326a00-2333-11e9-8e9d-46ac98e4cb6b.png)
![image](https://user-images.githubusercontent.com/15329494/51858281-a2e99780-2334-11e9-994d-87aaad7b7d8c.png)
