### PR TITLE
Fix hb entry border bug

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1725,7 +1725,9 @@ headerbar {
 
     .stack-switcher.linked button,
     buttonbox.linked button,
-    buttonbox.linked button.text-button ~ button {
+    buttonbox.linked button.text-button ~ button,
+    box.linked button,
+    box.linked entry {
       border-style: solid;
       border-color: lighten($inkstone, 5%);
 

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1723,27 +1723,6 @@ headerbar {
       }
     }
 
-    .linked:not(.path-bar):not(.stack-switcher):not(buttonbox) button, .linked:not(.vertical) entry {
-      // force linked buttons and entries to be separate
-      // this needs a lot of testing
-      &:focus {
-        & + entry { border-left-color: _border_color($graphite); }
-        & + button { border-left-color: transparent; }
-
-        & + entry,
-        & + button {
-          &:disabled { border-left-color: transparent; }
-          &:backdrop { border-left-color: _border_color($headerbar_bg_color); }
-        }
-      }
-      border-width: 1px;
-      border-style: solid;
-      border-radius: $small_radius;
-      -gtk-outline-radius: $small_radius;
-
-      &:not(:last-child) { margin-right: 4px; }
-    }
-
     .stack-switcher.linked button,
     buttonbox.linked button,
     buttonbox.linked button.text-button ~ button {


### PR DESCRIPTION
The border of linked widgets is gone when you focus the headerbar entry 

![unfocused_bugged](https://user-images.githubusercontent.com/15329494/58411369-704a7400-8074-11e9-988d-2abc57bd0332.png)
![Screenshot-20190527113506-186x152](https://user-images.githubusercontent.com/15329494/58411367-6fb1dd80-8074-11e9-837d-ba7c27f53aed.png)
![Screenshot_20190527-152639_Samsung Internet](https://user-images.githubusercontent.com/15329494/58422866-f9bd6e80-8093-11e9-9cb3-d0dbb8f1a3c4.jpg)


This removes the separation
![hbentryunfocusedfixed](https://user-images.githubusercontent.com/15329494/58411390-7e989000-8074-11e9-82ae-2f434174427f.png)
![hbentryfocusfixed](https://user-images.githubusercontent.com/15329494/58411394-80faea00-8074-11e9-9d3f-2b7bbbd3e489.png)

@galgalesh was probably right here
https://github.com/ubuntu/yaru/issues/68#issuecomment-358628766

Eventually caused by https://github.com/ubuntu/yaru/pull/197