### PR TITLE
Fix slider fine-tune

### DIFF
--- a/gtk/src/light/gtk-3.20/_common.scss
+++ b/gtk/src/light/gtk-3.20/_common.scss
@@ -3360,15 +3360,15 @@ scale {
             margin: -7px;
 
             @if $dir_class == 'horizontal' {
-              @if $marks_infix == 'scale-has-marks-above' { margin-top: -11px; }
+              @if $marks_infix == 'scale-has-marks-above' { margin-top: -5px; }
 
-              @else { margin-bottom: -11px; }
+              @else { margin-bottom: -5px; }
             }
 
             @else {
-              @if $marks_infix == 'scale-has-marks-above' { margin-left: -11px; }
+              @if $marks_infix == 'scale-has-marks-above' { margin-left: -5px; }
 
-              @else { margin-right: -11px; }
+              @else { margin-right: -5px; }
             }
           }
         }


### PR DESCRIPTION
Fine-tune feature currently is not working properly. Instead of making
the slider thicker, it actually changes only the space around causing the
window to shrink.

![eoan-fine-tune-bug](https://user-images.githubusercontent.com/2883614/63687376-b5fa1280-c804-11e9-8579-afbe8dd075bc.gif)
(peek doesn't seem to show the cursor, but it is over the slider handle)

The fix consists in changing the margin-(top/bottom/left/right) according
to the position of the marks (above/below/etc.).

![eoan-fine-tune-fix](https://user-images.githubusercontent.com/2883614/63687547-315bc400-c805-11e9-8ee4-ece0e75cad1c.gif)

Note: tested only on slider with marks below for the lack of apps with
the other kind of sliders.