### PR TITLE
Revert "Removes firefox headerbar bleed fix because ...."

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -532,6 +532,12 @@ headerbar button image ~ window decoration ~ menu separator {
  * Firefox *
  ***********/
 #MozillaGtkWidget.background  {
+  headerbar.titlebar {
+    // Removes the round corners until firefox fixed the white border bleed at the top edges
+    // REMOVE THIS when firefox 65 is in the ubuntu repos on the end of Januar 2019
+    border-radius: 0;
+  }
+
   // Removes rounded menus because the border bleeds in firefox
   // REMOVE THIS when firefox supports rounded menus
   menu, .menu,.context-menu { border-radius: 0; }


### PR DESCRIPTION
Reverts ubuntu/yaru#1037

The issue is back
@madsrh @clobrano decide if you want to merge this can't commit until today's evening

![image](https://user-images.githubusercontent.com/15329494/52107060-3ea92b00-25f5-11e9-9c8f-757d15b8cefe.png)

