### PR TITLE
Switches and switches in the headerbar

### DIFF
--- a/gtk/src/light/gtk-3.20/_colors.scss
+++ b/gtk/src/light/gtk-3.20/_colors.scss
@@ -71,7 +71,7 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 
 //special cased widget colors
 $suggested_bg_color: $success_color;
-$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), $suggested_bg_color);
+$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
 $progress_bg_color: $blue;
 $progress_border_color: $progress_bg_color;
 $checkradio_bg_color: $suggested_bg_color;

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2842,7 +2842,7 @@ switch {
 
       @include button(backdrop);
     }
-    // TODO: REMOVE this line diff when we fixed this upstream (upstream has blue suggested border color)
+    // TODO: REMOVE the diff when we fixed this upstream (upstream has blue suggested border color)
     &:checked slider { border-color: if($variant == 'light', $suggested_bg_color, $suggested_border_color); }
 
     &:disabled slider { @include button(backdrop-insensitive); }

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2842,7 +2842,7 @@ switch {
 
       @include button(backdrop);
     }
-    // TODO: REMOVE the diff when we fixed this upstream (upstream has blue suggested border color)
+
     &:checked slider { border-color: if($variant == 'light', $suggested_bg_color, $suggested_border_color); }
 
     &:disabled slider { @include button(backdrop-insensitive); }
@@ -2855,7 +2855,7 @@ switch {
 
       &:backdrop { border-color: $selected_borders_color; }
 
-      slider { &:checked, & { border-color: $suggested_border_color; } }
+      slider { &:checked, & { border-color: $selected_borders_color; } }
     }
   }
 

--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -2842,7 +2842,7 @@ switch {
 
       @include button(backdrop);
     }
-
+    // TODO: REMOVE this line diff when we fixed this upstream (upstream has blue suggested border color)
     &:checked slider { border-color: if($variant == 'light', $suggested_bg_color, $suggested_border_color); }
 
     &:disabled slider { @include button(backdrop-insensitive); }
@@ -2855,7 +2855,7 @@ switch {
 
       &:backdrop { border-color: $selected_borders_color; }
 
-      slider { &:checked, & { border-color: $selected_borders_color; } }
+      slider { &:checked, & { border-color: $suggested_border_color; } }
     }
   }
 

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -1,6 +1,8 @@
 @import 'ubuntu-colors';
 
 $small_radius: 4px;
+$_headerbar_button_bg: lighten($headerbar_bg_color, 4%);
+$_dark_border_color: rgb(20, 19, 19);;
 
 // copied from drawing, modified the gradients here to have less diff in drawing
 @mixin yaru_headerbar_fill($c:$headerbar_color, $hc:$top_hilight, $ov: none) {
@@ -97,7 +99,7 @@ headerbar,
   .path-bar button {
     $_btn_backdrop_border: darken($headerbar_border_color, 3%);
 
-    @include button(normal, lighten($headerbar_bg_color, 4%), $headerbar_fg_color);
+    @include button(normal, $_headerbar_button_bg, $headerbar_fg_color);
 
     &.flat {
       @include button(undecorated);
@@ -256,8 +258,40 @@ headerbar,
     background: image(darken(#3d3d3d, 11%));
   }
 
-  switch:checked {
-    border-color: $suggested_bg_color;
+  @if $variant=='light' {
+    switch {
+      border-color: $_dark_border_color;
+      color: $headerbar_fg_color;
+      background-color: $_headerbar_button_bg;
+      &:hover { background-color: lighten($_headerbar_button_bg, 2%); }
+      &:backdrop {
+        background-color: lighten($headerbar_bg_color,1%);
+        box-shadow: none;
+      }
+      &:disabled {
+        background-color: $headerbar_bg_color;
+        border-color: $_dark_border_color;
+      }
+  
+      &:checked {
+        color: $selected_fg_color;
+        border-color: $suggested_bg_color;
+        background-color: $suggested_bg_color;
+      }
+  
+      slider {
+        border-color: $_dark_border_color;
+        
+        &:checked {
+          border-color: $suggested_border_color;
+        }
+        &:disabled {
+          background-color: $headerbar_bg_color;
+          border-color: $_dark_border_color;
+          @include button(insensitive, $headerbar_bg_color);
+        }
+      }      
+    }
   }
 
   // re-insert the full selection mode section from common ...
@@ -491,7 +525,7 @@ headerbar button.titlebutton.appmenu.popup.toggle {
   &:active, &:checked {
     $_bg: lighten($headerbar_bg_color, if($variant==light, 0%, 1%));
     @include button(active, $_bg, $headerbar_fg_color);
-    border-color: rgb(20, 19, 19);
+    border-color: $_dark_border_color;
     background-image: image(darken($_bg, 9%));
   }
 }

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -275,7 +275,7 @@ headerbar,
   
       &:checked {
         color: $selected_fg_color;
-        border-color: $suggested_bg_color;
+        border-color: transparentize($suggested_bg_color, 0.6);
         background-color: $suggested_bg_color;
       }
   

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -576,3 +576,17 @@ spinner {
     color: $progress_bg_color;
   }
 }
+
+// TODO: REMOVE the diff when we fixed this upstream (upstream has blue suggested border color)
+switch {
+  row:selected:not(:disabled) & {
+    @if $variant == 'light' {
+      box-shadow: none;
+      border-color: $selected_borders_color;
+
+      &:backdrop { border-color: $selected_borders_color; }
+
+      slider { &:checked { border-color: $suggested_border_color; } }
+    }
+  }
+}


### PR DESCRIPTION
- use a darker switch border for the dark theme (exactly like upstream)
![grafik](https://user-images.githubusercontent.com/15329494/63165088-a3c0ed00-c02a-11e9-8e40-4a4bf553adce.png)
- use a local var for headerbar buttons
- adjust the headerbar switches in the light theme to the dark headerbar
![grafik](https://user-images.githubusercontent.com/15329494/63165107-b2a79f80-c02a-11e9-8236-3915827cbfcd.png)

- Fix selected row slider border this needs to be done upstream for the next cycle, fixing this for EON downstream