### PR TITLE
Add round edges for desktop items selection frame

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -2226,3 +2226,8 @@ StScrollBar {
     border-radius: $small_radius;
     padding: 6px;
   }
+
+  // gnome-shell-extension-desktop-icons styling
+  .file-item {
+    border-radius: $small_radius;
+  }


### PR DESCRIPTION
After recent improvement to the desktop icons extension by the awesome @clobrano :tada: 
This commit adds a tiny roundness to the selection frame, which is the same small border radius we use in other parts of the theme

Before:
![photo_2019-03-06_15-30-34](https://user-images.githubusercontent.com/15329494/53888572-2fb6fd80-4025-11e9-9c36-77f440fa6d5a.jpg)



After:
![photo_2019-03-06_15-30-30](https://user-images.githubusercontent.com/15329494/53888568-2b8ae000-4025-11e9-8dba-52260439967e.jpg)
