### PR TITLE
Remove border-color for sliders in headerbar

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1874,6 +1874,9 @@ headerbar {
       }
     }
   }
+
+  // grey borders look fuzzy on dark backgrounds - thus cutting the border in headerbar
+  scale slider { &, &:disabled { border-color: transparent; } }
 }
 
 headerbar {


### PR DESCRIPTION
Headerbar sliders look blurry, this should fix it. 

Before:
![image](https://user-images.githubusercontent.com/15329494/53769589-9bda1a00-3edc-11e9-939c-eabb3e67e465.png)

After:
![image](https://user-images.githubusercontent.com/15329494/53769609-adbbbd00-3edc-11e9-9fb6-46d21de58aad.png)

Tested with lollypop built from src