### PR TITLE
Add missing Remmina symlink

### DIFF
--- a/icons/Suru/16x16/apps/org.remmina.Remmina.png
+++ b/icons/Suru/16x16/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/16x16@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/16x16@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/24x24/apps/org.remmina.Remmina.png
+++ b/icons/Suru/24x24/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/24x24@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/24x24@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/256x256/apps/org.remmina.Remmina.png
+++ b/icons/Suru/256x256/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/256x256@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/256x256@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/32x32/apps/org.remmina.Remmina.png
+++ b/icons/Suru/32x32/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/32x32@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/32x32@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/48x48/apps/org.remmina.Remmina.png
+++ b/icons/Suru/48x48/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/48x48@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/48x48@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png


### PR DESCRIPTION
I know we likely won't need this for long, but, for completeness, I added the missing symlink for Remmina.  This means Disco will use the Yaru icon for Remmina in the meantime.

Test:

![image](https://user-images.githubusercontent.com/38893390/62011754-5a405900-b174-11e9-852a-be5eb6dc9100.png)
