### PR TITLE
Fixing headerbar

### DIFF
--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -2,6 +2,7 @@
 
 $small_radius: 4px;
 
+// copied from drawing, modified the gradients here to have less diff in drawing
 @mixin yaru_headerbar_fill($c:$headerbar_color, $hc:$top_hilight, $ov: none) {
   //
   // headerbar fill
@@ -24,6 +25,7 @@ $small_radius: 4px;
   border-color: if($c==$suggested_bg_color, $c, darken($c, 7%));
 }
 
+// helper mixin for the yaru titlebuttons
 @mixin draw_circle($c, $size:24px) {
   $button_size: $size + 2px * 2;
   $circle_size: 20px / $button_size / 2;
@@ -62,113 +64,366 @@ $small_radius: 4px;
   }
 }
 
-headerbar {
-  &:not(.selection-mode) &,
-    &:not(.selection-mode)
-   {
-    
-    &, %yaru_titlebar {
-      @include yaru_headerbar_fill($headerbar_bg_color, $hc: $headerbar_border_color);
-      color: $headerbar_fg_color;
+// overwriting the headerbar styling from common, for the inverted look in the light theme
+headerbar,
+.titlebar {
+  @include yaru_headerbar_fill($headerbar_bg_color, $hc: $headerbar_border_color);
+  color: $headerbar_fg_color;
 
-      label .title {
-        color: $headerbar_fg_color;
-      }
+  label .title {
+    color: $headerbar_fg_color;
+  }
 
-      &:backdrop {
-        border-color: mix(darken($inkstone, 11%), darken($inkstone, 1%), 80%);
-        background-color: $backdrop_headerbar_bg_color;
-        box-shadow: inset 0 1px $headerbar_border_color;
-      }
+  &:backdrop {
+    border-color: mix(darken($inkstone, 11%), darken($inkstone, 1%), 80%);
+    background-color: $backdrop_headerbar_bg_color;
+    box-shadow: inset 0 1px $headerbar_border_color;
+  }
 
-      .maximized &,
-      .fullscreen & {
-        box-shadow: none;
+  .maximized &,
+  .fullscreen & {
+    box-shadow: none;
+  }
+
+  button,
+  button.image-button,
+  button.image-button.toggle,
+  button.text-button,
+  button.toggle,
+  box button.toggle,
+  buttonbox.toggle,
+  stackswitcher button,
+  filechooser .path-bar.linked>button,
+  .path-bar button {
+    $_btn_backdrop_border: darken($headerbar_border_color, 3%);
+
+    @include button(normal, lighten($headerbar_bg_color, 4%), $headerbar_fg_color);
+
+    &.flat {
+      @include button(undecorated);
+    }
+
+    &:hover {
+      @include button(hover, lighten($headerbar_bg_color, 8%), $headerbar_fg_color);
+    }
+
+    &:active,
+    &:checked,
+    &.toggle:checked,
+    &.toggle:active {
+      $_bg: lighten($headerbar_bg_color, if($variant==light, 0%, 1%));
+      @include button(active, $_bg, $headerbar_fg_color);
+      border-color: rgb(20, 19, 19);
+      background-image: image(darken($_bg, 9%));
+    }
+
+    &:backdrop {
+
+      &.flat,
+      & {
+        @include button(backdrop, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
+
+        -gtk-icon-effect: none;
+        border-color: $_btn_backdrop_border;
+
+        &:active,
+        &:checked {
+          $_bg: if($variant=='light', darken($backdrop_headerbar_bg_color, 9%), lighten($backdrop_headerbar_bg_color, 2%));
+          @include button(backdrop-active, $_bg, $backdrop_headerbar_fg_color);
+          border-color: $_btn_backdrop_border;
+        }
+
+        &:disabled {
+          @include button(backdrop-insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $backdrop_headerbar_fg_color);
+
+          border-color: $_btn_backdrop_border;
+
+          &:active,
+          &:checked {
+            @include button(backdrop-insensitive-active, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
+
+            border-color: $_btn_backdrop_border;
+          }
+        }
       }
     }
 
-    button:not(.titlebutton):not(.suggested-action):not(.destructive-action), button:not(.selection-menu).toggle {
-      $_btn_backdrop_border: darken($headerbar_border_color, 3%);
+    &:disabled {
+      @include button(insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $headerbar_fg_color);
+      border-color: darken($headerbar_bg_color, 6%);
 
-      @include button(normal, lighten($headerbar_bg_color, 4%), $headerbar_fg_color);
+      &:active,
+      &:checked {
+        @include button(insensitive-active, $headerbar_bg_color, $headerbar_fg_color);
+      }
+    }
 
-      &.flat { @include button(undecorated); }
+    // Suggested and Destructive Action buttons, need to overwrite them again here
+    // copied from common, disabled buttons bg color changed to match the headerbar
+    @each $b_type,
+    $b_color in (suggested-action, $suggested_bg_color),
+    (destructive-action, $destructive_color) {
+      &.#{$b_type} {
+        @include button(normal, $b_color, white);
+
+        &.flat {
+          @include button(undecorated);
+
+          color: $b_color;
+        }
+
+        &:hover {
+          @include button(hover, $b_color, white);
+        }
+
+        &:active,
+        &:checked {
+          @include button(active, $b_color, white);
+        }
+
+        &:backdrop,
+        &.flat:backdrop {
+          @include button(backdrop, $b_color, white);
+
+          &:active,
+          &:checked {
+            @include button(backdrop-active, $b_color, white);
+          }
+
+          &:disabled {
+            @include button(backdrop-insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $backdrop_headerbar_fg_color);
+
+            &:active,
+            &:checked {
+              @include button(backdrop-insensitive-active, $b_color, white);
+            }
+          }
+        }
+
+        &.flat {
+
+          &:backdrop,
+          &:disabled,
+          &:backdrop:disabled {
+            @include button(undecorated);
+
+            color: transparentize($b_color, 0.2);
+          }
+        }
+
+        &:disabled {
+          @include button(insensitive, if($variant== "light", darken($headerbar_bg_color, 15%), $headerbar_bg_color), $headerbar_fg_color);
+
+          &:active,
+          &:checked {
+            @include button(insensitive-active, $b_color, white);
+          }
+        }
+
+        .osd & {
+          @include button(osd, $b_color);
+
+          &:hover {
+            @include button(osd-hover, $b_color);
+          }
+
+          &:active,
+          &:checked {
+
+            &:backdrop,
+            & {
+              @include button(osd-active, $b_color);
+            }
+          }
+
+          &:disabled {
+
+            &:backdrop,
+            & {
+              @include button(osd-insensitive, $b_color);
+            }
+          }
+
+          &:backdrop {
+            @include button(osd-backdrop, $b_color);
+          }
+        }
+      }
+    }
+  }
+
+  separator {
+    background: image(darken(#3d3d3d, 11%));
+  }
+
+  switch:checked {
+    border-color: $suggested_bg_color;
+  }
+
+  // re-insert the full selection mode section from common ...
+  .selection-mode &,
+  &.selection-mode {
+    $_hc: mix($top_hilight, $suggested_bg_color, 50%); // hilight color
+
+    color: $selected_fg_color;
+    border-color: $suggested_border_color;
+
+    @include yaru_headerbar_fill($suggested_bg_color, $_hc);
+
+    separator {
+      background: image(lighten($suggested_bg_color, 5%));
+    }
+
+    &:backdrop {
+      background-color: $suggested_bg_color;
+      background-image: none;
+      box-shadow: inset 0 1px mix($top_hilight, $suggested_bg_color, 60%);
+
+      label {
+        text-shadow: none;
+        color: $selected_fg_color;
+      }
+    }
+
+    .subtitle:link {
+      @extend *:link:selected;
+    }
+
+    button,
+    button.image-button,
+    button.image-button.toggle,
+    button.text.button,
+    button.toggle,
+    box button.toggle,
+    buttonbox.toggle,
+    stackswitcher button,
+    filechooser .path-bar.linked>button,
+    .path-bar button {
+      @include button(normal, $suggested_bg_color, $selected_fg_color);
+
+      &.flat {
+        @include button(undecorated);
+      }
 
       &:hover {
-        @include button(hover, lighten($headerbar_bg_color, 8%), $headerbar_fg_color);
+        @include button(hover, $suggested_bg_color, $selected_fg_color);
       }
 
       &:active,
       &:checked,
       &.toggle:checked,
       &.toggle:active {
-        $_bg: lighten($headerbar_bg_color, if($variant==light, 0%, 1%));
-        @include button(active, $_bg, $headerbar_fg_color);
-        border-color: rgb(20, 19, 19);
-        background-image: image(darken($_bg, 9%));
+        @include button(active, $suggested_bg_color, $selected_fg_color);
       }
 
       &:backdrop {
 
         &.flat,
         & {
-          @include button(backdrop, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
+          @include button(backdrop, $suggested_bg_color, $selected_fg_color);
 
-          border-color: $_btn_backdrop_border;
+          -gtk-icon-effect: none;
+          border-color: lighten($suggested_bg_color, 5%);
 
           &:active,
           &:checked {
-            $_bg: if($variant=='light', darken($backdrop_headerbar_bg_color, 9%), lighten($backdrop_headerbar_bg_color, 2%));
-            @include button(backdrop-active, $_bg, $backdrop_headerbar_fg_color);
-            border-color: $_btn_backdrop_border;
+            @include button(backdrop-active, $suggested_bg_color, $selected_fg_color);
+
+            border-color: $suggested_border_color;
           }
 
           &:disabled {
-            @include button(backdrop-insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $backdrop_headerbar_fg_color);
+            @include button(backdrop-insensitive, $suggested_bg_color, $selected_fg_color);
 
-            border-color: $_btn_backdrop_border;
+            border-color: $suggested_border_color;
 
             &:active,
             &:checked {
-              @include button(backdrop-insensitive-active, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
+              @include button(backdrop-insensitive-active, $suggested_bg_color, $selected_fg_color);
 
-              border-color: $_btn_backdrop_border;
+              border-color: $suggested_border_color;
             }
           }
         }
       }
 
+      &.flat {
+
+        &:backdrop,
+        &:disabled,
+        &:backdrop:disabled {
+          @include button(undecorated);
+        }
+      }
+
       &:disabled {
-        @include button(insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $headerbar_fg_color);
-        border-color: darken($headerbar_bg_color, 6%);
+        @include button(insensitive, $suggested_bg_color, $selected_fg_color);
 
         &:active,
         &:checked {
-          @include button(insensitive-active, $headerbar_bg_color, $headerbar_fg_color);
+          @include button(insensitive-active, $suggested_bg_color, $selected_fg_color);
         }
       }
-    }
 
-    button {
-      &.suggested-action, &.destructive-action {
+      &.suggested-action {
+        @include button(normal);
+
+        border-color: $suggested_border_color;
+
+        &:hover {
+          @include button(hover);
+
+          border-color: $suggested_border_color;
+        }
+
+        &:active {
+          @include button(active);
+
+          border-color: $suggested_border_color;
+        }
+
         &:disabled {
-          @include button(insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $headerbar_fg_color);
-          border-color: darken($headerbar_bg_color, 6%);
+          @include button(insensitive);
+
+          border-color: $suggested_border_color;
+        }
+
+        &:backdrop {
+          @include button(backdrop);
+
+          border-color: $suggested_border_color;
+        }
+
+        &:backdrop:disabled {
+          @include button(backdrop-insensitive);
+
+          border-color: $suggested_border_color;
         }
       }
     }
 
-    switch:checked {
-      border-color: $suggested_bg_color;
-    }    
-  }
-}
+    .selection-menu {
 
-.titlebar {
-  @extend %yaru_titlebar;
+      &:backdrop,
+      & {
+        border-color: transparentize($suggested_bg_color, 1);
+        background-color: transparentize($suggested_bg_color, 1);
+        background-image: none;
+        box-shadow: none;
+        min-height: 20px;
+        padding: $_sel_menu_pad;
 
-  &:not(.selection-mode) separator {
-    background: image(darken($inkstone, 11%));
+        arrow {
+          -GtkArrow-arrow-scaling: 1;
+        }
+
+        .arrow {
+          -gtk-icon-source: -gtk-icontheme('pan-down-symbolic');
+          color: transparentize($selected_fg_color, 0.5);
+          -gtk-icon-shadow: none;
+        }
+      }
+    }
   }
 }
 
@@ -181,8 +436,7 @@ button.titlebutton {
 
     headerbar &,
     .titlebar &,
-    headerbar.selection-mode
-    & {
+    headerbar.selection-mode & {
 
       // spec bump otherwise :backdrop  will still have a bg
       &,
@@ -199,6 +453,7 @@ button.titlebutton {
 
   &:not(.close):not(.appmenu) {
     color: $headerbar_fg_color;
+
     &:hover {
       @include draw_circle($headerbar_bg_color);
     }
@@ -223,44 +478,60 @@ button.titlebutton {
 }
 
 headerbar button.titlebutton.appmenu.popup.toggle {
-  &, &:backdrop { @include button(undecorated); }
-  &:hover { @include button(hover, lighten($headerbar_bg_color, 8%), $headerbar_fg_color); }
+
+  &,
+  &:backdrop {
+    @include button(undecorated);
+  }
+
+  &:hover {
+    @include button(hover, lighten($headerbar_bg_color, 8%), $headerbar_fg_color);
+  }
 }
 
+// with a flatter headerbar and buttons, we dont need that heavy shadows in the headerbar
 headerbar * {
   text-shadow: none;
   -gtk-icon-shadow: none;
 }
-
+// same for the rest of the theme, but not axe the icon shadows, otherwise things don't work
 * {
   text-shadow: none;
 }
 
+// make checks and radios more flat, remove this when upstream flattens their cheks/radios
 check,
 radio {
 
-    &,
-    &:hover,
-    &:active,
-    &:checked, &:disabled {
+  &,
+  &:hover,
+  &:active,
+  &:checked,
+  &:disabled {
 
-        &:not(.selected) {
-            box-shadow: none;
-            background-image: none;
-            -gtk-icon-shadow: none;
-        }
+    &:not(.selected) {
+      box-shadow: none;
+      background-image: none;
+      -gtk-icon-shadow: none;
     }
+  }
 
 
-    &:not(:backdrop):checked:not(.selected) {
-        border-color: $checkradio_bg_color;
-        background-image: image($checkradio_bg_color);
-        color: $checkradio_fg_color;
-    }
-    &:not(:backdrop):disabled:checked { 
-      background-image: image(mix($checkradio_bg_color, $insensitive_bg_color, 50%));
-      border-color: mix($checkradio_bg_color, $insensitive_bg_color, 50%);
-    }
+  &:not(:backdrop):checked:not(.selected) {
+    border-color: $checkradio_bg_color;
+    background-image: image($checkradio_bg_color);
+    color: $checkradio_fg_color;
+  }
+
+  &:not(:backdrop):disabled:checked {
+    background-image: image(mix($checkradio_bg_color, $insensitive_bg_color, 50%));
+    border-color: mix($checkradio_bg_color, $insensitive_bg_color, 50%);
+  }
 }
 
-spinner { &:not(:backdrop) { color: $progress_bg_color; }}
+// blue spinner
+spinner {
+  &:not(:backdrop) {
+    color: $progress_bg_color;
+  }
+}

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -487,6 +487,13 @@ headerbar button.titlebutton.appmenu.popup.toggle {
   &:hover {
     @include button(hover, lighten($headerbar_bg_color, 8%), $headerbar_fg_color);
   }
+
+  &:active, &:checked {
+    $_bg: lighten($headerbar_bg_color, if($variant==light, 0%, 1%));
+    @include button(active, $_bg, $headerbar_fg_color);
+    border-color: rgb(20, 19, 19);
+    background-image: image(darken($_bg, 9%));
+  }
 }
 
 // with a flatter headerbar and buttons, we dont need that heavy shadows in the headerbar


### PR DESCRIPTION
- re-inserting selection mode styling
- insert suggested and destructive action buttons
- add comments for each section
- fix some intendation

@clobrano please test the branch, there is a lot diff, because I needed to re-insert many lines

Things tested:
- normal headerbar 
![image](https://user-images.githubusercontent.com/15329494/63009438-c7e2c980-be84-11e9-822c-7c1ad2436e32.png)

- selection menu in gnome software 
![image](https://user-images.githubusercontent.com/15329494/63009494-e648c500-be84-11e9-872a-3738924ca3c0.png)

- selection mode in gnome contacts
![image](https://user-images.githubusercontent.com/15329494/63009518-f496e100-be84-11e9-8e85-997f0f3411f2.png)

- selection mode in gnome-music / gnome-videos
![image](https://user-images.githubusercontent.com/15329494/63009542-037d9380-be85-11e9-8907-3b49db25fd7f.png)

- suggested action buttons in headerbars:
![image](https://user-images.githubusercontent.com/15329494/63009591-1728fa00-be85-11e9-8d93-2ad25ef1aa3a.png)

![image](https://user-images.githubusercontent.com/15329494/63009608-1f813500-be85-11e9-9a87-5fb497ecfa01.png)

- headerbars that are not .titlebar like Gedit:
![image](https://user-images.githubusercontent.com/15329494/63009657-332c9b80-be85-11e9-98d9-e85ac4b148cc.png)

- appmenu
![image](https://user-images.githubusercontent.com/15329494/63009904-b3530100-be85-11e9-9673-b34330b96e6b.png)
- appmenu hover
![image](https://user-images.githubusercontent.com/15329494/63009919-be0d9600-be85-11e9-9dfe-45749e4a803b.png)
- appmenu active/checked
![image](https://user-images.githubusercontent.com/15329494/63009949-c9f95800-be85-11e9-8d58-e938770350c5.png)
