### PR TITLE
Fix path-bar and nautilus-path-bar styling to the known underline design

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1967,39 +1967,45 @@ headerbar { // headerbar border rounding
   &, &:backdrop { box-shadow: inset 0 -2px transparent; }
 }
 
-.path-bar button:dir(ltr), .path-bar button:dir(rtl) {
-  @extend %underline_focus_effect;
-  background-color: transparent;
-  color: $insensitive_fg_color;
-  border-style: none;
-  border-radius: 0;
-  box-shadow: none;
-
-  &:hover { 
-    box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5);
-    background-color: transparent;
-    color: $insensitive_fg_color; 
-  }
-  
-  &:active { box-shadow: inset 0 -2px $insensitive_fg_color; }
-
-  &:checked, &:checked:active {
-    color: $headerbar_fg_color;
-    background-color: transparent;
-    &:hover { box-shadow: inset 0 -2px $insensitive_fg_color; }
-    &:hover, &:backdrop { background-color: transparent; }
-  }
-
-  &:backdrop {
-    background-color: transparent;
-    color: $backdrop_insensitive_color;
-    border-color: transparent;
-    box-shadow: inset 0 -2px transparent;
-    &:hover { 
-      box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5); 
+.path-bar button, .nautilus-path-bar button {  
+    &, &:dir(ltr), &:dir(rtl) {
+      &, &.text-button, &.image-button, &.image-button.text-button {  
+      @extend %underline_focus_effect;
       background-color: transparent;
-      color: $backdrop_insensitive_color;
-    }
+      color: $insensitive_fg_color;
+      &:only-child, &:last-child {
+        &, &:hover { color: $headerbar_fg_color; }
+      }
+      border-style: none;
+      &, &:not(:first-child):not(:last-child) { border-radius: 0; }
+      box-shadow: none;
+
+      &:hover { 
+        box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5);
+        background-color: transparent;
+        color: $insensitive_fg_color; 
+      }
+      
+      &:active { box-shadow: inset 0 -2px $insensitive_fg_color; }
+
+      &:checked, &:checked:active {
+        color: $headerbar_fg_color;
+        background-color: transparent;
+        &:hover { box-shadow: inset 0 -2px $insensitive_fg_color; }
+        &:hover, &:backdrop { background-color: transparent; }
+      }
+
+      &:backdrop {
+        background-color: transparent;
+        color: $backdrop_insensitive_color;
+        border-color: transparent;
+        box-shadow: inset 0 -2px transparent;
+        &:hover { 
+          box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5); 
+          background-color: transparent;
+          color: $backdrop_insensitive_color;
+        }
+      }
   }
 
   &.text-button, &.image-button, & {
@@ -2033,6 +2039,7 @@ headerbar { // headerbar border rounding
       opacity: 0.3;
     }
   }
+}
 }
 
 /**************

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1977,7 +1977,7 @@ headerbar { // headerbar border rounding
         &, &:hover { color: $headerbar_fg_color; }
       }
       border-style: none;
-      &, &:not(:first-child):not(:last-child) { border-radius: 0; }
+      &, &:not(:first-child):not(:last-child), &:first-child, &:last-child { border-radius: 0; }
       box-shadow: none;
 
       &:hover { 
@@ -2006,6 +2006,7 @@ headerbar { // headerbar border rounding
           color: $backdrop_insensitive_color;
         }
       }
+    }
   }
 
   &.text-button, &.image-button, & {
@@ -2039,7 +2040,6 @@ headerbar { // headerbar border rounding
       opacity: 0.3;
     }
   }
-}
 }
 
 /**************


### PR DESCRIPTION
![image_2019-02-10_00-19-09](https://user-images.githubusercontent.com/15329494/52537942-c6690500-2d6c-11e9-8d38-026cba7395ce.png)

![peek 2019-02-10 19-45](https://user-images.githubusercontent.com/15329494/52537925-84d85a00-2d6c-11e9-827d-0bfd26a3e488.gif)

Upstream changed the pathbar again
This hopefully fixes it

At least one of you
@clobrano @madsrh @ubuntujaggers @eaglersdeveloper 
Please check this on
- 18.04 with the snap (update: works!)
![peek 2019-02-10 20-13](https://user-images.githubusercontent.com/15329494/52538232-5e1c2280-2d70-11e9-97d8-0481ca9a7af1.gif)

- 18.10 with meson installation
- 19.4 with the meson installation

Todo

- [x]  Align code style https://github.com/ubuntu/yaru/pull/1172/commits/96749ee6dcfb519b1db69656ac7c19438c4297c3#diff-1b30fa3f60328fce0c66d39158906ac1R2043