### PR TITLE
Fix gnome-terminal tab close button hover color

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -167,7 +167,6 @@ terminal-window {
 
       button.flat {
         &, &:backdrop {
-          color: $terminal_fg_color;
           @each $state, $t in (':hover', 'hover'),
           (':active, &:checked', 'active'),
           (':backdrop', 'backdrop'),
@@ -177,7 +176,7 @@ terminal-window {
           (':disabled', 'insensitive') {
             &#{$state} {
               @include button($t, $headerbar_bg_color, $headerbar_bg_color, $flat:true);
-              color: $base_color;
+              color: $porcelain;
             }
           }
 


### PR DESCRIPTION
Close button hover color was too dark in Yaru-dark.
Considering that the tab background is always dark in both Yaru and Yaru-dark,
it is not necessary to use a variant-dependent color and an always bright
color can be used instead. Using `porcelain` in this case.

closes #1263