### PR TITLE
Make slider border-color transparent for headerbars

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3196,7 +3196,7 @@ scale {
     // OSD
     .osd & { }
   }
-  headerbar slider { &, &:disabled { border-color: transparent; } }
+  headerbar scale slider { &, &:disabled { border-color: transparent; } }
 
   value { color: gtkalpha(currentColor, 0.55); }
 

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3196,6 +3196,7 @@ scale {
     // OSD
     .osd & { }
   }
+  headerbar slider { &, &:disabled { border-color: transparent; } }
 
   value { color: gtkalpha(currentColor, 0.55); }
 


### PR DESCRIPTION
Headerbar sliders look blurry, this should fix it. 

Before:
![image](https://user-images.githubusercontent.com/15329494/53769589-9bda1a00-3edc-11e9-939c-eabb3e67e465.png)

After:
![image](https://user-images.githubusercontent.com/15329494/53769609-adbbbd00-3edc-11e9-9fb6-46d21de58aad.png)

Edit: pardon for the messy PRs, but lollypop is not available for disco yet from the ppa. so I need to check on my bionic host -.- 