### PR TITLE
Testing PR: reduce the orange in selected rows

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3785,6 +3785,7 @@ row {
 
   &:selected {
     color: if($variant=='light', darken($fg_color, 9%), white);
+    background-color: if($variant=='light', transparentize(black, 0.92), transparentize($silk, 0.8));
     box-shadow: inset 3px 0 0 $selected_bg_color;
   }
 }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3779,7 +3779,12 @@ row {
     }
   }
 
-  &:selected { @extend %selected_items; }
+  &:selected { 
+    background-color: $base_active_color;
+    color: $fg_color;
+    font-weight: 500;
+    box-shadow: inset 3px 0 0 $selected_bg_color;
+  }
 }
 
 

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3757,13 +3757,16 @@ list {
 row {
   outline-offset: -3px;
   transition: all 150ms $ease-out-quad;
-  color: if($variant=='light', lighten($fg_color, 3%), darken($fg_color, 3%));
+  color: if($variant=='light', lighten($fg_color, 7%), darken($fg_color, 5%));
 
   &:not(:selected) {
     outline-color: gtkalpha(currentColor, 0.3);
     &:not(:backdrop):hover { background-color: $base_hover_color; }
     &:not(:backdrop):active { background-color: $base_active_color; }
   }
+
+  &:hover { background-color: $base_hover_color; }
+  &:active { background-color: $base_active_color; }
 
   &:backdrop { transition: $backdrop_transition; }
 
@@ -3780,8 +3783,7 @@ row {
     }
   }
 
-  &:selected { 
-    background-color: transparentize($color: black, $amount: 0.9);
+  &:selected {
     color: if($variant=='light', darken($fg_color, 9%), white);
     box-shadow: inset 3px 0 0 $selected_bg_color;
   }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3757,6 +3757,7 @@ list {
 row {
   outline-offset: -3px;
   transition: all 150ms $ease-out-quad;
+  color: if($variant=='light', lighten($fg_color, 3%), darken($fg_color, 3%));
 
   &:not(:selected) {
     outline-color: gtkalpha(currentColor, 0.3);
@@ -3780,9 +3781,8 @@ row {
   }
 
   &:selected { 
-    background-color: $base_active_color;
-    color: $fg_color;
-    font-weight: 500;
+    background-color: transparentize($color: black, $amount: 0.9);
+    color: if($variant=='light', darken($fg_color, 9%), white);
     box-shadow: inset 3px 0 0 $selected_bg_color;
   }
 }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3786,7 +3786,6 @@ row {
   &:selected {
     color: if($variant=='light', darken($fg_color, 9%), white);
     background-color: if($variant=='light', transparentize(black, 0.92), transparentize($silk, 0.8));
-    box-shadow: inset 3px 0 0 $selected_bg_color;
   }
 }
 


### PR DESCRIPTION
Edit: updated with mads correction

![Screenshot from 2019-04-19 16-03-24](https://user-images.githubusercontent.com/15329494/56427584-ba457a80-62bc-11e9-909a-e5cc963b9380.png)
@madsrh @ubuntujaggers @clobrano @mpt :innocent: 

Why?

1) We love our orange but it is a problematic color - especially  when it is used as a big surface like the rows. Staring at it every day using ubuntu as my daily driver on my private PC, it becomes really hard for the eyes.
2) The full color selection is a little bit dated, when you comepare it to... 
Spotify
![photo_2019-04-18_17-34-41](https://user-images.githubusercontent.com/15329494/56372975-552c4f00-6200-11e9-8c5a-abfddd719c4e.jpg)
Vscode
![photo_2019-04-18_17-34-48](https://user-images.githubusercontent.com/15329494/56372994-5a899980-6200-11e9-9e08-28274e928921.jpg)
Windows10 settings
![image](https://user-images.githubusercontent.com/15329494/56373043-6d03d300-6200-11e9-9ae0-8f0944696851.png)
Gmail on tablets
![image](https://user-images.githubusercontent.com/15329494/56373154-ab998d80-6200-11e9-80bb-09684ecbbc08.png)
Battle.net Client
![image](https://user-images.githubusercontent.com/15329494/56423031-9416df00-62aa-11e9-820a-4d960f4ed046.png)
Imgur settings
![image](https://user-images.githubusercontent.com/15329494/56423073-b6106180-62aa-11e9-8da5-9efaafac89c2.png)
discourse settings
![image](https://user-images.githubusercontent.com/15329494/56423122-eb1cb400-62aa-11e9-8d7f-fc7983d04651.png)
gnome gitlab
![image](https://user-images.githubusercontent.com/15329494/56423322-d4c32800-62ab-11e9-8edc-ce284bcc253c.png)


3) it "fits" somehow to firefox tabs design
![image](https://user-images.githubusercontent.com/15329494/56374023-90c81880-6202-11e9-86ec-363ebf257061.png)
and To our gnome shell panel button selection
![image](https://user-images.githubusercontent.com/15329494/56374073-aa696000-6202-11e9-98f1-e265bbc1aeb9.png)
and to our gnome shell workspace selections
![image](https://user-images.githubusercontent.com/15329494/56391882-478ebd80-6230-11e9-8f20-4e27354acb37.png)

