### PR TITLE
Adapt application-x-executablesymbolic > fullcolor

### DIFF
--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -8993,26 +8993,6 @@
          style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
     </g>
     <g
-       transform="translate(60.000039,1.0351562e-6)"
-       style="display:inline"
-       id="g2769-62"
-       inkscape:label="application-x-executable">
-      <rect
-         transform="rotate(90)"
-         y="-528"
-         x="199.99994"
-         height="15.999999"
-         width="16"
-         id="rect2713-9"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.66653478;marker:none;enable-background:accumulate" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path967-9-1"
-         d="m 518.75586,201 c -0.48485,1.0101 -0.95009,2.03328 -1.39453,3.07031 -0.44445,1.02357 -0.89561,2.1011 -1.35352,3.23242 -0.2098,0.53405 -0.4328,1.13327 -0.64843,1.69727 H 514.5 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.74119 0.53361,1.34896 1.23828,1.47266 -0.36109,0.96894 -0.72149,1.93381 -1.11914,3.02734 h 2.6582 l 1.06836,-3 H 523 c 0.36116,1.01205 0.86169,2.08327 1.19988,3 h 2.61457 c -0.41034,-1.08092 -0.77559,-2.04944 -1.14062,-3.01758 C 526.42119,211.89572 527,211.27137 527,210.5 c 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -0.9707 c -0.21556,-0.55206 -0.43194,-1.11772 -0.64453,-1.63672 -0.44445,-1.13131 -1.33399,-3.25195 -1.33399,-3.25195 0,0 -0.91574,-2.07429 -1.41406,-3.11133 h -1.19727 z m 1.24414,2.5 2,5.5 h -4.08594 l 2.08599,-5.5 z m -5.5,6.5 h 3.93359 3.06641 4.06641 c 0.24027,0 0.43359,0.19332 0.43359,0.43359 v 0.13282 C 526,210.80668 525.80668,211 525.56641,211 H 521.5 518.43359 514.5 c -0.277,0 -0.5,-0.223 -0.5,-0.5 0,-0.277 0.223,-0.5 0.5,-0.5 z"
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:196.24819946px;line-height:1000%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.50505048px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         sodipodi:nodetypes="ccccssccccccccsscccccccccccsccssssccsss" />
-    </g>
-    <g
        style="display:inline"
        id="g2692-3"
        inkscape:label="settings-app"
@@ -9069,6 +9049,54 @@
          d="m 499.64845,263.01367 c -1.60235,0.11249 -3.12186,0.99052 -3.98242,2.48242 -1.37689,2.38706 -0.55308,5.45342 1.83593,6.83399 2.38903,1.38058 5.45319,0.56088 6.83008,-1.82617 1.37689,-2.38706 0.55308,-5.45145 -1.83594,-6.83203 -0.89588,-0.51773 -1.88625,-0.72569 -2.84765,-0.65821 z M 500.00001,264 a 4,4 0 0 1 4,4 4,4 0 0 1 -4,4 4,4 0 0 1 -4,-4 4,4 0 0 1 4,-4 z"
          id="path2764-3-1"
          inkscape:connector-curvature="0" />
+    </g>
+    <rect
+       transform="rotate(90)"
+       y="-610"
+       x="200.00006"
+       height="16"
+       width="16"
+       id="rect1903-3-9-2"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate" />
+    <g
+       id="g7576">
+      <title
+         id="title7578">application-x-executable</title>
+      <g
+         transform="matrix(0.76455843,0,0,0.76455843,197.72104,4.1287581)"
+         inkscape:label=""
+         id="g2692-3-3"
+         style="display:inline">
+        <rect
+           transform="rotate(90)"
+           y="-508"
+           x="260"
+           height="16"
+           width="16"
+           id="rect2758-6-67"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.66653484;marker:none;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path2760-7-5"
+           d="m 500.18165,261.00391 c -2.48304,-0.0657 -4.92247,1.19408 -6.24805,3.49218 -1.9281,3.3427 -0.77551,7.62899 2.57032,9.5625 3.34581,1.93352 7.63439,0.79191 9.5625,-2.55078 1.9281,-3.34269 0.77551,-7.63289 -2.57032,-9.5664 -1.04556,-0.60423 -2.1858,-0.90763 -3.31445,-0.9375 z M 500.00001,262 a 6,6 0 0 1 6,6 6,6 0 0 1 -6,6 6,6 0 0 1 -6,-6 6,6 0 0 1 6,-6 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.66666687;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path2762-5-3"
+           d="m 501.32238,259.92051 -2.63222,0.39327 v 1.35335 a 6.4893367,6.4774947 43.145679 0 1 2.63222,0.005 v -1.75146 z m -5.38585,1.19061 -2.00544,1.70491 0.98801,1.17757 a 6.4893367,6.4774947 43.145679 0 1 2.01736,-1.69076 z m 8.12867,0.0127 -0.99285,1.18353 a 6.4893367,6.4774947 43.145679 0 1 0.17056,0.0905 6.4893367,6.4774947 43.145679 0 1 1.84457,1.60287 l 1.00514,-1.19769 z m -11.60999,4.21684 -0.44056,2.59535 1.51535,0.26739 a 6.4893367,6.4774947 43.145679 0 1 0.45509,-2.59274 z m 15.08573,0.003 -1.5228,0.26851 a 6.4893367,6.4774947 43.145679 0 1 0.46365,2.59088 l 1.53286,-0.27 z m -13.68247,4.69464 -1.35149,0.78058 h -3.4e-4 l 1.33101,2.27098 1.33808,-0.77238 a 6.4893367,6.4774947 43.145679 0 1 -1.31723,-2.27918 z m 12.30081,0.003 a 6.4893367,6.4774947 43.145679 0 1 -0.53478,1.21481 6.4893367,6.4774947 43.145679 0 1 -0.77388,1.0692 l 1.33883,0.77313 1.30158,-2.28811 z m -9.55687,3.47164 -0.53479,1.4688 2.47953,0.88448 0.52585,-1.44534 a 6.4893367,6.4774947 43.145679 0 1 -2.30338,-0.79995 6.4893367,6.4774947 43.145679 0 1 -0.16721,-0.10799 z m 6.8133,0.0153 a 6.4893367,6.4774947 43.145679 0 1 -2.47468,0.89752 l 0.53031,1.45651 2.46761,-0.91651 z"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.33333337;marker:none;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path2764-3-5"
+           d="m 499.64845,263.01367 c -1.60235,0.11249 -3.12186,0.99052 -3.98242,2.48242 -1.37689,2.38706 -0.55308,5.45342 1.83593,6.83399 2.38903,1.38058 5.45319,0.56088 6.83008,-1.82617 1.37689,-2.38706 0.55308,-5.45145 -1.83594,-6.83203 -0.89588,-0.51773 -1.88625,-0.72569 -2.84765,-0.65821 z M 500.00001,264 a 4,4 0 0 1 4,4 4,4 0 0 1 -4,4 4,4 0 0 1 -4,-4 4,4 0 0 1 4,-4 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.66666681;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      </g>
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 576,201 c -1.2582,0.0145 -2.17889,-0.0306 -2.93164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 -0.16467,0.43867 -0.22461,0.95958 -0.22461,1.61719 v 10.00006 c 0,0.65761 0.0599,1.17858 0.22461,1.61719 0.16468,0.43861 0.46153,0.78852 0.83789,0.99609 0.75272,0.41514 1.67354,0.37165 2.93164,0.38672 h 0.002 8.00586 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37637,-0.20766 0.67323,-0.55938 0.83789,-0.99804 0.16453,-0.43867 0.22447,-0.95958 0.22447,-1.61719 V 204 c 0,-0.65761 -0.0599,-1.17858 -0.22461,-1.61719 -0.16468,-0.43861 -0.46153,-0.78852 -0.83789,-0.99609 -0.75272,-0.41513 -1.67355,-0.37165 -2.93164,-0.38672 h -0.002 -8.00586 z m 0.006,1 h 8 c 1.25862,0.0152 2.0891,0.0599 2.45508,0.26172 0.18342,0.10116 0.28722,0.21286 0.38476,0.47266 0.0974,0.25979 0.16002,0.67323 0.16002,1.26562 v 10.00006 c 0,0.59239 -0.0626,1.00572 -0.16016,1.26562 -0.0976,0.25991 -0.20135,0.37147 -0.38476,0.47266 -0.36596,0.20192 -1.19656,0.24701 -2.45508,0.26172 h -7.99414 -0.006 c -1.25863,-0.0152 -2.0891,-0.0599 -2.45508,-0.26172 -0.18342,-0.10116 -0.28722,-0.21286 -0.38476,-0.47266 -0.0975,-0.25979 -0.16016,-0.67323 -0.16016,-1.26562 V 204 c 0,-0.59239 0.0626,-1.00572 0.16016,-1.26562 0.0976,-0.25991 0.20135,-0.37147 0.38476,-0.47266 0.36596,-0.20192 1.19655,-0.24702 2.45508,-0.26172 z"
+         id="path2732-8-9-1-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsscsccccccssccccccccccsscccccccsscccc" />
     </g>
   </g>
   <g


### PR DESCRIPTION
Closes https://github.com/ubuntu/yaru/issues/1295

![image](https://user-images.githubusercontent.com/15329494/57580145-1a87a080-74a6-11e9-8122-eac12cfd8f9e.png)

That is the already existing full-color icon
![image](https://user-images.githubusercontent.com/15329494/57580156-35f2ab80-74a6-11e9-809c-cff1fa5d275e.png)

Todo:

- [ ] Export pngs