### PR TITLE
Bionic: Sharpen backdrop headerbar border color

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -1609,7 +1609,7 @@ headerbar {
 
   &:backdrop {
     background-color: $backdrop_headerbar_bg_color;
-    border-color: transparentize(_border_color($backdrop_headerbar_bg_color), 0.7);
+    border-color: transparent;
     color: $backdrop_fg_color;
     transition: $backdrop_transition;
   }


### PR DESCRIPTION
By setting it to transparent. Previously it became blurry in the backdrop.

Cherry-pick from https://github.com/ubuntu/yaru/pull/1399