### PR TITLE
common: fix 1px gap in sidebar

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3731,7 +3731,7 @@ scrolledwindow {
 //vbox and hbox separators
 separator {
   background: transparentize($borders_color, 0.7);
-  min-width: 1px;
+  min-width: 0px;
   min-height: 1px;
 }
 


### PR DESCRIPTION
When a viewport is inside a scrolledwindow there is 1 px gap due to
separator's min-width visible only when the row is selected, since
otherwise viewport and separator have the same bg color.

To fix this, let separator's min-width be zero.

![Screenshot from 2019-05-17 17-47-12](https://user-images.githubusercontent.com/2883614/57940004-d93f2880-78cb-11e9-9fd9-2319fb74f0c7.png)




closes #1363