### PR TITLE
Reduce gtk and shell theme tooltip differences

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1463,7 +1463,7 @@ StScrollBar {
   }
 
   .dash-label { //osd tooltip
-    border-radius: $medium_radius;
+    border-radius: 5px;
     padding: 6px 12px;
     color: $osd_fg_color;
     background-color: $osd_bg_color;

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -4271,7 +4271,7 @@ tooltip {
   decoration { background-color: transparent; }
 
   > * { // Yeah this is ugly
-    min-height: 32px - (6px - 1px) * 2; // tooltip has hard-coded 6px padding
+    min-height: 30px - (6px - 1px) * 2; // tooltip has hard-coded 6px padding
     padding: 0 8px - (6px - 1px);       // and does not consider border-width
     background-color: transparent;
     color: $porcelain;


### PR DESCRIPTION
Reduce height for the gtk theme tooltips
Reduce border radius for the shell theme tooltips

Before:
![image](https://user-images.githubusercontent.com/15329494/57257616-42b47100-705a-11e9-9760-0ec135372389.png)
![image](https://user-images.githubusercontent.com/15329494/57257636-5069f680-705a-11e9-9705-70945bf8f197.png)


After:
![image](https://user-images.githubusercontent.com/15329494/57257547-126cd280-705a-11e9-8ac8-363756721dc8.png)
![image](https://user-images.githubusercontent.com/15329494/57257570-23b5df00-705a-11e9-9bc5-1700f638f1ba.png)
