### PR TITLE
Fix headerbars that are not titlebars

### DIFF
--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -62,7 +62,7 @@ $small_radius: 4px;
   }
 }
 
-headerbar.titlebar {
+headerbar {
   &:not(.selection-mode) &,
     &:not(.selection-mode)
    {
@@ -224,6 +224,7 @@ button.titlebutton {
 
 headerbar button.titlebutton.appmenu.popup.toggle {
   &, &:backdrop { @include button(undecorated); }
+  &:hover { @include button(hover, lighten($headerbar_bg_color, 8%), $headerbar_fg_color); }
 }
 
 headerbar * {


### PR DESCRIPTION
- fixes headerbars that are not titlebars to be also dark ...
- needs fixing again for selection mode buttons in some apps like gnome-contacts
- also fixing app menu hover state

Merging it now, since inconsistent app titlebars are more of a problem and creating an issue for the selection mode buttons