### PR TITLE
Fix HB suggested- and destructive-action buttons border color

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1708,7 +1708,7 @@ headerbar {
                               (":backdrop:active, &:backdrop:checked", 'backdrop-active'),
                               (":backdrop:disabled", 'backdrop-insensitive'),
                               (":backdrop:disabled:active, &:backdrop:disabled:checked", 'backdrop-insensitive-active') {
-            &#{$state} { @include button($t, $b_color, white, $flat:true); }
+            &#{$state} { @include button($t, $b_color, white, $flat:true); &:not(:active) { border-color: $b_color; } }
           }
         }
       }


### PR DESCRIPTION
suggested and destructive btns Border-color changes on hover and active in headerbar
![wtf](https://user-images.githubusercontent.com/15329494/51929246-0b4d7d00-23f8-11e9-9f2a-9adcd0fc1276.gif)

This should fix it:
![wtf_weg](https://user-images.githubusercontent.com/15329494/51929251-0dafd700-23f8-11e9-98e6-b0ef30cf8e9f.gif)
