### PR TITLE
Fix Light/Dark emoji.popover button:checked difference

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2421,7 +2421,7 @@ popover.background {
     separator { background-image: image(darken($menu_border,13%)); }
     scrollbar slider { background-color: $scrollbar_slider_color; }
     entry:not(:focus), button { border-color: darken($inkstone,1%); &:backdrop { border-color: lighten($inkstone,5%); } }
-    button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
+    button:not(button.emoji-section), button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
     switch { @include switch($dark_fill, $success_color); }
   }
 }
@@ -4657,7 +4657,7 @@ button.emoji-section {
 
   &:checked {
     box-shadow: inset 0 2px $selected_bg_color;
-    background-color: transparent;
+    
     &:hover {
       box-shadow: inset 0 2px $selected_bg_color;
       background-color: $base_hover_color;


### PR DESCRIPTION
I hope that's the last vicitim of my wildcard. @clobrano @madsrh please see if you like this unification 
Fixed #1184

Before:
no orange stripe on :checked but orange stripe on :checked:hover, transparent button bg
![image](https://user-images.githubusercontent.com/15329494/52847980-a2deeb00-30db-11e9-92cf-a3cda67ea246.png)
orange stripe on :checked and :hover, transparent bg
![image](https://user-images.githubusercontent.com/15329494/52848006-affbda00-30db-11e9-9eef-5274ab197e2f.png)


After:
orange stripe on :checked and :hover, button bg
![image](https://user-images.githubusercontent.com/15329494/52848480-d1a99100-30dc-11e9-9626-ef452bd47c5a.png)

orange stripe on :checked and :hover, transparent bg
![image](https://user-images.githubusercontent.com/15329494/52847924-83e05900-30db-11e9-9e75-dd347d85e4a5.png)
