### PR TITLE
Remove orange bottom border in selected tab

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -156,7 +156,7 @@ terminal-window {
     &:checked {
       color: $terminal_fg_color;
       border-color: $inkstone;
-      border-bottom: 2px solid darken($selected_bg_color, 10%);
+      //border-bottom: 2px solid darken($selected_bg_color, 10%);
     }
   }
 
@@ -220,7 +220,6 @@ terminal-window {
         &:hover:checked:not(:backdrop) {
           background-color: lighten($headerbar_bg_color, 6%);
           border-color: $inkstone;
-          border-bottom: 2px solid $selected_bg_color;
         }
 
         &:backdrop {

--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -156,7 +156,6 @@ terminal-window {
     &:checked {
       color: $terminal_fg_color;
       border-color: $inkstone;
-      //border-bottom: 2px solid darken($selected_bg_color, 10%);
     }
   }
 

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2591,7 +2591,6 @@ notebook {
 
       &:checked {
         color: $fg_color;
-        font-weight: 500;
         background-color: $base_color;
         border-color: $_borders_color;
         & label {padding-bottom: 1px};


### PR DESCRIPTION
Bottom border on checked tabs seems to cause resize issues to the new
gnome-terminal when the scaling factor is > 1 (e.g. 1.5).

Removing such border fixes it.

fixes #1196

![image](https://user-images.githubusercontent.com/2883614/52963895-4ad90a80-33a1-11e9-9f69-be930e1ec27d.png)

