### PR TITLE
sidebar: fix orange border in selected row's button

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -654,11 +654,9 @@ button {
 
   @at-root %button_selected, & {
     row:selected & {
-      @if $variant == 'light' { border-color: _border_color($selected_bg_color); }
-
       &, &.flat{
         &.small-button:not(:disabled) {
-          &, &:hover { 
+          &, &:hover {
             color: $fg_color;
             border-color: transparent;
 


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/2883614/57858938-454d5e00-77f2-11e9-910d-571339d03efa.png)


after:
![image](https://user-images.githubusercontent.com/2883614/57858971-54341080-77f2-11e9-872a-8fe443d0872e.png)
