### PR TITLE
Fix dark popover selected items

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2403,6 +2403,7 @@ popover.background {
     entry:not(:focus), button { border-color: darken($headerbar_border_color,1%); &:backdrop { border-color: lighten($headerbar_border_color,5%); } }
     button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
     switch { @include switch($dark_fill, $success_color); }
+    *:selected { @extend %selected_items; }
   }
 }
 


### PR DESCRIPTION
The wildcard to get the osd styled dark popovers destroys also the selected background color.
Adding yet one more wildcard for every widget in :selected state fixes this

![photo_2019-06-15_16-08-57](https://user-images.githubusercontent.com/15329494/59552499-0bee4680-8f88-11e9-91cd-53aae690dba1.jpg)

--->

![photo_2019-06-15_16-08-59](https://user-images.githubusercontent.com/15329494/59552498-0bee4680-8f88-11e9-8509-6f26daf77a59.jpg)


Closes https://github.com/ubuntu/yaru/issues/1406