### PR TITLE
symlink: Improved generate-symlinks script CLI

### DIFF
--- a/icons/src/symlinks/generate-symlinks.sh
+++ b/icons/src/symlinks/generate-symlinks.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# Description:
-#   A script for quick generation of symlinks of an in-development icon theme
+## A script for quick generation of symlinks of an in-development icon theme
 #
 # Legal Stuff:
 #
@@ -16,11 +15,66 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, see <https://www.gnu.org/licenses/gpl-3.0.txt>
+##
+## usage:
+##      generate-symlinks.sh [--all|--match <string>] [--verbose]
+##
+## options:
+##      -a, --all            Generates all the symlinks defined in .list files
+##                           (warning: this might break manually generated symlinks)
+##      -m, --match <string> Generates only the symlinks in .list files that matches
+##                           the provided string
+##      -v, --verbose        More verbose output
+##
+## example:
+##      $ generate-symlinks.sh -m inode-directory
+##
+##      This generates only the link defined in ./symbolic/apps.list
+# GENERATED_CODE: start
 
+# No-arguments is not allowed
+[ $# -eq 0 ] && sed -ne 's/^## \(.*\)/\1/p' $0 && exit 1
+
+# Converting long-options into short ones
+for arg in "$@"; do
+	shift
+	case "$arg" in
+		"--all") set -- "$@" "-a";;
+		"--match") set -- "$@" "-m";;
+		"--verbose") set -- "$@" "-v";;
+		*) set -- "$@" "$arg"
+	esac
+done
+
+function print_illegal() {
+	echo Unexpected flag in command line \"$@\"
+}
+
+# Parsing flags and arguments
+while getopts 'havm:' OPT; do
+	case $OPT in
+		h) sed -ne 's/^## \(.*\)/\1/p' $0
+			exit 1 ;;
+		a) _all=1 ;;
+		v) _verbose=1 ;;
+		m) _match=$OPTARG ;;
+		\?) print_illegal $@ >&2;
+			echo "---"
+			sed -ne 's/^## \(.*\)/\1/p' $0
+			exit 1
+			;;
+	esac
+done
+# GENERATED_CODE: end
+
+[ ! -z $_match ] && needle=$_match || needle=''
+
+function dlog() {
+    [ ! -z $_verbose ] && echo $*
+}
 
 DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 THEME="Suru"
-needle=$1 # Symlink only the files that matches the needle
 
 # echo $DIR
 # Icon sizes and contextthe s
@@ -32,7 +86,7 @@ echo "Generating links for fullcolor icons..."
 # contexts for loop
 for CONTEXT in "${CONTEXTS[@]}"
 do
-	echo " -- "${CONTEXT}
+	dlog " -- "${CONTEXT}
 	# Sizes Loop
 	for SIZE in "${SIZES[@]}"
 	do
@@ -43,12 +97,15 @@ do
 			while read line;
 			do
 				if [[ $line == *"$needle"* ]]; then
+					echo linking $line in $SIZE"/"$CONTEXT
 					ln -sf $line
+				else
+					dlog "[match only mode] skipping $line"
 				fi
 			done < $LIST
 			cd $DIR/../../$THEME
 		else
-			echo "  -- skipping "$SIZE"/"$CONTEXT
+			dlog "  -- skipping "$SIZE"/"$CONTEXT
 		fi
 	done
 done
@@ -60,7 +117,7 @@ echo "Generating links for symbolic icons..."
 # contexts for loop
 for CONTEXT in "${CONTEXTS[@]}"
 do
-	echo " -- "$CONTEXT
+	dlog " -- "$CONTEXT
 	LIST="$DIR/symbolic/$CONTEXT.list"
 	# Check if directory exists
 	if [ -d "$DIR/../../$THEME/scalable/$CONTEXT" ]; then
@@ -68,8 +125,11 @@ do
 		while read line;
 		do
 			if [[ $line == *"$needle"* ]]; then
-					ln -sf $line
-				fi
+				echo linking $line in $SIZE"/"$CONTEXT
+				ln -sf $line
+			else
+				dlog "[match only mode] line $line does not match with $needle"
+			fi
 		done < $LIST
 		cd $DIR/../../$THEME
 	else


### PR DESCRIPTION
Add proper CLI interface to generate-symlinks.sh script to help usage.

* Use --help flag to show the usage message.
* Use --all flag to regenerate all the symlinks defined in .list files
* Use --match <string> flag to generate only the symlinks that match the given <string>

```
$ ./generate-symlinks.sh -h
A script for quick generation of symlinks of an in-development icon theme
usage:
     generate-symlinks.sh [--all|--match <string>] [--verbose]
options:
     -a, --all            Generates all the symlinks defined in .list files
                          (warning: this might break manually generated symlinks)
     -m, --match <string> Generates only the symlinks in .list files that matches
                          the provided string
     -v, --verbose        More verbose output
example:
     $ generate-symlinks.sh -m inode-directory
     This generates only the link defined in ./symbolic/apps.list
```