### PR TITLE
Bionic: Adding missing Remmina symlink

### DIFF
--- a/icons/Suru/16x16/apps/org.remmina.Remmina.png
+++ b/icons/Suru/16x16/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/16x16@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/16x16@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/24x24/apps/org.remmina.Remmina.png
+++ b/icons/Suru/24x24/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/24x24@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/24x24@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/256x256/apps/org.remmina.Remmina.png
+++ b/icons/Suru/256x256/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/256x256@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/256x256@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/32x32/apps/org.remmina.Remmina.png
+++ b/icons/Suru/32x32/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/32x32@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/32x32@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/48x48/apps/org.remmina.Remmina.png
+++ b/icons/Suru/48x48/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png

--- a/icons/Suru/48x48@2x/apps/org.remmina.Remmina.png
+++ b/icons/Suru/48x48@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remmina.png


### PR DESCRIPTION
This is a cherry pick of #1429, the missing symlink for Remmina, for Bionic.