### PR TITLE
Remove bordercolordifference in darkthemeswitches

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1657,10 +1657,7 @@ headerbar {
     $c: $headerbar_bg_color;
     $tc: $headerbar_fg_color;
 
-    switch {
-      @include switch(lighten($headerbar_bg_color, 25%));
-      &, &:backdrop { &, &:hover, &:checked, &:checked:hover { border-top-color: transparent; box-shadow: none; } }
-    }
+    switch { @include switch($headerbar_bg_color); }
 
     entry, %dark_entry {
       @include entry(normal, $c: $c, $tc: $tc);

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -701,7 +701,7 @@
 
   slider {
     background-color: if($bg == $dark_fill, white, $headerbar_fg_color);
-    background-clip: padding-box;
+    background-clip: border-box;
     border-radius: $small_radius;
     border: 1px solid transparent;
     box-shadow: 0 1px 1px if($bg == $dark_fill, darken($bg, 7%), rgba(0, 0, 0, 0.15));

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -617,13 +617,12 @@
  * Switches *
  ************/
 @mixin switch($bg:$dark_fill, $alt:$success_color) {
-  background-color: $bg;
+  background-color: if($bg==$headerbar_bg_color, lighten($bg, 25%), $bg);
   border-radius: 5px;
   border-width: 1px;
   border-style: solid;
-  border-color: darken($bg, 5%);
-  border-top-color: if($variant=='light', darken($bg, 20%), darken($bg, 5%));
-  box-shadow: inset 0 1px 1px 0 if($bg==$dark_fill, transparentize($bg, 0.2), rgba(0, 0, 0, 0.15));
+  border-color: if($bg==$headerbar_bg_color, lighten($bg, 25%), darken($bg, 5%));
+  box-shadow: if($bg==$dark_fill, inset 0 1px 1px 0 transparentize($bg, 0.2), none);
 
   $_insensitive_border_color: null;
   @if $bg == $dark_fill {
@@ -638,13 +637,13 @@
 
   &:hover {
     -gtk-icon-effect: highlight;
-    background-color: lighten($bg, 5%);
+    background-color: if($bg==$dark_fill, lighten($bg, 5%), lighten($bg, 30%));
   }
 
   &:checked {
     background-color: $alt;
     border-color: darken($alt, 5%);
-    border-top-color: if($variant=='light', darken($alt, 20%), darken($alt, 5%));
+    border-top-color: if($bg==$dark_fill and $variant=='light', darken($alt, 20%), darken($alt, 5%));
     box-shadow: inset 0 1px 1px 0 transparentize($alt, 0.2);
 
     &:hover {
@@ -669,23 +668,22 @@
       background-color: if($variant == 'light', _backdrop_color($bg), lighten($bg, 2%));
       $_border_color: if($variant == 'light', $borders_edge, $bg);
     } @else {
-      background-color: _backdrop_color(transparentize($bg, 0.3));
+      background-color: _backdrop_color(transparentize(lighten($bg, 25%), 0.3));
       $_border_color: transparent;
     }
 
     border: 1px solid $_border_color;
-    border-top-color: darken($bg, if($variant == 'light', 10%, 5%));
     transition: $backdrop_transition;
 
     &:hover {
-      background-color: $bg;
+      background-color: if($bg==$dark_fill, $bg, lighten($bg, 25%));
 
       &:checked { background-color: $alt; }
     }
 
     &:checked {
       background-color: _backdrop_color($alt);
-      border-top-color: darken($alt, 10%);
+      border-color: _backdrop_color($alt);
       box-shadow: none;
 
       &:disabled {
@@ -703,7 +701,7 @@
 
   slider {
     background-color: if($bg == $dark_fill, white, $headerbar_fg_color);
-    background-clip: if($variant == "light", border-box, padding-box);
+    background-clip: padding-box;
     border-radius: $small_radius;
     border: 1px solid transparent;
     box-shadow: 0 1px 1px if($bg == $dark_fill, darken($bg, 7%), rgba(0, 0, 0, 0.15));

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -622,7 +622,7 @@
   border-width: 1px;
   border-style: solid;
   border-color: darken($bg, 5%);
-  border-top-color: darken($bg, 20%);
+  border-top-color: if($variant=='light', darken($bg, 20%), darken($bg, 5%));
   box-shadow: inset 0 1px 1px 0 if($bg==$dark_fill, transparentize($bg, 0.2), rgba(0, 0, 0, 0.15));
 
   $_insensitive_border_color: null;
@@ -644,7 +644,7 @@
   &:checked {
     background-color: $alt;
     border-color: darken($alt, 5%);
-    border-top-color: darken($alt, 20%);
+    border-top-color: if($variant=='light', darken($alt, 20%), darken($alt, 5%));
     box-shadow: inset 0 1px 1px 0 transparentize($alt, 0.2);
 
     &:hover {


### PR DESCRIPTION
When the border color of the top border is different than the rest of the border, there are dark and washed out edges in the border top where a darker green shines through the lighter green. Probably because gtk lets the background color shine through the green. which is no problem in the light theme but in the headerbar and the darktheme. We changed this already for the headerbar some months ago, this commit does the same for the dark theme in general.

Before:
![image](https://user-images.githubusercontent.com/15329494/57012869-d6c0ab80-6c08-11e9-80d3-3d87a93c2dcd.png)
![image](https://user-images.githubusercontent.com/15329494/57012918-02439600-6c09-11e9-8373-56de5e2b95c9.png)

![image](https://user-images.githubusercontent.com/15329494/57012893-edff9900-6c08-11e9-826d-9fa283f6db4a.png)


After:
![image](https://user-images.githubusercontent.com/15329494/57012842-b98bdd00-6c08-11e9-957a-916642f35420.png)
![image](https://user-images.githubusercontent.com/15329494/57012929-138ca280-6c09-11e9-8f55-7140bd484886.png)

![image](https://user-images.githubusercontent.com/15329494/57012830-ad078480-6c08-11e9-9896-f4b523d78e2f.png)
