### PR TITLE
Improve treeview focus outline for white background

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -466,7 +466,7 @@ entry {
 
 treeview, row {
   &:focus {
-    outline-color: transparentize(white, 0.2);
+    outline-color: gtkalpha(currentColor, 0.3);
     outline-offset: -2px;
     -gtk-outline-radius: $small_radius;
   }
@@ -2075,6 +2075,8 @@ treeview.view {
   rubberband { @extend rubberband; } // to avoid borders being overridden by the previously set props
 
   &:selected {
+    outline-color: gtkalpha(white, 0.8);
+
     &:focus, & {
       @extend %selected_items;
       border-radius: 0;


### PR DESCRIPTION
The treeview focus outline is invisible on white background. This PR changes the outline to the same style than the [global outline](https://github.com/ubuntu/yaru/blob/6a4d98747160c9d28bb0fe1249d4117d37bb472c/gtk/src/light/gtk-3.20/_common.scss#L29).

Before: 
![before](https://user-images.githubusercontent.com/2457311/54871810-a50f2600-4dba-11e9-8824-ebdda682bcb9.gif)

After:
![after](https://user-images.githubusercontent.com/2457311/54871816-c112c780-4dba-11e9-9fd8-271f51fe032e.gif)

