### PR TITLE
Add symbolic icons for view-more-symbolic and view-more-horizontal-symbolic

### DIFF
--- a/icons/Suru/scalable/actions/view-more-horizontal-symbolic.svg
+++ b/icons/Suru/scalable/actions/view-more-horizontal-symbolic.svg
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-273.00005,87)'/>
+  <g id='layer2' style='display:inline' transform='translate(-31.999847,-280)'/>
+  <g id='layer4' style='display:inline' transform='translate(-31.999847,-280)'/>
+  <g id='g1812' style='display:inline' transform='translate(-31.999847,-280)'/>
+  <g id='g6217' style='display:inline' transform='translate(-31.999847,-280)'/>
+  <g id='layer3' style='display:inline' transform='translate(-31.999847,-280)'/>
+  <g id='g1833' style='display:inline' transform='translate(-31.999847,-280)'/>
+  <g id='layer1' style='display:inline' transform='translate(-31.999847,-280)'>
+    
+    <path d='M 35.80469,287 C 35.26826,287 35,287.00015 35,287.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 36.73174,289 37,288.99985 37,288.375 v -0.75 C 37,287.02247 36.73174,287 36.19531,287 Z' id='path4751' style='color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate'/>
+    <path d='M 39.80469,287 C 39.26826,287 39,287.00015 39,287.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 40.73174,289 41,288.99985 41,288.375 v -0.75 C 41,287.02247 40.73174,287 40.19531,287 Z' id='path4749' style='color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate'/>
+    <path d='M 43.80469,287 C 43.26826,287 43,287.00015 43,287.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 44.73174,289 45,288.99985 45,288.375 v -0.75 C 45,287.02247 44.73174,287 44.19531,287 Z' id='path4747' style='color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate'/>
+  </g>
+</svg>

--- a/icons/Suru/scalable/actions/view-more-symbolic.svg
+++ b/icons/Suru/scalable/actions/view-more-symbolic.svg
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-293.00005,87)'/>
+  <g id='layer2' style='display:inline' transform='translate(-51.999847,-280)'/>
+  <g id='layer4' style='display:inline' transform='translate(-51.999847,-280)'/>
+  <g id='g1812' style='display:inline' transform='translate(-51.999847,-280)'/>
+  <g id='g6217' style='display:inline' transform='translate(-51.999847,-280)'/>
+  <g id='layer3' style='display:inline' transform='translate(-51.999847,-280)'/>
+  <g id='g1833' style='display:inline' transform='translate(-51.999847,-280)'/>
+  <g id='layer1' style='display:inline' transform='translate(-51.999847,-280)'>
+    
+    <path d='M 59.80469,283 C 59.26826,283 59,283.00015 59,283.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 60.73174,285 61,284.99985 61,284.375 v -0.75 C 61,283.02247 60.73174,283 60.19531,283 Z' id='path4773' style='color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate'/>
+    <path d='M 59.80469,287 C 59.26826,287 59,287.00015 59,287.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 60.73174,289 61,288.99985 61,288.375 v -0.75 C 61,287.02247 60.73174,287 60.19531,287 Z' id='path4767' style='color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate'/>
+    <path d='M 59.80469,291 C 59.26826,291 59,291.00015 59,291.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 60.73174,293 61,292.99985 61,292.375 v -0.75 C 61,291.02247 60.73174,291 60.19531,291 Z' id='path4761' style='color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate'/>
+  </g>
+</svg>

--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -33,12 +33,12 @@
      id="namedview88"
      showgrid="false"
      inkscape:zoom="0.99999999"
-     inkscape:cx="480.30066"
-     inkscape:cy="303.41513"
+     inkscape:cx="66.386537"
+     inkscape:cy="334.15128"
      inkscape:window-x="67"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g1833"
+     inkscape:current-layer="layer1"
      showborder="true"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
@@ -12147,6 +12147,54 @@
          sodipodi:end="5.6723201"
          d="m -323.12262,63.441525 a 5.9793701,6.000401 0 0 1 -6.69604,2.280995 5.9793701,6.000401 0 0 1 -4.18134,-5.722684 5.9793701,6.000401 0 0 1 4.18134,-5.722684 5.9793701,6.000401 0 0 1 6.69604,2.280995"
          sodipodi:open="true" />
+    </g>
+    <g
+       id="g4781"
+       inkscape:label="view-more-horizontal">
+      <rect
+         transform="rotate(90)"
+         y="-47.999847"
+         x="280"
+         height="16"
+         width="16"
+         id="rect4782-2-6"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate" />
+      <path
+         id="path4751"
+         d="M 35.80469,287 C 35.26826,287 35,287.00015 35,287.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 36.73174,289 37,288.99985 37,288.375 v -0.75 C 37,287.02247 36.73174,287 36.19531,287 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+      <path
+         id="path4749"
+         d="M 39.80469,287 C 39.26826,287 39,287.00015 39,287.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 40.73174,289 41,288.99985 41,288.375 v -0.75 C 41,287.02247 40.73174,287 40.19531,287 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+      <path
+         id="path4747"
+         d="M 43.80469,287 C 43.26826,287 43,287.00015 43,287.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 44.73174,289 45,288.99985 45,288.375 v -0.75 C 45,287.02247 44.73174,287 44.19531,287 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+    </g>
+    <g
+       id="g4787"
+       inkscape:label="view-more">
+      <rect
+         transform="rotate(90)"
+         y="-67.999847"
+         x="280"
+         height="16"
+         width="16"
+         id="rect4782-2-6-3"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate" />
+      <path
+         id="path4773"
+         d="M 59.80469,283 C 59.26826,283 59,283.00015 59,283.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 60.73174,285 61,284.99985 61,284.375 v -0.75 C 61,283.02247 60.73174,283 60.19531,283 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+      <path
+         id="path4767"
+         d="M 59.80469,287 C 59.26826,287 59,287.00015 59,287.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 60.73174,289 61,288.99985 61,288.375 v -0.75 C 61,287.02247 60.73174,287 60.19531,287 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+      <path
+         id="path4761"
+         d="M 59.80469,291 C 59.26826,291 59,291.00015 59,291.625 v 0.75 c 0,0.62485 0.26826,0.625 0.80469,0.625 h 0.39062 C 60.73174,293 61,292.99985 61,292.375 v -0.75 C 61,291.02247 60.73174,291 60.19531,291 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
For #1144 - I've exactly cloned the dots/positioning from the view-app-grid-symbolic icon for maximum consistency:

![image](https://user-images.githubusercontent.com/38893390/52512203-8df5e980-2bfb-11e9-8be2-4b8ea3c8c570.png)
