### PR TITLE
Sharpen backdrop headerbar border color

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1609,7 +1609,7 @@ headerbar {
 
   &:backdrop {
     background-color: $backdrop_headerbar_bg_color;
-    border-color: transparentize(_border_color($backdrop_headerbar_bg_color), 0.7);
+    border-color: transparent;
     color: $backdrop_fg_color;
     transition: $backdrop_transition;
   }


### PR DESCRIPTION
By setting it to transparent. Previously it became blurry in the backdrop.
@clobrano please see if you like it - if not just close it and let's try other stuff!

Before:
![grafik](https://user-images.githubusercontent.com/15329494/59177754-55d8c600-8b5d-11e9-8c86-f7c18385447e.png)

After:
![grafik](https://user-images.githubusercontent.com/15329494/59177814-86206480-8b5d-11e9-89cb-b5a32691b37a.png)
