### PR TITLE
Fix path-bar-box with width-maximized class

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1976,8 +1976,6 @@ headerbar { // headerbar border rounding
     @include button(active, $headerbar_bg_color, $headerbar_fg_color, $flat:true);
     &:hover { @include button(hover, $headerbar_bg_color, $headerbar_fg_color, $flat:true); }
   }
-  &:not(:only-child):last-child { border-radius: 0; }
-  &:only-child { border-radius: $small_radius 0 0 $small_radius; }
 }
 
 .path-bar-box.width-maximized {
@@ -2006,12 +2004,12 @@ headerbar { // headerbar border rounding
       &, &:not(:first-child):not(:last-child), &:first-child, &:last-child { border-radius: 0; }
       box-shadow: none;
 
-      &:hover { 
+      &:hover {
         box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5);
         background-color: transparent;
-        color: $insensitive_fg_color; 
+        color: $insensitive_fg_color;
       }
-      
+
       &:active { box-shadow: inset 0 -2px $insensitive_fg_color; }
 
       &:checked, &:checked:active {
@@ -2026,8 +2024,8 @@ headerbar { // headerbar border rounding
         color: $backdrop_insensitive_color;
         border-color: transparent;
         box-shadow: inset 0 -2px transparent;
-        &:hover { 
-          box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5); 
+        &:hover {
+          box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5);
           background-color: transparent;
           color: $backdrop_insensitive_color;
         }
@@ -4720,4 +4718,6 @@ button.emoji-section {
  * will be overwritten */
 .path-bar-box.width-maximized > .nautilus-path-bar button {
   margin: -1px;
+  &:not(:only-child):last-child { border-radius: 0; }
+  &:only-child { border-radius: $small_radius 0 0 $small_radius; }
 }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1744,6 +1744,7 @@ headerbar {
       &:not(:last-child) { margin-right: 4px; }
     }
 
+    .path-bar,
     .nautilus-path-bar button,
     .stack-switcher.linked button,
     buttonbox.linked button,
@@ -1992,47 +1993,6 @@ headerbar { // headerbar border rounding
   &, &:backdrop { box-shadow: inset 0 -2px transparent; }
 }
 .path-bar button {
-    &, &:dir(ltr), &:dir(rtl) {
-      &, &.text-button, &.image-button, &.image-button.text-button {
-      @extend %underline_focus_effect;
-      background-color: transparent;
-      color: $insensitive_fg_color;
-      &:only-child, &:last-child {
-        &, &:hover { color: $headerbar_fg_color; }
-      }
-      border-style: none;
-      &, &:not(:first-child):not(:last-child), &:first-child, &:last-child { border-radius: 0; }
-      box-shadow: none;
-
-      &:hover {
-        box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5);
-        background-color: transparent;
-        color: $insensitive_fg_color;
-      }
-
-      &:active { box-shadow: inset 0 -2px $insensitive_fg_color; }
-
-      &:checked, &:checked:active {
-        color: $headerbar_fg_color;
-        background-color: transparent;
-        &:hover { box-shadow: inset 0 -2px $insensitive_fg_color; }
-        &:hover, &:backdrop { background-color: transparent; }
-      }
-
-      &:backdrop {
-        background-color: transparent;
-        color: $backdrop_insensitive_color;
-        border-color: transparent;
-        box-shadow: inset 0 -2px transparent;
-        &:hover {
-          box-shadow: inset 0 -2px transparentize($insensitive_fg_color, 0.5);
-          background-color: transparent;
-          color: $backdrop_insensitive_color;
-        }
-      }
-    }
-  }
-
   &.text-button, &.image-button, & {
     padding-left: 4px;
     padding-right: 4px;

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1723,32 +1723,13 @@ headerbar {
       }
     }
 
-    .linked:not(.path-bar):not(.nautilus-path-bar):not(.stack-switcher):not(buttonbox) button, .linked:not(.vertical) entry {
-      // force linked buttons and entries to be separate
-      // this needs a lot of testing
-      &:focus {
-        & + entry { border-left-color: _border_color($graphite); }
-        & + button { border-left-color: transparent; }
-
-        & + entry,
-        & + button {
-          &:disabled { border-left-color: transparent; }
-          &:backdrop { border-left-color: _border_color($headerbar_bg_color); }
-        }
-      }
-      border-width: 1px;
-      border-style: solid;
-      border-radius: $small_radius;
-      -gtk-outline-radius: $small_radius;
-
-      &:not(:last-child) { margin-right: 4px; }
-    }
-
     .path-bar,
     .nautilus-path-bar button,
     .stack-switcher.linked button,
     buttonbox.linked button,
-    buttonbox.linked button.text-button ~ button {
+    buttonbox.linked button.text-button ~ button,
+    box.linked button,
+    box.linked entry {
       border-style: solid;
       border-color: lighten($headerbar_border_color, 5%);
 
@@ -1981,6 +1962,7 @@ headerbar { // headerbar border rounding
 
 .path-bar-box.width-maximized {
   border: 1px solid lighten($headerbar_bg_color, 10%); // same color as active button
+  padding: 1px;
   border-radius: $small_radius;
 }
 

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1979,12 +1979,6 @@ headerbar { // headerbar border rounding
   }
 }
 
-.path-bar-box.width-maximized {
-  border: 1px solid lighten($headerbar_bg_color, 10%); // same color as active button
-  border-radius: $small_radius;
-  padding: 1px;
-}
-
 %underline_focus_effect {
   // indeterminate is there to lazily force the style
   transition: 300ms ease;

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4668,11 +4668,3 @@ button.emoji-section {
   &:active{@include button(active);}
   &:disabled{@include button(insensitive)}
 }
-
-/* This needs to stay after `.regular-button` or the margin setting
- * will be overwritten */
-.path-bar-box.width-maximized > .nautilus-path-bar button {
-  margin: -1px;
-  &:not(:only-child):last-child { border-radius: 0; }
-  &:only-child { border-radius: $small_radius 0 0 $small_radius; }
-}

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1982,6 +1982,7 @@ headerbar { // headerbar border rounding
 .path-bar-box.width-maximized {
   border: 1px solid lighten($headerbar_bg_color, 10%); // same color as active button
   border-radius: $small_radius;
+  padding: 1px;
 }
 
 %underline_focus_effect {

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1723,7 +1723,7 @@ headerbar {
       }
     }
 
-    .linked:not(.path-bar):not(.stack-switcher):not(buttonbox) button, .linked:not(.vertical) entry {
+    .linked:not(.path-bar):not(.nautilus-path-bar):not(.stack-switcher):not(buttonbox) button, .linked:not(.vertical) entry {
       // force linked buttons and entries to be separate
       // this needs a lot of testing
       &:focus {
@@ -1744,6 +1744,7 @@ headerbar {
       &:not(:last-child) { margin-right: 4px; }
     }
 
+    .nautilus-path-bar button,
     .stack-switcher.linked button,
     buttonbox.linked button,
     buttonbox.linked button.text-button ~ button {
@@ -1970,6 +1971,20 @@ headerbar { // headerbar border rounding
 /************
  * Pathbars *
  ************/
+.nautilus-path-bar button {
+  &:only-child, &:last-child {
+    @include button(active, $headerbar_bg_color, $headerbar_fg_color, $flat:true);
+    &:hover { @include button(hover, $headerbar_bg_color, $headerbar_fg_color, $flat:true); }
+  }
+  &:not(:only-child):last-child { border-radius: 0; }
+  &:only-child { border-radius: $small_radius 0 0 $small_radius; }
+}
+
+.path-bar-box.width-maximized {
+  border: 1px solid lighten($headerbar_bg_color, 10%); // same color as active button
+  border-radius: $small_radius;
+}
+
 %underline_focus_effect {
   // indeterminate is there to lazily force the style
   transition: 300ms ease;
@@ -1978,10 +1993,9 @@ headerbar { // headerbar border rounding
 
   &, &:backdrop { box-shadow: inset 0 -2px transparent; }
 }
-
-.path-bar button, .nautilus-path-bar button {  
+.path-bar button {
     &, &:dir(ltr), &:dir(rtl) {
-      &, &.text-button, &.image-button, &.image-button.text-button {  
+      &, &.text-button, &.image-button, &.image-button.text-button {
       @extend %underline_focus_effect;
       background-color: transparent;
       color: $insensitive_fg_color;
@@ -2053,7 +2067,6 @@ headerbar { // headerbar border rounding
     }
   }
 }
-
 /**************
  * Tree Views *
  **************/
@@ -3943,7 +3956,7 @@ filechooser {
         label { color: $backdrop_text_color; }
       }
     }
-    .slider-button { 
+    .slider-button {
       &:first-child { border-radius: $small_radius 0 0 $small_radius; }
       &:last-child { border-radius: 0 $small_radius $small_radius  0; }
     }
@@ -4449,7 +4462,7 @@ decoration {
   .ssd & { box-shadow: 0 0 0 1px $window_border; }
   //These shadows are applied to the context-menu!
   .csd.popup & {
-    border-radius: $small_radius;    
+    border-radius: $small_radius;
     box-shadow: $menu_shadow,
                 0 0 0 1px $menu_border;
   }
@@ -4701,4 +4714,10 @@ button.emoji-section {
   &:hover{@include button(hover)};
   &:active{@include button(active);}
   &:disabled{@include button(insensitive)}
+}
+
+/* This needs to stay after `.regular-button` or the margin setting
+ * will be overwritten */
+.path-bar-box.width-maximized > .nautilus-path-bar button {
+  margin: -1px;
 }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1723,13 +1723,32 @@ headerbar {
       }
     }
 
+    .linked:not(.path-bar):not(.nautilus-path-bar):not(.stack-switcher):not(buttonbox) button, .linked:not(.vertical) entry {
+      // force linked buttons and entries to be separate
+      // this needs a lot of testing
+      &:focus {
+        & + entry { border-left-color: _border_color($graphite); }
+        & + button { border-left-color: transparent; }
+
+        & + entry,
+        & + button {
+          &:disabled { border-left-color: transparent; }
+          &:backdrop { border-left-color: _border_color($headerbar_bg_color); }
+        }
+      }
+      border-width: 1px;
+      border-style: solid;
+      border-radius: $small_radius;
+      -gtk-outline-radius: $small_radius;
+
+      &:not(:last-child) { margin-right: 4px; }
+    }
+
     .path-bar,
     .nautilus-path-bar button,
     .stack-switcher.linked button,
     buttonbox.linked button,
-    buttonbox.linked button.text-button ~ button,
-    box.linked button,
-    box.linked entry {
+    buttonbox.linked button.text-button ~ button {
       border-style: solid;
       border-color: lighten($headerbar_border_color, 5%);
 
@@ -1962,7 +1981,6 @@ headerbar { // headerbar border rounding
 
 .path-bar-box.width-maximized {
   border: 1px solid lighten($headerbar_bg_color, 10%); // same color as active button
-  padding: 1px;
   border-radius: $small_radius;
 }
 


### PR DESCRIPTION
depends on https://gitlab.gnome.org/GNOME/nautilus/issues/992

---

Latest nautilus added a `.width-maximized` class style that is applied
to nautilus-path-bar when the windows is "big enough". In such situation, the
nautilus-path-bar changes from left-aligned to centered and it starts moving
together with the `search` button. Yaru did not show any connection
between nautilus-path-bar and search icon, so the two widgets looked floating
in the headerbar with no reason.

Add a path-bar border (only when `.width-maximized` class exists) that
starts from the right end towards the search button to show that a
connection exists (very much like Adwaita does).

Note: path-bar class (i.e. filechooser) did not changed

Closes #1304

![image](https://user-images.githubusercontent.com/2883614/56572306-1fe87e00-65bf-11e9-9f9f-112cdc57d802.png)
![image](https://user-images.githubusercontent.com/2883614/56572348-355da800-65bf-11e9-8098-59bda431ace9.png)
![image](https://user-images.githubusercontent.com/2883614/56572396-473f4b00-65bf-11e9-9f47-0a8697af52e9.png)
![image](https://user-images.githubusercontent.com/2883614/56572419-4efeef80-65bf-11e9-8ec8-e9a5ee9e2705.png)

Note^2: I noticed some glitches in my VM so that sometimes the path-bar extended border is drawn unstyled. Moving the windows in backdrop and in focus again solves it (eventually, open a bug upstream if confirmed)
