### PR TITLE
Minor changes to focus borders

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -84,6 +84,7 @@ stage {
 
 /* Entries */
 StEntry {
+  min-height: 22px;
   border-radius: $button_radius;
   padding: 4px;
   border-width: 1px;

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -771,7 +771,7 @@ StScrollBar {
   background-color: darken($bg_color, 2%);
   border-color: $_bubble_borders_color;
   box-shadow: none;
-  &:focus { border: 1px solid $selected_bg_color; }
+  &:focus { border: 2px solid $selected_bg_color; }
 }
 
 %bubble-panel {

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -944,7 +944,7 @@ StScrollBar {
     .world-clocks-button,
     .weather-button,
     .events-section-title {
-      &:hover, focus { background-color: $_hover_bg_color }
+      &:hover, &:focus { background-color: $_hover_bg_color }
       &:active { background-color: $_active_bg_color }
     }
 
@@ -1015,7 +1015,7 @@ StScrollBar {
       background-color: transparent;
       width: 32px;
       border-radius: 4px;
-      &:hover, focus { background-color: $_hover_bg_color; }
+      &:hover, &:focus { background-color: $_hover_bg_color; }
       &:active { background-color: transparentize($fg_color, 0.84); }
     }
 
@@ -1031,7 +1031,7 @@ StScrollBar {
       margin: 2px;
       border-radius: 1.4em;
       font-feature-settings: "tnum";
-      &:hover, focus { background-color: $_hover_bg_color; }
+      &:hover, &:focus { background-color: $_hover_bg_color; }
       &:active,&:selected {
         color: lighten($selected_fg_color,5%);
         background-color: $selected_bg_color;

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1364,7 +1364,8 @@ StScrollBar {
     background-color: $base_color;
     border-color: $borders_color;
     &:focus {
-      border-width: 1px;
+      padding: 6px 8px;
+      border-width: 2px;
       border-color: $selected_bg_color;
     }
 

--- a/gtk/src/light/gtk-3.20/_drawing.scss
+++ b/gtk/src/light/gtk-3.20/_drawing.scss
@@ -53,7 +53,7 @@
     // for the transition to work the number of shadows in different states needs to match, hence the transparent shadow here.
   }
   @if $t==focus {
-    @if $variant=='dark' { @include _shadows(entry_focus_shadow($fc), $_entry_edge); }
+    @include _shadows(entry_focus_shadow($fc), $_entry_edge);
     border-color: entry_focus_border($fc);
   }
   @if $t==insensitive {


### PR DESCRIPTION
- less diff in gtk and shell
- fixes a bug gnome-contacts focus border bottom for 1px borders

- also fixed jumping in GDM entry, reported this back to upstream
- and two typo fixes from gnome shell master