### PR TITLE
Style new hdyleaflet separators

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1643,7 +1643,7 @@ headerbar {
   }
 
   // GNOME 3.32+ responsive design headerbar separators
-  hdyleaflet separator.sidebar.vertical { 
+  hdyleaflet separator.sidebar.vertical {
     border-color: mix($inkstone, $headerbar_bg_color, 50%);
     &:backdrop { border-color: mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%); }
   }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1642,6 +1642,12 @@ headerbar {
     }
   }
 
+  // GNOME 3.32+ responsive design headerbar separators
+  hdyleaflet separator.sidebar.vertical { 
+    border-color: mix($inkstone, $headerbar_bg_color, 50%);
+    &:backdrop { border-color: mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%); }
+  }
+
   & {
     // style headerbar buttons and entries using the appropriate headerbar colors
     $c: $headerbar_bg_color;


### PR DESCRIPTION
With GNOME 3.32 the settings app provides a responsive design. The headerbar was changed and a new widget called hdyleaflet needs extra styling to keep our current look for separators in the headerbar, which is added with this commit.

Before:
![image](https://user-images.githubusercontent.com/15329494/52955610-15a9c980-335b-11e9-92b8-265002bf032f.png)


After:
![image](https://user-images.githubusercontent.com/15329494/52955505-cf546a80-335a-11e9-9b29-c4560407bc63.png)

@clobrano please see if you would prefer a local variable instead of 3x styling the same color with that mixed(...) function

Firstly reported in #1175