### PR TITLE
Build snaps only for bionic branch

### DIFF
--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -14,7 +14,7 @@ SOURCE_REPO="${TRAVIS_PULL_REQUEST_SLUG%%/*}"
 YARU_BRANCH="$TRAVIS_BRANCH"
 channel=""
 if [ "$REPO" == "ubuntu" ] && ([ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "$SOURCE_REPO" == "ubuntu" ]) ; then
-        # only push build to `bionic` branch are released, the rest will be as PR via dedicated channel
+        # only push build to `bionic` branch are released
         if [ "$TRAVIS_BRANCH" == "bionic" ]; then
                 channel="edge"
                 echo "Push to bionic ubuntu repo: will release to $channel"

--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -18,7 +18,7 @@ if [ "$REPO" == "ubuntu" ] && ([ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "$SOUR
         if [ "$TRAVIS_BRANCH" == "bionic" ]; then
                 channel="edge"
                 echo "Push to bionic ubuntu repo: will release to $channel"
-        elif
+        else
                 echo "No bionic target, nothing to snap"
         fi
 

--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -9,28 +9,14 @@ cmd="sed -i s/xenial/bionic/g /etc/apt/sources.list && apt update -qq && cd $(pw
 
 # Only release as a snap from main repo (ubuntu slug), enabling other forks to test build the snap.
 # Notes that the tokens are only available when the source repo is under ubuntu/ project.
-REPO="${TRAVIS_REPO_SLUG%%/*}"
-SOURCE_REPO="${TRAVIS_PULL_REQUEST_SLUG%%/*}"
 YARU_BRANCH="$TRAVIS_BRANCH"
-channel=""
-if [ "$REPO" == "ubuntu" ] && ([ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "$SOURCE_REPO" == "ubuntu" ]) ; then
-        # only push build to `bionic` branch are released
-        if [ "$TRAVIS_BRANCH" == "bionic" ]; then
-                channel="edge"
-                echo "Push to bionic ubuntu repo: will release to $channel"
-        else
-                echo "No bionic target, nothing to snap"
-        fi
 
-        if [ ! -z "$channel" ]; then
-                cmd="$cmd && echo \"$SNAP_TOKEN\" | snapcraft login --with - && snapcraft push *.snap --release=$channel"
-        fi
-elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-        echo "This PR doesn't originate from an ubuntu/ repo for an ubuntu/ destination repo. We can't upload automatically a snap on your beyond thus."
-fi
+[ "$TRAVIS_BRANCH" != "bionic" ] && echo "skipping: snaps are only for bionic builds" && exit 0
+channel="edge"
 
-# stop if no channel is set for push
-[ -z "$channel" ] && exit 0
+echo "Push to bionic ubuntu repo: will release to $channel"
+
+cmd="$cmd && echo \"$SNAP_TOKEN\" | snapcraft login --with - && snapcraft push *.snap --release=$channel"
 
 docker run -v $(pwd):$(pwd) -t snapcore/snapcraft:stable sh -c "$cmd"
 

--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -18,6 +18,8 @@ if [ "$REPO" == "ubuntu" ] && ([ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "$SOUR
         if [ "$TRAVIS_BRANCH" == "bionic" ]; then
                 channel="edge"
                 echo "Push to bionic ubuntu repo: will release to $channel"
+        elif
+                echo "No bionic target, nothing to snap"
         fi
 
         if [ ! -z "$channel" ]; then
@@ -27,10 +29,10 @@ elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         echo "This PR doesn't originate from an ubuntu/ repo for an ubuntu/ destination repo. We can't upload automatically a snap on your beyond thus."
 fi
 
-docker run -v $(pwd):$(pwd) -t snapcore/snapcraft:stable sh -c "$cmd"
-
-# stop if this was just a test build without any snap pushed
+# stop if no channel is set for push
 [ -z "$channel" ] && exit 0
+
+docker run -v $(pwd):$(pwd) -t snapcore/snapcraft:stable sh -c "$cmd"
 
 # build now gtk-common-themes
 # FIXME: we won't need this once snapd can accept and auto-install theme snaps.

--- a/build-helpers/prepare-build-snap
+++ b/build-helpers/prepare-build-snap
@@ -14,15 +14,10 @@ SOURCE_REPO="${TRAVIS_PULL_REQUEST_SLUG%%/*}"
 YARU_BRANCH="$TRAVIS_BRANCH"
 channel=""
 if [ "$REPO" == "ubuntu" ] && ([ "$TRAVIS_PULL_REQUEST" == "false" ] || [ "$SOURCE_REPO" == "ubuntu" ]) ; then
-        # if it's a PR event from
-        if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-                channel="edge/${TRAVIS_REPO_SLUG#*/}-pr$TRAVIS_PULL_REQUEST"
-                YARU_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
-                echo "PR to main ubuntu repo: will release to $channel"
-        # only push build to master are released, the rest will be as PR via dedicated channel
-        elif [ "$TRAVIS_BRANCH" == "master" ]; then
+        # only push build to `bionic` branch are released, the rest will be as PR via dedicated channel
+        if [ "$TRAVIS_BRANCH" == "bionic" ]; then
                 channel="edge"
-                echo "Push to master ubuntu repo: will release to $channel"
+                echo "Push to bionic ubuntu repo: will release to $channel"
         fi
 
         if [ ! -z "$channel" ]; then


### PR DESCRIPTION
As per Gnome shell changes on Disco, we are going to freeze Bionic
development. For this reason, any future change for the snap package
will be build only if pushed on the dedicated `bionic` branch.
Moreover, the majority of PRs will be for master branch, so there is no
real need to build testing snaps for each of them.

Summing it up:
- Stop building testing snap for each PR
- Build and push on edge channel only merge on `bionic` channel