### PR TITLE
Allow generate-symlink providing a pattern

### DIFF
--- a/icons/src/symlinks/generate-symlinks.sh
+++ b/icons/src/symlinks/generate-symlinks.sh
@@ -20,10 +20,10 @@
 
 DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 THEME="Suru"
+needle=$1 # Symlink only the files that matches the needle
 
 # echo $DIR
-
-# Icon sizes and contexts
+# Icon sizes and contextthe s
 CONTEXTS=("actions" "apps" "devices" "categories" "mimetypes" "places" "status")
 SIZES=("16x16" "24x24" "32x32" "48x48" "256x256" "16x16@2x" "24x24@2x" "32x32@2x" "48x48@2x" "256x256@2x")
 
@@ -42,7 +42,9 @@ do
 			cd $DIR/../../$THEME/$SIZE/$CONTEXT
 			while read line;
 			do
-				ln -sf $line
+				if [[ $line == *"$needle"* ]]; then
+					ln -sf $line
+				fi
 			done < $LIST
 			cd $DIR/../../$THEME
 		else
@@ -65,7 +67,9 @@ do
 		cd $DIR/../../$THEME/scalable/$CONTEXT
 		while read line;
 		do
-			ln -sf $line
+			if [[ $line == *"$needle"* ]]; then
+					ln -sf $line
+				fi
 		done < $LIST
 		cd $DIR/../../$THEME
 	else


### PR DESCRIPTION
`generate-symlink` now accepts one argument to filter out
any `.list` entry that does not match with such argument.
With this change, it is possible to generate only specific symlinks.

If no argument is provided, the script falls back to the usual behavior,
symlinking all the entries in any `.list` file.

e.g.

  The command

    $ ./generate-simlink.sh folder-open

  generates only symlinks for `.list` entries that concern
`folder-open`, both as source and destination

  folder-open folder          (OK)
  folder-close folder-open    (OK)
  folder-one   folder-two     (NO)
  image-x      image-y        (NO)