### PR TITLE
Symbols: Updated file manager, camera, new symbol for Jockey

### DIFF
--- a/icons/Suru/scalable/apps/camera-app-symbolic.svg
+++ b/icons/Suru/scalable/apps/camera-app-symbolic.svg
@@ -1,35 +1,114 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata20854'>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   id="svg7384"
+   version="1.1"
+   width="16"
+   sodipodi:docname="camera-app-symbolic.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="785"
+     inkscape:window-height="480"
+     id="namedview9511"
+     showgrid="false"
+     inkscape:zoom="5.2149125"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata20854">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:title/>
+      <cc:Work
+         rdf:about="">
+        <dc:title />
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient id='linearGradient4526' osb:paint='solid'>
-      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         id="stop4528"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
-      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
-      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    <linearGradient
+       id="linearGradient3600-4"
+       osb:paint="gradient">
+      <stop
+         id="stop3602-7"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1" />
+      <stop
+         id="stop3604-6"
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1" />
     </linearGradient>
   </defs>
-  <g id='layer9' label='status' style='display:inline' transform='translate(-853.00024,147.00006)'/>
-  <g id='layer2' style='display:inline' transform='translate(-612.00004,-219.99994)'/>
-  <g id='layer4' style='display:inline' transform='translate(-612.00004,-219.99994)'/>
-  <g id='g1812' style='display:inline' transform='translate(-612.00004,-219.99994)'/>
-  <g id='g6217' style='display:inline' transform='translate(-612.00004,-219.99994)'/>
-  <g id='layer3' style='display:inline' transform='translate(-612.00004,-219.99994)'/>
-  <g id='g1833' style='display:inline' transform='translate(-612.00004,-219.99994)'>
-    <path d='m 615.99418,222 c -1.2582,0.0145 -2.17889,-0.0306 -2.93164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 -0.16467,0.43867 -0.22461,0.95958 -0.22461,1.61719 v 7 c 0,0.65761 0.0599,1.17853 0.22461,1.61719 0.16467,0.43866 0.46152,0.79039 0.83789,0.99804 0.75275,0.41532 1.67345,0.3702 2.93164,0.38477 h 0.004 8.0039 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37637,-0.20766 0.67322,-0.55938 0.83789,-0.99804 0.16395,-0.43867 0.22443,-0.95958 0.22443,-1.61719 v -7 c 0,-0.65761 -0.0599,-1.17852 -0.22461,-1.61719 -0.16466,-0.43866 -0.46152,-0.79038 -0.83789,-0.99804 -0.75275,-0.41534 -1.67344,-0.37025 -2.93164,-0.38477 h -0.004 -8.0039 z m 2.90234,1.0918 c 1.74896,-0.004 3.49727,-0.001 5.2461,0.0215 0.86117,0.14671 2.16104,-0.34154 2.67383,0.66797 0.25574,2.92399 0.0694,5.88197 0.1289,8.81836 -0.0871,0.38019 -0.18482,1.14361 -0.73047,1.12891 -3.53641,0.23538 -7.09146,0.10846 -10.63476,0.13476 -0.78646,-0.11198 -1.99991,0.2903 -2.4043,-0.6914 -0.1705,-2.4656 -0.0888,-4.94964 -0.0898,-7.43555 0.12175,-0.84105 -0.29598,-2.06451 0.6875,-2.51172 1.6892,-0.21162 3.40839,-0.0775 5.12304,-0.13281 z M 625.00004,224 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 z m -5,1 c -2.216,0 -4,1.784 -4,4 0,2.216 1.784,4 4,4 2.216,0 4,-1.784 4,-4 0,-2.216 -1.784,-4 -4,-4 z m 0,1 c 1.662,0 3,1.338 3,3 0,1.662 -1.338,3 -3,3 -1.662,0 -3,-1.338 -3,-3 0,-1.662 1.338,-3 3,-3 z' id='path1817-7' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
-    
-  </g>
-  <g id='layer1' style='display:inline' transform='translate(-612.00004,-219.99994)'/>
+  <g
+     id="layer9"
+     label="status"
+     style="display:inline"
+     transform="translate(-853.00024,147.00006)" />
+  <g
+     id="layer2"
+     style="display:inline"
+     transform="translate(-612.00004,-219.99994)" />
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(-612.00004,-219.99994)" />
+  <g
+     id="g1812"
+     style="display:inline"
+     transform="translate(-612.00004,-219.99994)" />
+  <g
+     id="g6217"
+     style="display:inline"
+     transform="translate(-612.00004,-219.99994)" />
+  <g
+     id="layer3"
+     style="display:inline"
+     transform="translate(-612.00004,-219.99994)" />
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(-612.00004,-219.99994)" />
+  <path
+     inkscape:connector-curvature="0"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 3.00003,1.00006 v 1 H 3.99417 C 2.73597,2.01456 1.81528,1.96946 1.06253,2.38483 0.68616,2.59249 0.3893,2.94421 0.22464,3.38287 0.05997,3.82154 3e-5,4.34245 3e-5,5.00006 v 6 c 0,0.65761 0.0599,1.17853 0.22461,1.61719 0.16467,0.43866 0.46152,0.79039 0.83789,0.99804 0.75275,0.41532 1.67345,0.3702 2.93164,0.38477 h 0.004 8.0039 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37637,-0.20766 0.67322,-0.55938 0.83789,-0.99804 0.16431,-0.43867 0.22443,-0.95958 0.22443,-1.61719 v -6 c 0,-0.65761 -0.0599,-1.17852 -0.22461,-1.61719 C 15.61076,2.94421 15.3139,2.59249 14.93753,2.38483 14.18478,1.96949 13.26409,2.01458 12.00589,2.00006 h -0.004 -7.00186 v -1 z m 1,2 h 8 c 1.25852,0.0147 2.08717,0.0598 2.45312,0.26172 0.18341,0.1012 0.28916,0.21274 0.38672,0.47266 0.09743,0.25991 0.16016,0.67323 0.16016,1.26562 v 6 c 0,0.59239 -0.0626,1.00573 -0.16016,1.26562 -0.0976,0.25991 -0.20331,0.37147 -0.38672,0.47266 -0.36594,0.20191 -1.1946,0.24701 -2.45312,0.26172 H 4.00589 4.00003 C 2.7415,12.98536 1.91091,12.94026 1.54495,12.73834 1.36154,12.63715 1.25775,12.5256 1.16019,12.26568 1.06262,12.00578 1.00003,11.59245 1.00003,11.00006 v -6 c 0,-0.59239 0.0626,-1.00572 0.16016,-1.26562 C 1.25779,3.47453 1.36154,3.36297 1.54495,3.26178 1.91091,3.05987 2.7415,3.01477 4.00003,3.00006 Z m 4,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z m 5.5,0 a 0.5,0.5 0 0 0 -0.5,0.5 0.5,0.5 0 0 0 0.5,0.5 0.5,0.5 0 0 0 0.5,-0.5 0.5,0.5 0 0 0 -0.5,-0.5 z m -5.5,1 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m -0.084,1.00391 a 2,2 0 0 0 -1.916,1.99609 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -1.90039,-1.99414 1,1 0 0 1 0.90039,0.99414 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 0.91602,-0.99609 z"
+     id="path8678-2" />
 </svg>

--- a/icons/Suru/scalable/apps/filemanager-app-symbolic.svg
+++ b/icons/Suru/scalable/apps/filemanager-app-symbolic.svg
@@ -1,35 +1,117 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata20854'>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   id="svg7384"
+   version="1.1"
+   width="16"
+   sodipodi:docname="filemanager-app-symbolic.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     id="namedview7367"
+     showgrid="true"
+     inkscape:zoom="11.313709"
+     inkscape:cx="-1.1625857"
+     inkscape:cy="4.9984652"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384">
+    <inkscape:grid
+       type="xygrid"
+       id="grid7912" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata20854">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:title/>
+      <cc:Work
+         rdf:about="">
+        <dc:title />
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient id='linearGradient4526' osb:paint='solid'>
-      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         id="stop4528"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
-      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
-      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    <linearGradient
+       id="linearGradient3600-4"
+       osb:paint="gradient">
+      <stop
+         id="stop3602-7"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1" />
+      <stop
+         id="stop3604-6"
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1" />
     </linearGradient>
   </defs>
-  <g id='layer9' label='status' style='display:inline' transform='translate(-733.00024,207)'/>
-  <g id='layer2' style='display:inline' transform='translate(-492.00004,-160)'/>
-  <g id='layer4' style='display:inline' transform='translate(-492.00004,-160)'/>
-  <g id='g1812' style='display:inline' transform='translate(-492.00004,-160)'/>
-  <g id='g6217' style='display:inline' transform='translate(-492.00004,-160)'/>
-  <g id='layer3' style='display:inline' transform='translate(-492.00004,-160)'/>
-  <g id='g1833' style='display:inline' transform='translate(-492.00004,-160)'>
-    
-    <path d='m 495.99418,161 c -1.25819,0.0145 -2.17883,-0.0286 -2.93164,0.38672 -0.37641,0.20768 -0.67518,0.55747 -0.83984,0.99609 -0.16465,0.43862 -0.22266,0.9596 -0.22266,1.61719 v 8 c 0,0.65759 0.058,1.17857 0.22266,1.61719 0.16466,0.43862 0.46343,0.79036 0.83984,0.99804 0.75281,0.41535 1.67345,0.37023 2.93164,0.38477 h 0.006 8 0.006 c 1.25819,-0.0145 2.17883,0.0306 2.93164,-0.38477 0.37641,-0.20768 0.67518,-0.55942 0.83984,-0.99804 0.16438,-0.43862 0.22238,-0.9596 0.22238,-1.61719 v -3 -3 c 0,-0.65759 -0.058,-1.17857 -0.22266,-1.61719 -0.0205,-0.0546 -0.0479,-0.10399 -0.0742,-0.15429 -0.01,-0.0185 -0.0178,-0.038 -0.0273,-0.0566 -0.1727,-0.33876 -0.42547,-0.61453 -0.73828,-0.78711 -0.75287,-0.41535 -1.67351,-0.37023 -2.9317,-0.38477 h -0.006 -3.0332 l -2.02149,-2 h -2.94922 z m 0.0117,1 h 2.5293 l 1.76562,1.74609 L 499.03324,165 h -3.0332 -0.006 c -1.25819,0.0145 -2.17883,-0.0306 -2.93164,0.38477 -0.0222,0.0122 -0.0409,0.0297 -0.0625,0.043 V 164 c 0,-0.59241 0.0626,-1.0057 0.16016,-1.26563 0.0976,-0.25996 0.20334,-0.37147 0.38672,-0.47265 0.36675,-0.20235 1.19544,-0.24713 2.45898,-0.26172 z m 5.45898,2 h 2.52735 c 1.26354,0.0146 2.09222,0.0594 2.45898,0.26172 0.18338,0.10118 0.28915,0.21269 0.38672,0.47265 0.0977,0.25994 0.16213,0.67322 0.16213,1.26563 v 3 3 c 0,0.59241 -0.0627,1.00569 -0.16016,1.26562 -0.0976,0.25995 -0.20332,0.37148 -0.38672,0.47266 -0.36611,0.20202 -1.19322,0.24702 -2.45312,0.26172 h -0.006 -7.994 c -1.2599,-0.0147 -2.087,-0.0597 -2.45312,-0.26172 -0.18341,-0.10118 -0.28915,-0.21271 -0.38672,-0.47266 -0.0976,-0.25993 -0.16016,-0.67321 -0.16016,-1.26562 v -4 c 0,-0.59241 0.0644,-1.00569 0.16211,-1.26563 0.0976,-0.25996 0.20334,-0.37147 0.38672,-0.47265 0.36676,-0.20232 1.19544,-0.24712 2.45898,-0.26172 h 3.43555 z' id='path1829' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00000048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
-  </g>
-  <g id='layer1' style='display:inline' transform='translate(-492.00004,-160)'/>
+  <g
+     id="layer9"
+     label="status"
+     style="display:inline"
+     transform="translate(-733.00024,207)" />
+  <g
+     id="layer2"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="g1812"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="g6217"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="layer3"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 5.9941406 1 C 4.7359423 1.0145341 3.8152478 0.96943874 3.0625 1.3847656 C 2.6861261 1.5924291 2.389274 1.9441474 2.2246094 2.3828125 C 2.0599447 2.8214776 2 3.3423913 2 4 L 2 13 C 2 13.657611 2.059927 14.178577 2.2246094 14.617188 C 2.3892918 15.055796 2.6861385 15.405714 3.0625 15.613281 C 3.8152229 16.028416 4.7360404 15.984933 5.9941406 16 L 5.9960938 16 L 10.001953 16 L 10.005859 16 C 11.264052 15.98546 12.184752 16.03056 12.9375 15.615234 C 13.313874 15.407571 13.610725 15.055852 13.775391 14.617188 C 13.940065 14.178522 14 13.657611 14 13 L 14 4 C 14 3.342391 13.940074 2.8214208 13.775391 2.3828125 C 13.610707 1.9442042 13.313862 1.594285 12.9375 1.3867188 C 12.184777 0.97158603 11.263955 1.0150668 10.005859 1 L 10.003906 1 L 5.9980469 1 L 5.9941406 1 z M 6 2 L 10 2 C 11.258621 2.015235 12.089098 2.059878 12.455078 2.2617188 C 12.6385 2.3628774 12.742298 2.4745771 12.839844 2.734375 C 12.93739 2.9941729 13 3.407609 13 4 L 13 13 C 13 13.592394 12.93741 14.005716 12.839844 14.265625 C 12.742284 14.525534 12.638488 14.637086 12.455078 14.738281 C 12.089123 14.940196 11.258524 14.985293 10 15 L 6.0058594 15 L 6 15 C 4.741374 14.984765 3.9109003 14.940122 3.5449219 14.738281 C 3.3615008 14.637123 3.2577019 14.525425 3.1601562 14.265625 C 3.0626107 14.005825 3 13.592394 3 13 L 3 4 C 3 3.4076087 3.062593 2.9942833 3.1601562 2.734375 C 3.2577198 2.4744667 3.3615133 2.3629139 3.5449219 2.2617188 C 3.9108755 2.0598045 4.7414716 2.0147015 6 2 z M 4 3 L 4 6 L 12 6 L 12 3 L 4 3 z M 7 4 L 9 4 L 9 5 L 7 5 L 7 4 z M 4 7 L 4 10 L 12 10 L 12 7 L 4 7 z M 7 8 L 9 8 L 9 9 L 7 9 L 7 8 z M 4 11 L 4 14 L 12 14 L 12 11 L 4 11 z M 7 12 L 9 12 L 9 13 L 7 13 L 7 12 z "
+     id="path2732-8-1-77" />
 </svg>

--- a/icons/Suru/scalable/apps/jockey-symbolic.svg
+++ b/icons/Suru/scalable/apps/jockey-symbolic.svg
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   id="svg7384"
+   version="1.1"
+   width="16"
+   sodipodi:docname="jockey-symbolic.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     id="namedview7367"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="4.1248208"
+     inkscape:cy="4.6357233"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384">
+    <inkscape:grid
+       type="xygrid"
+       id="grid7912" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata20854">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title></dc:title>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         id="stop4528"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4"
+       osb:paint="gradient">
+      <stop
+         id="stop3602-7"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1" />
+      <stop
+         id="stop3604-6"
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <g
+     id="layer9"
+     label="status"
+     style="display:inline"
+     transform="translate(-733.00024,207)" />
+  <g
+     id="layer2"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="g1812"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="g6217"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="layer3"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(-492.00004,-160)" />
+  <path
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 4.5,4 C 4.223,4 4,4.223 4,4.5 v 7 C 4,11.777 4.223,12 4.5,12 h 7 c 0.277,0 0.5,-0.223 0.5,-0.5 v -7 C 12,4.223 11.777,4 11.5,4 Z M 5,5 h 6 v 6 H 5 Z"
+     id="rect5102"
+     inkscape:connector-curvature="0" />
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104"
+     width="2"
+     height="3"
+     x="4"
+     y="0"
+     rx="0.5"
+     ry="0.5" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-6"
+     width="2"
+     height="3"
+     x="7"
+     y="0"
+     rx="0.5"
+     ry="0.5" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-0"
+     width="2"
+     height="3"
+     x="10"
+     y="0"
+     rx="0.5"
+     ry="0.5" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-8"
+     width="2"
+     height="3"
+     x="4"
+     y="13"
+     rx="0.5"
+     ry="0.5" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-6-7"
+     width="2"
+     height="3"
+     x="7"
+     y="13"
+     rx="0.5"
+     ry="0.5" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-0-9"
+     width="2"
+     height="3"
+     x="10"
+     y="13"
+     rx="0.5"
+     ry="0.5" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-2"
+     width="2"
+     height="3"
+     x="-6"
+     y="13"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-90)" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-6-0"
+     width="2"
+     height="3"
+     x="-9"
+     y="13"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-90)" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-0-2"
+     width="2"
+     height="3"
+     x="-12"
+     y="13"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-90)" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-8-3"
+     width="2"
+     height="3"
+     x="-6"
+     y="3.6739403e-16"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-90)" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-6-7-7"
+     width="2"
+     height="3"
+     x="-9"
+     y="5.5109107e-16"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-90)" />
+  <rect
+     style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5104-0-9-5"
+     width="2"
+     height="3"
+     x="-12"
+     y="7.3478806e-16"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-90)" />
+  <path
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 4,2 C 2.892,2 2,2.892 2,4 v 8 c 0,1.108 0.892,2 2,2 h 8 c 1.108,0 2,-0.892 2,-2 V 4 C 14,2.892 13.108,2 12,2 Z m 0.5,1 h 7 C 12.331,3 13,3.669 13,4.5 v 7 c 0,0.831 -0.669,1.5 -1.5,1.5 h -7 C 3.669,13 3,12.331 3,11.5 v -7 C 3,3.669 3.669,3 4.5,3 Z"
+     id="rect5228"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -31,10 +31,10 @@
      inkscape:window-width="1296"
      inkscape:window-height="704"
      id="namedview88"
-     showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="520.62382"
-     inkscape:cy="248.92123"
+     showgrid="true"
+     inkscape:zoom="4"
+     inkscape:cx="554.54468"
+     inkscape:cy="289.79217"
      inkscape:window-x="70"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -6777,25 +6777,6 @@
          transform="rotate(90)" />
     </g>
     <g
-       id="g1831"
-       inkscape:label="system-file-manager"
-       transform="translate(-59.999958,108)"
-       style="display:inline">
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate"
-         id="rect1827"
-         width="16"
-         height="16"
-         x="52.000004"
-         y="-568"
-         transform="rotate(90)" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00000048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 555.99414,53 c -1.25819,0.0145 -2.17883,-0.0286 -2.93164,0.386719 -0.37641,0.20768 -0.67518,0.557473 -0.83984,0.996093 C 552.05801,54.821433 552,55.34241 552,56 v 8 c 0,0.65759 0.058,1.178567 0.22266,1.617188 0.16466,0.43862 0.46343,0.790366 0.83984,0.998046 0.75281,0.41535 1.67345,0.370226 2.93164,0.384766 h 0.006 8 0.006 c 1.25819,-0.01454 2.17883,0.03058 2.93164,-0.384766 0.37641,-0.20768 0.67518,-0.559426 0.83984,-0.998046 C 567.942,65.178567 568,64.65759 568,64 v -3 -3 c 0,-0.65759 -0.058,-1.178566 -0.22266,-1.617188 -0.0205,-0.05455 -0.0479,-0.103993 -0.0742,-0.154296 -0.01,-0.01848 -0.0178,-0.03805 -0.0273,-0.05664 -0.1727,-0.338752 -0.42547,-0.614522 -0.73828,-0.787109 C 566.18469,54.969416 565.26405,55.01454 564.00586,55 H 564 560.9668 l -2.02149,-2 h -2.94922 z m 0.0117,1 h 2.5293 l 1.76562,1.746094 L 559.0332,57 H 556 555.994 c -1.25819,0.01454 -2.17883,-0.03058 -2.93164,0.384766 -0.0222,0.01224 -0.0409,0.02974 -0.0625,0.04297 V 56 c 0,-0.59241 0.0626,-1.005695 0.16016,-1.265625 0.0976,-0.25996 0.20334,-0.371476 0.38672,-0.472656 0.36675,-0.20235 1.19544,-0.247129 2.45898,-0.261719 z m 5.45898,2 h 2.52735 c 1.26354,0.0146 2.09222,0.0594 2.45898,0.261719 0.18338,0.10118 0.28915,0.212696 0.38672,0.472656 C 566.93559,56.994315 567,57.40759 567,58 v 3 3 c 0,0.59241 -0.0627,1.005695 -0.16016,1.265625 -0.0976,0.25995 -0.20332,0.371476 -0.38672,0.472656 C 566.08701,65.9403 565.2599,65.9853 564,66 H 563.994 556 c -1.2599,-0.0147 -2.087,-0.0597 -2.45312,-0.261719 -0.18341,-0.10118 -0.28915,-0.212706 -0.38672,-0.472656 C 553.06256,65.005695 553,64.59241 553,64 v -4 c 0,-0.59241 0.0644,-1.005685 0.16211,-1.265625 0.0976,-0.25996 0.20334,-0.371476 0.38672,-0.472656 C 553.91559,58.0594 554.74427,58.0146 556.00781,58 h 3.43555 z"
-         id="path1829"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
        style="display:inline"
        id="g2017"
        inkscape:label="utilities-system-monitor"
@@ -7516,25 +7497,6 @@
          height="15.999999"
          x="219.99994"
          y="-588"
-         transform="rotate(90)" />
-    </g>
-    <g
-       transform="translate(4.2001252e-5)"
-       style="display:inline"
-       id="g3608"
-       inkscape:label="camera-app">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 615.99414,222 c -1.2582,0.0145 -2.17889,-0.0306 -2.93164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 C 612.05994,223.82148 612,224.34239 612,225 v 7 c 0,0.65761 0.0599,1.17853 0.22461,1.61719 0.16467,0.43866 0.46152,0.79039 0.83789,0.99804 0.75275,0.41532 1.67345,0.3702 2.93164,0.38477 h 0.004 8.0039 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37637,-0.20766 0.67322,-0.55938 0.83789,-0.99804 C 627.93952,233.17852 628,232.65761 628,232 v -7 c 0,-0.65761 -0.0599,-1.17852 -0.22461,-1.61719 -0.16466,-0.43866 -0.46152,-0.79038 -0.83789,-0.99804 -0.75275,-0.41534 -1.67344,-0.37025 -2.93164,-0.38477 h -0.004 -8.0039 z m 2.90234,1.0918 c 1.74896,-0.004 3.49727,-0.001 5.2461,0.0215 0.86117,0.14671 2.16104,-0.34154 2.67383,0.66797 0.25574,2.92399 0.0694,5.88197 0.1289,8.81836 -0.0871,0.38019 -0.18482,1.14361 -0.73047,1.12891 -3.53641,0.23538 -7.09146,0.10846 -10.63476,0.13476 -0.78646,-0.11198 -1.99991,0.2903 -2.4043,-0.6914 -0.1705,-2.4656 -0.0888,-4.94964 -0.0898,-7.43555 0.12175,-0.84105 -0.29598,-2.06451 0.6875,-2.51172 1.6892,-0.21162 3.40839,-0.0775 5.12304,-0.13281 z M 625,224 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 z m -5,1 c -2.216,0 -4,1.784 -4,4 0,2.216 1.784,4 4,4 2.216,0 4,-1.784 4,-4 0,-2.216 -1.784,-4 -4,-4 z m 0,1 c 1.662,0 3,1.338 3,3 0,1.662 -1.338,3 -3,3 -1.662,0 -3,-1.338 -3,-3 0,-1.662 1.338,-3 3,-3 z"
-         id="path1817-7"
-         inkscape:connector-curvature="0" />
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.66653478;marker:none;enable-background:accumulate"
-         id="rect1819-4"
-         width="16"
-         height="15.999999"
-         x="219.99994"
-         y="-628"
          transform="rotate(90)" />
     </g>
     <g
@@ -8875,25 +8837,6 @@
          style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.00000001, 2.00000001;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     </g>
     <g
-       id="g1831-8"
-       inkscape:label="filemanager-app"
-       transform="translate(40.000062,268.00006)"
-       style="display:inline">
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate"
-         id="rect1827-7"
-         width="16"
-         height="16"
-         x="52.000004"
-         y="-568"
-         transform="rotate(90)" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00000048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 555.99414,53 c -1.25819,0.0145 -2.17883,-0.0286 -2.93164,0.386719 -0.37641,0.20768 -0.67518,0.557473 -0.83984,0.996093 C 552.05801,54.821433 552,55.34241 552,56 v 8 c 0,0.65759 0.058,1.178567 0.22266,1.617188 0.16466,0.43862 0.46343,0.790366 0.83984,0.998046 0.75281,0.41535 1.67345,0.370226 2.93164,0.384766 h 0.006 8 0.006 c 1.25819,-0.01454 2.17883,0.03058 2.93164,-0.384766 0.37641,-0.20768 0.67518,-0.559426 0.83984,-0.998046 C 567.942,65.178567 568,64.65759 568,64 v -3 -3 c 0,-0.65759 -0.058,-1.178566 -0.22266,-1.617188 -0.0205,-0.05455 -0.0479,-0.103993 -0.0742,-0.154296 -0.01,-0.01848 -0.0178,-0.03805 -0.0273,-0.05664 -0.1727,-0.338752 -0.42547,-0.614522 -0.73828,-0.787109 C 566.18469,54.969416 565.26405,55.01454 564.00586,55 H 564 560.9668 l -2.02149,-2 h -2.94922 z m 0.0117,1 h 2.5293 l 1.76562,1.746094 L 559.0332,57 H 556 555.994 c -1.25819,0.01454 -2.17883,-0.03058 -2.93164,0.384766 -0.0222,0.01224 -0.0409,0.02974 -0.0625,0.04297 V 56 c 0,-0.59241 0.0626,-1.005695 0.16016,-1.265625 0.0976,-0.25996 0.20334,-0.371476 0.38672,-0.472656 0.36675,-0.20235 1.19544,-0.247129 2.45898,-0.261719 z m 5.45898,2 h 2.52735 c 1.26354,0.0146 2.09222,0.0594 2.45898,0.261719 0.18338,0.10118 0.28915,0.212696 0.38672,0.472656 C 566.93559,56.994315 567,57.40759 567,58 v 3 3 c 0,0.59241 -0.0627,1.005695 -0.16016,1.265625 -0.0976,0.25995 -0.20332,0.371476 -0.38672,0.472656 C 566.08701,65.9403 565.2599,65.9853 564,66 H 563.994 556 c -1.2599,-0.0147 -2.087,-0.0597 -2.45312,-0.261719 -0.18341,-0.10118 -0.28915,-0.212706 -0.38672,-0.472656 C 553.06256,65.005695 553,64.59241 553,64 v -4 c 0,-0.59241 0.0644,-1.005685 0.16211,-1.265625 0.0976,-0.25996 0.20334,-0.371476 0.38672,-0.472656 C 553.91559,58.0594 554.74427,58.0146 556.00781,58 h 3.43555 z"
-         id="path1829-9"
-         inkscape:connector-curvature="0" />
-    </g>
-    <g
        style="display:inline"
        id="g2584-2"
        inkscape:label="software-properties"
@@ -9360,6 +9303,229 @@
          x="340"
          y="-528"
          transform="rotate(90)" />
+    </g>
+    <g
+       id="g5249"
+       inkscape:label="jockey">
+      <g
+         transform="translate(260.00004,20.000001)"
+         id="g1825-7"
+         inkscape:label="utilities-terminal"
+         style="display:inline">
+        <rect
+           transform="rotate(90)"
+           y="-287.99997"
+           x="319.99994"
+           height="15.999999"
+           width="16"
+           id="rect1819-9"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.66653478;marker:none;enable-background:accumulate" />
+      </g>
+      <path
+         id="rect5102"
+         d="M 536.5 344 C 536.223 344 536 344.223 536 344.5 L 536 351.5 C 536 351.777 536.223 352 536.5 352 L 543.5 352 C 543.777 352 544 351.777 544 351.5 L 544 344.5 C 544 344.223 543.777 344 543.5 344 L 536.5 344 z M 537 345 L 543 345 L 543 351 L 537 351 L 537 345 z "
+         style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="340"
+         x="536"
+         height="3"
+         width="2"
+         id="rect5104"
+         style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="340"
+         x="539"
+         height="3"
+         width="2"
+         id="rect5104-6"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="340"
+         x="542"
+         height="3"
+         width="2"
+         id="rect5104-0"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="353"
+         x="536"
+         height="3"
+         width="2"
+         id="rect5104-8"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="353"
+         x="539"
+         height="3"
+         width="2"
+         id="rect5104-6-7"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="353"
+         x="542"
+         height="3"
+         width="2"
+         id="rect5104-0-9"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="rotate(-90)"
+         ry="0.5"
+         rx="0.5"
+         y="545"
+         x="-346"
+         height="3"
+         width="2"
+         id="rect5104-2"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="rotate(-90)"
+         ry="0.5"
+         rx="0.5"
+         y="545"
+         x="-349"
+         height="3"
+         width="2"
+         id="rect5104-6-0"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="rotate(-90)"
+         ry="0.5"
+         rx="0.5"
+         y="545"
+         x="-352"
+         height="3"
+         width="2"
+         id="rect5104-0-2"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="rotate(-90)"
+         ry="0.5"
+         rx="0.5"
+         y="532"
+         x="-346"
+         height="3"
+         width="2"
+         id="rect5104-8-3"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="rotate(-90)"
+         ry="0.5"
+         rx="0.5"
+         y="532"
+         x="-349"
+         height="3"
+         width="2"
+         id="rect5104-6-7-7"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="rotate(-90)"
+         ry="0.5"
+         rx="0.5"
+         y="532"
+         x="-352"
+         height="3"
+         width="2"
+         id="rect5104-0-9-5"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         id="rect5228"
+         d="M 536 342 C 534.892 342 534 342.892 534 344 L 534 352 C 534 353.108 534.892 354 536 354 L 544 354 C 545.108 354 546 353.108 546 352 L 546 344 C 546 342.892 545.108 342 544 342 L 536 342 z M 536.5 343 L 543.5 343 C 544.331 343 545 343.669 545 344.5 L 545 351.5 C 545 352.331 544.331 353 543.5 353 L 536.5 353 C 535.669 353 535 352.331 535 351.5 L 535 344.5 C 535 343.669 535.669 343 536.5 343 z "
+         style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
+       style="display:inline"
+       id="g8709-9"
+       inkscape:label="camera-app"
+       transform="translate(200,60.000001)">
+      <path
+         id="path8678-2"
+         d="m 415,161 v 1 h 0.99414 c -1.2582,0.0145 -2.17889,-0.0306 -2.93164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 C 412.05994,163.82148 412,164.34239 412,165 v 6 c 0,0.65761 0.0599,1.17853 0.22461,1.61719 0.16467,0.43866 0.46152,0.79039 0.83789,0.99804 0.75275,0.41532 1.67345,0.3702 2.93164,0.38477 h 0.004 8.0039 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37637,-0.20766 0.67322,-0.55938 0.83789,-0.99804 C 427.93988,172.17852 428,171.65761 428,171 v -6 c 0,-0.65761 -0.0599,-1.17852 -0.22461,-1.61719 -0.16466,-0.43866 -0.46152,-0.79038 -0.83789,-0.99804 -0.75275,-0.41534 -1.67344,-0.37025 -2.93164,-0.38477 h -0.004 H 417 v -1 z m 1,2 h 8 c 1.25852,0.0147 2.08717,0.0598 2.45312,0.26172 0.18341,0.1012 0.28916,0.21274 0.38672,0.47266 C 426.93727,163.99429 427,164.40761 427,165 v 6 c 0,0.59239 -0.0626,1.00573 -0.16016,1.26562 -0.0976,0.25991 -0.20331,0.37147 -0.38672,0.47266 C 426.08718,172.94019 425.25852,172.98529 424,173 H 416.00586 416 c -1.25853,-0.0147 -2.08912,-0.0598 -2.45508,-0.26172 -0.18341,-0.10119 -0.2872,-0.21274 -0.38476,-0.47266 C 413.06259,172.00572 413,171.59239 413,171 v -6 c 0,-0.59239 0.0626,-1.00572 0.16016,-1.26562 0.0976,-0.25991 0.20135,-0.37147 0.38476,-0.47266 C 413.91088,163.05981 414.74147,163.01471 416,163 Z m 4,1 a 4,4 0 0 0 -4,4 4,4 0 0 0 4,4 4,4 0 0 0 4,-4 4,4 0 0 0 -4,-4 z m 5.5,0 a 0.5,0.5 0 0 0 -0.5,0.5 0.5,0.5 0 0 0 0.5,0.5 0.5,0.5 0 0 0 0.5,-0.5 0.5,0.5 0 0 0 -0.5,-0.5 z m -5.5,1 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z m -0.084,1.00391 A 2,2 0 0 0 418,168 a 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -1.90039,-1.99414 A 1,1 0 0 1 421,167 a 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 0.91602,-0.99609 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <rect
+         transform="rotate(90)"
+         y="-427.99997"
+         x="159.99994"
+         height="15.999999"
+         width="16"
+         id="rect8680-2"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.66653478;marker:none;enable-background:accumulate" />
+    </g>
+    <g
+       id="g11052"
+       inkscape:label="system-file-manager">
+      <g
+         inkscape:label="system-file-manager"
+         id="g10861">
+        <g
+           id="g8519"
+           inkscape:label="system-file-manager">
+          <g
+             inkscape:label="system-file-manager"
+             id="g5386-3"
+             style="display:inline"
+             transform="translate(-19.99996)">
+            <rect
+               transform="rotate(90)"
+               y="-528"
+               x="160"
+               height="16"
+               width="16"
+               id="rect1903-6"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate" />
+          </g>
+        </g>
+      </g>
+      <path
+         id="path2732-8-1-77-6"
+         d="m 497.99414,161 c -1.2582,0.0145 -2.17889,-0.0306 -2.93164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 C 494.05994,162.82148 494,163.34239 494,164 v 9 c 0,0.65761 0.0599,1.17858 0.22461,1.61719 0.16468,0.43861 0.46153,0.78852 0.83789,0.99609 0.75272,0.41514 1.67354,0.37165 2.93164,0.38672 h 0.002 4.00586 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37638,-0.20766 0.67323,-0.55938 0.83789,-0.99804 C 505.94006,174.17852 506,173.65761 506,173 v -9 c 0,-0.65761 -0.0599,-1.17858 -0.22461,-1.61719 -0.16468,-0.43861 -0.46153,-0.78852 -0.83789,-0.99609 -0.75272,-0.41513 -1.67355,-0.37165 -2.93164,-0.38672 h -0.002 -4.00586 z m 0.006,1 h 4 c 1.25862,0.0152 2.0891,0.0599 2.45508,0.26172 0.18342,0.10116 0.28722,0.21286 0.38476,0.47265 C 504.93739,162.99417 505,163.40761 505,164 v 9 c 0,0.59239 -0.0626,1.00572 -0.16016,1.26562 -0.0976,0.25991 -0.20135,0.37147 -0.38476,0.47266 C 504.08912,174.9402 503.25852,174.98529 502,175 H 498.00586 498 c -1.25863,-0.0152 -2.0891,-0.0599 -2.45508,-0.26172 -0.18342,-0.10116 -0.28722,-0.21285 -0.38476,-0.47266 C 495.06261,174.00582 495,173.59239 495,173 v -9 c 0,-0.59239 0.0626,-1.00572 0.16016,-1.26563 0.0976,-0.2599 0.20135,-0.37146 0.38476,-0.47265 C 495.91088,162.0598 496.74147,162.0147 498,162 Z m -2,1 v 3 h 8 v -3 z m 3,1 h 2 v 1 h -2 z m -3,3 v 3 h 8 v -3 z m 3,1 h 2 v 1 h -2 z m -3,3 v 3 h 8 v -3 z m 3,1 h 2 v 1 h -2 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="translate(100,160)"
+       style="display:inline"
+       id="g11052-1"
+       inkscape:label="filemanager-app">
+      <g
+         inkscape:label="system-file-manager"
+         id="g10861-2">
+        <g
+           id="g8519-9"
+           inkscape:label="system-file-manager">
+          <g
+             inkscape:label="system-file-manager"
+             id="g5386-3-3"
+             style="display:inline"
+             transform="translate(-19.99996)">
+            <rect
+               transform="rotate(90)"
+               y="-528"
+               x="160"
+               height="16"
+               width="16"
+               id="rect1903-6-1"
+               style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate" />
+          </g>
+        </g>
+      </g>
+      <path
+         id="path2732-8-1-77-6-9"
+         d="m 497.99414,161 c -1.2582,0.0145 -2.17889,-0.0306 -2.93164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 C 494.05994,162.82148 494,163.34239 494,164 v 9 c 0,0.65761 0.0599,1.17858 0.22461,1.61719 0.16468,0.43861 0.46153,0.78852 0.83789,0.99609 0.75272,0.41514 1.67354,0.37165 2.93164,0.38672 h 0.002 4.00586 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37638,-0.20766 0.67323,-0.55938 0.83789,-0.99804 C 505.94006,174.17852 506,173.65761 506,173 v -9 c 0,-0.65761 -0.0599,-1.17858 -0.22461,-1.61719 -0.16468,-0.43861 -0.46153,-0.78852 -0.83789,-0.99609 -0.75272,-0.41513 -1.67355,-0.37165 -2.93164,-0.38672 h -0.002 -4.00586 z m 0.006,1 h 4 c 1.25862,0.0152 2.0891,0.0599 2.45508,0.26172 0.18342,0.10116 0.28722,0.21286 0.38476,0.47265 C 504.93739,162.99417 505,163.40761 505,164 v 9 c 0,0.59239 -0.0626,1.00572 -0.16016,1.26562 -0.0976,0.25991 -0.20135,0.37147 -0.38476,0.47266 C 504.08912,174.9402 503.25852,174.98529 502,175 H 498.00586 498 c -1.25863,-0.0152 -2.0891,-0.0599 -2.45508,-0.26172 -0.18342,-0.10116 -0.28722,-0.21285 -0.38476,-0.47266 C 495.06261,174.00582 495,173.59239 495,173 v -9 c 0,-0.59239 0.0626,-1.00572 0.16016,-1.26563 0.0976,-0.2599 0.20135,-0.37146 0.38476,-0.47265 C 495.91088,162.0598 496.74147,162.0147 498,162 Z m -2,1 v 3 h 8 v -3 z m 3,1 h 2 v 1 h -2 z m -3,3 v 3 h 8 v -3 z m 3,1 h 2 v 1 h -2 z m -3,3 v 3 h 8 v -3 z m 3,1 h 2 v 1 h -2 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
   <g


### PR DESCRIPTION
I'm doing this as one PR to avoid clashes.

**File Manager**

The symbol has been updated to use the same design as the new full colour:

![image](https://user-images.githubusercontent.com/38893390/62970150-ba86fa00-be06-11e9-884c-622d9afb4788.png)

**Camera**

I drew a camera symbol for the app, but recently found an existing one in Devices.  The existing one is a nicer design, so I retired mine:

![image](https://user-images.githubusercontent.com/38893390/62970232-eefab600-be06-11e9-90d9-bf395a436a95.png)

**Jockey**

...and we've got a symbol for Jockey:

![image](https://user-images.githubusercontent.com/38893390/62970311-1a7da080-be07-11e9-946c-dbacc3388346.png)
