### PR TITLE
Disco: Cherry-Picked from Bionic branch - New symlinks for gnome-control-center

### DIFF
--- a/icons/Suru/scalable/apps/gnome-power-manager-symbolic.svg
+++ b/icons/Suru/scalable/apps/gnome-power-manager-symbolic.svg
@@ -1,0 +1,1 @@
+preferences-system-power-symbolic.svg

--- a/icons/Suru/scalable/apps/goa-panel-symbolic.svg
+++ b/icons/Suru/scalable/apps/goa-panel-symbolic.svg
@@ -1,0 +1,1 @@
+preferences-desktop-online-accounts-symbolic.svg

--- a/icons/src/symlinks/symbolic/apps.list
+++ b/icons/src/symlinks/symbolic/apps.list
@@ -79,6 +79,8 @@ passwords-app-symbolic.svg org.gnome.seahorse.Application-symbolic.svg
 podcasts-app-symbolic.svg org.gnome.Podcasts-symbolic.svg
 polari-symbolic.svg org.gnome.Polari-symbolic.svg
 power-statistics-symbolic.svg org.gnome.PowerStats-symbolic.svg
+preferences-system-power-symbolic.svg gnome-power-manager-symbolic.svg
+preferences-desktop-online-accounts-symbolic.svg goa-panel-symbolic.svg
 rhythmbox-symbolic.svg org.gnome.Rhythmbox-symbolic.svg
 root-terminal-app-symbolic.svg gksu-root-terminal-symbolic.svg
 screenshot-app-symbolic.svg applets-screenshooter-symbolic.svg


### PR DESCRIPTION
Cherry picked from bionic_IconTheme_goa_and_power_symlinks

preferences-system-power-symbolic.svg->gnome-power-manager-symbolic.svg
preferences-desktop-online-accounts-symbolic.svg->goa-panel-symbolic.svg