### PR TITLE
Bionic: New symlinks for gnome-control-center

### DIFF
--- a/icons/Suru/scalable/apps/gnome-power-manager-symbolic.svg
+++ b/icons/Suru/scalable/apps/gnome-power-manager-symbolic.svg
@@ -1,0 +1,1 @@
+preferences-system-power-symbolic.svg

--- a/icons/Suru/scalable/apps/goa-panel-symbolic.svg
+++ b/icons/Suru/scalable/apps/goa-panel-symbolic.svg
@@ -1,0 +1,1 @@
+preferences-desktop-online-accounts-symbolic.svg

--- a/icons/src/symlinks/symbolic/apps.list
+++ b/icons/src/symlinks/symbolic/apps.list
@@ -79,6 +79,8 @@ passwords-app-symbolic.svg org.gnome.seahorse.Application-symbolic.svg
 podcasts-app-symbolic.svg org.gnome.Podcasts-symbolic.svg
 polari-symbolic.svg org.gnome.Polari-symbolic.svg
 power-statistics-symbolic.svg org.gnome.PowerStats-symbolic.svg
+preferences-system-power-symbolic.svg gnome-power-manager-symbolic.svg
+preferences-desktop-online-accounts-symbolic.svg goa-panel-symbolic.svg
 rhythmbox-symbolic.svg org.gnome.Rhythmbox-symbolic.svg
 root-terminal-app-symbolic.svg gksu-root-terminal-symbolic.svg
 screenshot-app-symbolic.svg applets-screenshooter-symbolic.svg


### PR DESCRIPTION
I wonder why this suddenly came up in bionic? Has something been backported? O.o


We need a SRU for this to get into 19.04 - any volunteers? ;D @madsrh @ubuntujaggers 

preferences-system-power-symbolic.svg->gnome-power-manager-symbolic.svg
preferences-desktop-online-accounts-symbolic.svg->goa-panel-symbolic.svg

Closes #1259 

![Screenshot from 2019-03-13 11-42-22](https://user-images.githubusercontent.com/15329494/54273008-2c6fc480-4585-11e9-8fb5-15f6f1d09322.png)

