### PR TITLE
Symbolic icon for Livepatch

### DIFF
--- a/icons/Suru/scalable/apps/livepatch-symbolic.svg
+++ b/icons/Suru/scalable/apps/livepatch-symbolic.svg
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16.000061' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-833.0002,167.00006)'/>
+  <g id='layer2' style='display:inline' transform='translate(-592,-199.99994)'/>
+  <g id='layer4' style='display:inline' transform='translate(-592,-199.99994)'/>
+  <g id='g1812' style='display:inline' transform='translate(-592,-199.99994)'/>
+  <g id='g6217' style='display:inline' transform='translate(-592,-199.99994)'/>
+  <g id='layer3' style='display:inline' transform='translate(-592,-199.99994)'/>
+  <g id='g1833' style='display:inline' transform='translate(-592,-199.99994)'>
+    
+    <path d='m 599,202 c 0,0 -1,0 -1,1 0,1 1,1 1,1 h 1 a 4,4 0 0 1 4,4 4,4 0 0 1 -4,4 4,4 0 0 1 -4,-4 h 2 l -3,-4 -3,4 h 2 c 0,3.31371 2.6863,6 6,6 3.31371,0 6,-2.68629 6,-6 0,-3.3137 -2.68629,-6 -6,-6 z' id='path4868' style='opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2.66700006;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1'/>
+  </g>
+  <g id='layer1' style='display:inline' transform='translate(-592,-199.99994)'/>
+</svg>

--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -31,10 +31,10 @@
      inkscape:window-width="1296"
      inkscape:window-height="704"
      id="namedview88"
-     showgrid="false"
+     showgrid="true"
      inkscape:zoom="16"
-     inkscape:cx="573.68376"
-     inkscape:cy="397.01045"
+     inkscape:cx="594.80583"
+     inkscape:cy="393.74797"
      inkscape:window-x="70"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -9080,6 +9080,28 @@
          id="path9893"
          d="M 580 205 A 3 3 0 0 0 577 208 A 3 3 0 0 0 580 211 A 3 3 0 0 0 583 208 A 3 3 0 0 0 580 205 z M 580 206 A 2 2 0 0 1 582 208 A 2 2 0 0 1 580 210 A 2 2 0 0 1 578 208 A 2 2 0 0 1 580 206 z "
          style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
+       id="g4896"
+       inkscape:label="livepatch">
+      <g
+         inkscape:label="application-x-executable"
+         id="g9903-3"
+         style="display:inline"
+         transform="translate(20,1.0351562e-6)">
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.66653478;marker:none;enable-background:accumulate"
+           id="rect2713-9-6"
+           width="16"
+           height="15.999999"
+           x="199.99994"
+           y="-588.00006"
+           transform="rotate(90)" />
+      </g>
+      <path
+         id="path4868"
+         d="M 599 202 C 599 202 598 202 598 203 C 598 204 599 204 599 204 L 600 204 A 4 4 0 0 1 604 208 A 4 4 0 0 1 600 212 A 4 4 0 0 1 596 208 L 598 208 L 595 204 L 592 208 L 594 208 C 594 211.31371 596.6863 214 600 214 C 603.31371 214 606 211.31371 606 208 C 606 204.6863 603.31371 202 600 202 L 599 202 z "
+         style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2.66700006;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
   </g>
   <g


### PR DESCRIPTION
I can't test this one myself because Livepatch isn't available for my system - I googled it, and I think you have to be on LTS or certain releases?  When I try to run Livepatch it just opens the normal software updater.

Here it is - it's called livepatch-symbolic.svg which I hope will work!!

![image](https://user-images.githubusercontent.com/38893390/59291543-10a6b800-8c73-11e9-8d41-95c1def1b9a5.png)
