### PR TITLE
Fix selected row bug

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3776,11 +3776,6 @@ row {
     &.has-open-popup, // this is for indicathing which row generated a popover see https://bugzilla.gnome.org/show_bug.cgi?id=754411
 
     &:active { box-shadow: inset 0 2px 2px -2px transparentize(black, 0.8); }
-
-    &:not(:backdrop):selected {
-      &.has-open-popup { background-color: mix($fg_color, $selected_bg_color, 10%); }
-
-    }
   }
 
   &:selected {


### PR DESCRIPTION
When one opens the popover on selected rows, the row turns orange
![Screenshot from 2019-05-27 12-07-22](https://user-images.githubusercontent.com/15329494/58413010-0207b080-8078-11e9-9ae4-6ab1522248f0.png)


This fixes this
![Screenshot from 2019-05-27 12-04-57](https://user-images.githubusercontent.com/15329494/58412905-c10f9c00-8077-11e9-97cf-402f828f4399.png)
