### PR TITLE
Gtk theme hdyleaflet again

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1642,11 +1642,14 @@ headerbar {
     }
   }
 
-  // GNOME 3.32+ responsive design has been reverted again
-  // add "hdyleaflet" in front of "separator" when it is added/enabled again
-  separator.sidebar.vertical {
-    border-color: mix($inkstone, $headerbar_bg_color, 50%);
-    &:backdrop { border-color: mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%); }
+  // GNOME 3.32+ responsive design headerbar separators
+  separator, hdyleaflet separator {
+    &, &.sidebar {
+      &, &.vertical, &.horizontal {
+        border-color: mix($inkstone, $headerbar_bg_color, 50%);
+        &:backdrop { border-color: mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%); }
+      }
+    }
   }
 
   & {

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1874,6 +1874,9 @@ headerbar {
       }
     }
   }
+
+  // grey borders look fuzzy on dark backgrounds - thus cutting the border in headerbar
+  scale slider { &, &:disabled { border-color: transparent; } }
 }
 
 headerbar {


### PR DESCRIPTION
Even though gnome-controlcenter removed hdyleaflet for 3.32, there are apps that use it.
Currently found gnome-contacts

Before:
![image](https://user-images.githubusercontent.com/15329494/54111989-7a4dc680-43e5-11e9-8087-7e9430befc0d.png)


After:
![image](https://user-images.githubusercontent.com/15329494/54111921-4ffc0900-43e5-11e9-8da2-8b1fc8711dd4.png)
