### PR TITLE
Fix dark popover selected items

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2437,6 +2437,7 @@ popover.background {
     entry:not(:focus), button { border-color: darken($inkstone,1%); &:backdrop { border-color: lighten($inkstone,5%); } }
     button, button.circular, button.flat, button.text-button, modelbutton { @extend %jet_popover_button; }
     switch { @include switch($dark_fill, $success_color); }
+    *:selected { @extend %selected_items; }
   }
 }
 


### PR DESCRIPTION
Cherry-pick
The wildcard to get the osd styled dark popovers destroys also the selected background color.
Adding yet one more wildcard for every widget in :selected state fixes this