### PR TITLE
Make headerbar border flexible

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1101,9 +1101,9 @@ toolbar.inline-toolbar toolbutton:backdrop {
   &.suggested-action:not(:disabled):not(:active):not(:hover) { background-color: $success_color; border-color: $success_color; }
   &.destructive-action:not(:disabled):not(:active):not(:hover) { background-color: $destructive_color; border-color: $destructive_color; }
   &, &:hover, &:active, &:checked { box-shadow: none; }
-  &:hover, &:checked:hover { background-color: lighten($inkstone, 2%); border-color: lighten($inkstone, 2%); }
-  &:checked { background-color: $inkstone; border-color: $inkstone; }
-  &:active, &:checked:active { background-color: lighten($inkstone, 5%) }
+  &:hover, &:checked:hover { background-color: lighten($headerbar_border_color, 2%); border-color: lighten($headerbar_border_color, 2%); }
+  &:checked { background-color: $headerbar_border_color; border-color: $headerbar_border_color; }
+  &:active, &:checked:active { background-color: lighten($headerbar_border_color, 5%) }
   &:backdrop {
     check, radio { background-color: transparent; }
     &:hover { background-color: lighten($backdrop_menu_color, 2%); } 
@@ -1594,7 +1594,7 @@ headerbar {
   padding: 0 6px;
   min-height: 40px;
   border-color: transparentize(_border_color($headerbar_bg_color), 0.7);
-  border-top-color: $inkstone;
+  border-top-color: $headerbar_border_color;
   border-style: solid;
   border-width: 0;
   border-top-width: 1px;
@@ -1631,15 +1631,15 @@ headerbar {
   }
 
   & > separator {
-      background-image: image(mix($inkstone, $headerbar_bg_color, 50%));
-      &:backdrop { background-image: image(mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%)); }
+      background-image: image(mix($headerbar_border_color, $headerbar_bg_color, 50%));
+      &:backdrop { background-image: image(mix(darken($headerbar_border_color, 5%), $backdrop_headerbar_bg_color, 50%)); }
   }
 
   ~ separator, separator, separator.sidebar {
     &, &.titlebutton {
      &.horizontal, &.vertical {
-        & { background-image: image(mix($inkstone, $headerbar_bg_color, 50%)); }
-        &:backdrop { background-image: image(mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%)); }
+        & { background-image: image(mix($headerbar_border_color, $headerbar_bg_color, 50%)); }
+        &:backdrop { background-image: image(mix(darken($headerbar_border_color, 5%), $backdrop_headerbar_bg_color, 50%)); }
       }
     }
   }
@@ -1648,8 +1648,8 @@ headerbar {
   separator, hdyleaflet separator {
     &, &.sidebar {
       &, &.vertical, &.horizontal {
-        border-color: mix($inkstone, $headerbar_bg_color, 50%);
-        &:backdrop { border-color: mix(darken($inkstone, 5%), $backdrop_headerbar_bg_color, 50%); }
+        border-color: mix($headerbar_border_color, $headerbar_bg_color, 50%);
+        &:backdrop { border-color: mix(darken($headerbar_border_color, 5%), $backdrop_headerbar_bg_color, 50%); }
       }
     }
   }
@@ -1748,14 +1748,14 @@ headerbar {
     buttonbox.linked button,
     buttonbox.linked button.text-button ~ button {
       border-style: solid;
-      border-color: lighten($inkstone, 5%);
+      border-color: lighten($headerbar_border_color, 5%);
 
       &:not(:only-child) { border-width: 1px 0; }
       &:first-child { border-width: 1px 0 1px 1px; }
       &:last-child { border-width: 1px 1px 1px 0; }
 
       &:backdrop {
-        &, &:checked { border-color: lighten($inkstone, 3%); }
+        &, &:checked { border-color: lighten($headerbar_border_color, 3%); }
       }
     }
   }
@@ -2434,7 +2434,7 @@ popover.background {
     *:not(fill):not(highlight):not(trough):not(slider):not(switch):not(selection):not(menu) { background-color: transparent; }
     separator { background-image: image(darken($menu_border,13%)); }
     scrollbar slider { background-color: $scrollbar_slider_color; }
-    entry:not(:focus), button { border-color: darken($inkstone,1%); &:backdrop { border-color: lighten($inkstone,5%); } }
+    entry:not(:focus), button { border-color: darken($headerbar_border_color,1%); &:backdrop { border-color: lighten($headerbar_border_color,5%); } }
     button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
     switch { @include switch($dark_fill, $success_color); }
   }

--- a/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
@@ -28,6 +28,7 @@ $terminal_borders_color: darken($terminal_bg_color, 10%);
 $headerbar_bg_color: #2B2929;
 $menubar_bg_color: $headerbar_bg_color;
 $headerbar_fg_color: $porcelain;
+$headerbar_border_color: lighten($headerbar_bg_color, 8%);
 $headerbar_text_color: $silk;
 $headerbar_insensitive_color: mix($headerbar_fg_color, $headerbar_bg_color, 50%);
 //


### PR DESCRIPTION
By introducing headerbar_border_color
and making it dependent on headerbar_bg_color
This way the border changes when the headerbar_bg changes without changing the previously designed color visibly

Inkstone:
![INSTONE](https://user-images.githubusercontent.com/15329494/58409254-fdd79500-806f-11e9-97af-a4142a5d8694.png)

lighten($headerbar_bg_color, 8%)
![lightenhbbgcolor8](https://user-images.githubusercontent.com/15329494/58409253-fdd79500-806f-11e9-8df5-dcaa6868b4f0.png)

Difference is barely visible:
![difference](https://user-images.githubusercontent.com/15329494/58409251-fdd79500-806f-11e9-957a-16c659857208.png)