### PR TITLE
Add inode-directory symlinks to folder icon

### DIFF
--- a/icons/Suru/16x16/places/inode-directory.png
+++ b/icons/Suru/16x16/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png

--- a/icons/Suru/16x16@2x/places/inode-directory.png
+++ b/icons/Suru/16x16@2x/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png

--- a/icons/Suru/24x24/places/inode-directory.png
+++ b/icons/Suru/24x24/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png

--- a/icons/Suru/24x24@2x/places/inode-directory.png
+++ b/icons/Suru/24x24@2x/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png

--- a/icons/Suru/256x256/places/inode-directory.png
+++ b/icons/Suru/256x256/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png

--- a/icons/Suru/256x256@2x/places/inode-directory.png
+++ b/icons/Suru/256x256@2x/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png

--- a/icons/Suru/32x32/places/inode-directory.png
+++ b/icons/Suru/32x32/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png

--- a/icons/Suru/32x32@2x/places/inode-directory.png
+++ b/icons/Suru/32x32@2x/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png

--- a/icons/Suru/48x48/places/inode-directory.png
+++ b/icons/Suru/48x48/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png

--- a/icons/Suru/48x48@2x/places/inode-directory.png
+++ b/icons/Suru/48x48@2x/places/inode-directory.png
@@ -1,0 +1,1 @@
+folder.png


### PR DESCRIPTION
Some applications such as KDE's Dolphin lookup the mimetype of files to
decide which icon to use. For folders that's inode/directory. This
mean's Yaru's custom folder icon is ignored and instead a fallback icon
used from another theme.

**Before:**

![](https://i.imgur.com/SKJ05O2.png)

(falling back to what I believe is the Humanity icon theme?)

**After:**

![](https://i.imgur.com/frrWNIW.png)

(correctly using Yaru's folder icon)