### PR TITLE
Add legacy document-new/open/edit icon

### DIFF
--- a/icons/Suru/scalable/actions/document-new.svg
+++ b/icons/Suru/scalable/actions/document-new.svg
@@ -1,0 +1,1 @@
+document-new-symbolic.svg

--- a/icons/Suru/scalable/actions/document-open.svg
+++ b/icons/Suru/scalable/actions/document-open.svg
@@ -1,0 +1,1 @@
+document-open-symbolic.svg

--- a/icons/Suru/scalable/actions/document-save.svg
+++ b/icons/Suru/scalable/actions/document-save.svg
@@ -1,0 +1,1 @@
+document-save-symbolic.svg

--- a/icons/src/symlinks/symbolic/actions.list
+++ b/icons/src/symlinks/symbolic/actions.list
@@ -39,3 +39,6 @@ selection-end-symbolic.svg selection-start-symbolic-rtl.svg
 selection-start-symbolic.svg selection-end-symbolic-rtl.svg
 system-restart-symbolic.svg system-reboot-symbolic.svg
 window-pop-out-symbolic.svg detach-symbolic.svg
+document-new-symbolic.svg document-new.svg
+document-open-symbolic.svg document-open.svg
+document-save-symbolic.svg document-save.svg


### PR DESCRIPTION
Some applications might use the (I guess) legacy names for the symbolic icons document-new, document-open, document-edit. In yaru those files are named document-new-symbolic, document-open-symbolic, document-edit-symbolic (which is the new name convention) and the application (see keepassxc) might not find them.

Adding new symlinks in symbolic/actions.list for fixing it


![Screenshot from 2019-03-29 17-24-54](https://user-images.githubusercontent.com/2883614/55247549-37df1300-5248-11e9-9ea8-d9ff9974f321.png)

NOTE: the difference in style is evident. Our action icons are `symbolic`, while Keepassxc ones are colorful. We are following the new convention though, so I think is up to Keepassxc to convert the other custom icons.

closes #1294