### PR TITLE
Set top-panel always full opaque

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -5,11 +5,11 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 /* #{$cakeisalie} */
 $panel-corner-radius: 0; // 6px;
 
-$panel-alpha-value: 0.0;
+$panel-alpha-value: 0.6;
 $panel_opaque_value: 0.0;
 
-$dash-alpha-value: 0.0;
-$dash-opaque-alpha-value: $panel_opaque_value;
+$dash-alpha-value: 0.6;
+$dash-opaque-alpha-value: 0.0;
 
 $popover-alpha-value: 0.025;
 
@@ -823,10 +823,14 @@ StScrollBar {
 
 #panel {
   $_fg: darken($panel_fg_color, 5%);
-  background-color: transparentize($panel_bg_color, $panel-alpha-value);
+  background-color: $panel_bg_color;
 
-  /* transition from solid to transparent */
-  transition-duration: 500ms;
+  &:overview {
+    background-color: transparentize($panel_bg_color, $panel-alpha-value);
+    /* transition from solid to transparent */
+    transition-duration: 500ms;
+  }
+
   font-weight: 450;
   height: 1.86em;
   font-feature-settings: "tnum";
@@ -1948,13 +1952,13 @@ StScrollBar {
     padding: 4px 18px;
     $c: darken($light_bg_color, 10%);
     $tc: $dark_fg_color;
-    @include button(normal, $c, $tc); box-shadow: none; 
+    @include button(normal, $c, $tc); box-shadow: none;
     &:active { @include button(active, $c, $tc); }
     &:focus { box-shadow: none; border-color: $selected_bg_color;  }
     &:hover { @include button(hover, $c, $tc); }
     &:focus:hover { @include button(focus-hover, $c, $tc); }
-    &:insensitive { 
-      border-color: darken($c, 20%); 
+    &:insensitive {
+      border-color: darken($c, 20%);
       background-color: darken($c, 20%);
       box-shadow: none;
       color: lighten($tc, 5%);
@@ -1963,7 +1967,7 @@ StScrollBar {
     &:default {
       padding-bottom: 5px;
       padding-top: 5px;
-      @include button(normal, $c:$success_color); box-shadow: none; 
+      @include button(normal, $c:$success_color); box-shadow: none;
       &:hover { @include button(hover, $c:$success_color); }
       &:focus { @include button(focus, $c:$success_color); }
       &:active { @include button(active, $c:$success_color); }

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -5,10 +5,10 @@ $cakeisalie: "This stylesheet is generated, DO NOT EDIT";
 /* #{$cakeisalie} */
 $panel-corner-radius: 0; // 6px;
 
-$panel-alpha-value: 0.6;
+$panel-alpha-value: 0.0;
 $panel_opaque_value: 0.0;
 
-$dash-alpha-value: 0.6;
+$dash-alpha-value: 0.0;
 $dash-opaque-alpha-value: $panel_opaque_value;
 
 $popover-alpha-value: 0.025;

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -104,7 +104,7 @@
     /* Temporary remove traslucency, see https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376
      * background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
      * transition-duration: 500ms; */
-    background-color: $dash_bg_color;
+    background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
     border-color: rgba(0, 0, 0, 0.4);
   }
 
@@ -112,7 +112,7 @@
     /* Temporary traslucency under overview state only. See https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376
      * background-color: transparentize($dash_bg_color, $dash-alpha-value);
      * transition-duration: 500ms; */
-    background-color: transparentize($dash_bg_color, 0.1);
+    background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
     border-color: rgba(0, 0, 0, 0.1);
 
     &:overview {

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -101,10 +101,10 @@
   }
 
   &.opaque {
-    /* Temporary remove traslucency, see https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376
+    /* Temporary reduce traslucency, see https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376      
      * background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
      * transition-duration: 500ms; */
-    background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
+    background-color: transparentize($dash_bg_color, 0.03);
     border-color: rgba(0, 0, 0, 0.4);
   }
 

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -101,10 +101,10 @@
   }
 
   &.opaque {
-    /* Temporary reduce traslucency, see https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376      
+    /* Temporary reduce traslucency, see https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376
      * background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
      * transition-duration: 500ms; */
-    background-color: transparentize($dash_bg_color, 0.03);
+    background-color: $dash_bg_color;
     border-color: rgba(0, 0, 0, 0.4);
   }
 
@@ -112,7 +112,7 @@
     /* Temporary traslucency under overview state only. See https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376
      * background-color: transparentize($dash_bg_color, $dash-alpha-value);
      * transition-duration: 500ms; */
-    background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
+    background-color: $dash_bg_color;
     border-color: rgba(0, 0, 0, 0.1);
 
     &:overview {

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -101,15 +101,19 @@
   }
 
   &.opaque {
-    background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
+    /* Temporary remove traslucency, see https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376
+     * background-color: transparentize($dash_bg_color, $dash-opaque-alpha-value);
+     * transition-duration: 500ms; */
+    background-color: $dash_bg_color;
     border-color: rgba(0, 0, 0, 0.4);
-    transition-duration: 500ms;
   }
 
   &.transparent {
-    background-color: transparentize($dash_bg_color, $dash-alpha-value);
+    /* Temporary remove traslucency, see https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376
+     * background-color: transparentize($dash_bg_color, $dash-alpha-value);
+     * transition-duration: 500ms; */
+    background-color: $dash_bg_color;
     border-color: rgba(0, 0, 0, 0.1);
-    transition-duration: 500ms;
   }
 
   .number-overlay {

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -109,11 +109,16 @@
   }
 
   &.transparent {
-    /* Temporary remove traslucency, see https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376
+    /* Temporary traslucency under overview state only. See https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/376
      * background-color: transparentize($dash_bg_color, $dash-alpha-value);
      * transition-duration: 500ms; */
-    background-color: $dash_bg_color;
+    background-color: transparentize($dash_bg_color, 0.1);
     border-color: rgba(0, 0, 0, 0.1);
+
+    &:overview {
+      background-color: transparentize($dash_bg_color, $dash-alpha-value);
+      transition-duration: 500ms;
+    }
   }
 
   .number-overlay {


### PR DESCRIPTION
gnome-shell 3.31.90 removed top-bar translucency feature in a way that the
settings we use for the `.transparent` class are used when the windows are
maximized.

This commit sets the transparency for top-bar at zero always. Since the comeback
of this feature is currently discussed, it is better to keep al the logic in place
so that it will be easy to reuse it later.

closes #1201

## known issue
~- [ ] [EDIT: in 19.04 only ] dashtodock is totally black when windows is maximized~