### PR TITLE
Correctly style headerbar sidebar separator

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1633,7 +1633,7 @@ headerbar {
       &:backdrop { background-image: image(mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%)); }
   }
 
-  ~ separator, separator {
+  ~ separator, separator, separator.sidebar {
     &, &.titlebutton {
      &.horizontal, &.vertical {
         & { background-image: image(mix($inkstone, $headerbar_bg_color, 50%)); }
@@ -1642,8 +1642,9 @@ headerbar {
     }
   }
 
-  // GNOME 3.32+ responsive design headerbar separators
-  hdyleaflet separator.sidebar.vertical {
+  // GNOME 3.32+ responsive design has been reverted again
+  // add "hdyleaflet" in front of "separator" when it is added/enabled again
+  separator.sidebar.vertical {
     border-color: mix($inkstone, $headerbar_bg_color, 50%);
     &:backdrop { border-color: mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%); }
   }


### PR DESCRIPTION
hdyleaflet widget has been deactivated for gnome 3.32, resulting in an unstyled separator in gnome-control-center again.
This removes the hdyleaflet selector which enables the correct styling for this gnome release

![image](https://user-images.githubusercontent.com/15329494/54022653-47ac8f80-4193-11e9-8073-1c2114ba060d.png)

After:
![image](https://user-images.githubusercontent.com/15329494/54022695-5b57f600-4193-11e9-8b8f-b221e1086345.png)
