### PR TITLE
row: no difference between pressed and pressed+selected row

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3780,8 +3780,6 @@ row {
     &:active { box-shadow: inset 0 2px 2px -2px transparentize(black, 0.8); }
 
     &:not(:backdrop):selected {
-      &:active { box-shadow: inset 2px 0 $selected_bg_color, inset 0 2px 3px -1px transparentize(black, 0.5); }
-
       &.has-open-popup { background-color: mix($fg_color, $selected_bg_color, 10%); }
 
     }


### PR DESCRIPTION
In sidebar, selected row has a stronger pressed effect and an orange
left border which does not seem necessary.

Before
![image](https://user-images.githubusercontent.com/2883614/57684671-8dc01c80-7636-11e9-86ba-e60801ec4707.png)

After
![image](https://user-images.githubusercontent.com/2883614/57684622-708b4e00-7636-11e9-972d-7743c40b4169.png)
