### PR TITLE
FIx asset paths and blue shift keys

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1067,7 +1067,7 @@ StScrollBar {
       .calendar-day-with-events {
         color: lighten($fg_color,10%);
         font-weight: bold;
-        background-image: url("resource:///org/gnome/shell/theme/calendar-today.svg");
+        background-image: url("calendar-today.svg");
       }
       .calendar-other-month-day {
         color: transparentize($fg_color ,0.5);
@@ -1421,7 +1421,7 @@ StScrollBar {
     }
 
     .placeholder {
-      background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+      background-image: url("dash-placeholder.svg");
       background-size: contain;
       height: 24px;
     }
@@ -1606,7 +1606,7 @@ StScrollBar {
     &:rtl { border-radius: 0 9px 9px 0;}
 
     .placeholder {
-      background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
+      background-image: url("dash-placeholder.svg");
       background-size: contain;
       height: 24px;
     }
@@ -1823,24 +1823,24 @@ StScrollBar {
     &.enter-key {
       border-color: lighten($selected_bg_color, 5%);
       background-color: $selected_bg_color;
-      background-image: url("resource:///org/gnome/shell/theme/key-enter.svg");
+      background-image: url("key-enter.svg");
       &:hover, &:checked { background-color: lighten($selected_bg_color, 3%); }
       &:active { background-color: darken($selected_bg_color, 2%); }
     }
     &.shift-key-lowercase {
-      background-image: url("resource:///org/gnome/shell/theme/key-shift.svg");
+      background-image: url("key-shift.svg");
     }
     &.shift-key-uppercase {
-      background-image: url("resource:///org/gnome/shell/theme/key-shift-uppercase.svg");
+      background-image: url("key-shift-uppercase.svg");
     }
     &.shift-key-uppercase:latched {
-      background-image: url("resource:///org/gnome/shell/theme/key-shift-latched-uppercase.svg");
+      background-image: url("key-shift-latched-uppercase.svg");
     }
     &.hide-key {
-      background-image: url("resource:///org/gnome/shell/theme/key-hide.svg");
+      background-image: url("key-hide.svg");
     }
     &.layout-key {
-      background-image: url("resource:///org/gnome/shell/theme/key-layout.svg");
+      background-image: url("key-layout.svg");
     }
   }
 
@@ -2138,7 +2138,7 @@ $_screenshield_shadow: 0px 0px 6px rgba(0, 0, 0, 0.726);
 }
 
 #lockDialogGroup {
-  background: darken($purple, 10%) url(resource:///org/gnome/shell/theme/noise-texture.png);
+  background: darken($purple, 10%) url(noise-texture.png);
   background-repeat: repeat;
 }
 

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1821,11 +1821,11 @@ StScrollBar {
       &:active { background-color: darken($_default_key_bg, 2%); }
     }
     &.enter-key {
-      border-color: lighten($selected_bg_color, 5%);
-      background-color: $selected_bg_color;
+      border-color: lighten($success_color, 5%);
+      background-color: $success_color;
       background-image: url("key-enter.svg");
-      &:hover, &:checked { background-color: lighten($selected_bg_color, 3%); }
-      &:active { background-color: darken($selected_bg_color, 2%); }
+      &:hover, &:checked { background-color: lighten($success_color, 3%); }
+      &:active { background-color: darken($success_color, 2%); }
     }
     &.shift-key-lowercase {
       background-image: url("key-shift.svg");

--- a/gnome-shell/src/key-enter.svg
+++ b/gnome-shell/src/key-enter.svg
@@ -14,7 +14,7 @@
    id="svg7384"
    height="32"
    sodipodi:docname="key-enter.svg"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -29,9 +29,9 @@
      id="namedview19"
      showgrid="false"
      inkscape:zoom="14.75"
-     inkscape:cx="7.9322034"
+     inkscape:cx="-4.2033898"
      inkscape:cy="14.554666"
-     inkscape:window-x="0"
+     inkscape:window-x="70"
      inkscape:window-y="55"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg7384" />
@@ -62,47 +62,45 @@
     </linearGradient>
   </defs>
   <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="layer9" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="layer10" />
-  <g
-     transform="translate(-141.0002,-791)"
-     id="layer11" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="layer13" />
-  <g
-     transform="translate(-141.0002,-791)"
-     id="layer14" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="layer15" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="g71291" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="g4953" />
-  <g
-     transform="matrix(2,0,0,2,-281.56285,-1615.0002)"
-     style="display:inline"
-     id="layer12">
+     id="g840">
+    <g
+       id="layer9"
+       style="display:inline"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="layer10"
+       style="display:inline"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="layer11"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="layer13"
+       style="display:inline"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="layer14"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="layer15"
+       style="display:inline"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="g71291"
+       style="display:inline"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="g4953"
+       style="display:inline"
+       transform="translate(-141.0002,-791)" />
     <path
        id="path16589"
-       d="m 148.00015,821.0002 h -1 c -0.26528,0 -0.53057,-0.093 -0.71875,-0.2812 l -3.71875,-3.7188 c 0,0 2.47917,-2.4792 3.71875,-3.7187 0.18817,-0.1882 0.45344,-0.2813 0.71875,-0.2813 h 1 v 1 c 0,0.2653 -0.0931,0.5306 -0.28125,0.7188 l -2.28125,2.2812 2.28125,2.2813 c 0.18811,0.1881 0.28129,0.4534 0.28125,0.7187 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:'Bitstream Vera Sans';-inkscape-font-specification:'Bitstream Vera Sans';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+       d="m 14.43745,27.0002 h -2 c -0.53056,0 -1.06114,-0.186 -1.4375,-0.5624 l -7.4375,-7.4376 c 0,0 4.95834,-4.9584 7.4375,-7.4374 0.37634,-0.3764 0.90688,-0.5626 1.4375,-0.5626 h 2 v 2 c 0,0.5306 -0.1862,1.0612 -0.5625,1.4376 l -4.5625,4.5624 4.5625,4.5626 c 0.37622,0.3762 0.56258,0.9068 0.5625,1.4374 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:'Bitstream Vera Sans';-inkscape-font-specification:'Bitstream Vera Sans';text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4;marker:none;enable-background:accumulate"
        inkscape:connector-curvature="0" />
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#bebebe;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       d="m 154.0002,810 v 4.5 c 0,1.3807 -1.11929,2.5 -2.5,2.5 h -6.50005"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 26.43755,4.9998 v 9 c 0,2.7614 -2.23858,5 -5,5 H 8.43745"
        id="path16591"
        inkscape:connector-curvature="0" />
   </g>

--- a/gnome-shell/src/key-shift-latched-uppercase.svg
+++ b/gnome-shell/src/key-shift-latched-uppercase.svg
@@ -8,13 +8,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="32"
-   viewBox="0 0 32 32"
+   width="26"
+   viewBox="0 0 26 26"
    version="1.1"
    id="svg7384"
-   height="32"
+   height="26"
    sodipodi:docname="key-shift-latched-uppercase.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,14 +24,14 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1791"
-     inkscape:window-height="908"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
      id="namedview19"
      showgrid="false"
      inkscape:zoom="14.75"
-     inkscape:cx="6.1694918"
-     inkscape:cy="18.033899"
-     inkscape:window-x="78"
+     inkscape:cx="0.881356"
+     inkscape:cy="10.711865"
+     inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg7384" />
@@ -62,48 +62,127 @@
     </linearGradient>
   </defs>
   <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="layer9" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="layer10" />
-  <g
-     transform="translate(-141.0002,-791)"
-     id="layer11" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="layer13" />
-  <g
-     transform="translate(-141.0002,-791)"
-     id="layer14" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="layer15" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="g71291" />
-  <g
-     transform="translate(-141.0002,-791)"
-     style="display:inline"
-     id="g4953" />
-  <g
-     transform="matrix(2,0,0,2,-282.0004,-1614.2187)"
-     style="display:inline;fill:#19b6ee;fill-opacity:1"
-     id="layer12">
-    <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#19b6ee;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
-       d="m 147,818 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
-       id="path16532"
-       inkscape:connector-curvature="0" />
-    <path
-       id="path16534"
-       d="m 147,822 v -2 h 3.9377 v 2 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#19b6ee;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
-       inkscape:connector-curvature="0" />
+     id="g920"
+     transform="translate(-3,-0.93985)">
+    <g
+       id="layer9"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="layer10"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="translate(-141.0002,-791)" />
+    <g
+       style="fill:#00a2e4;fill-opacity:1"
+       id="layer11"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="layer13"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="translate(-141.0002,-791)" />
+    <g
+       style="fill:#00a2e4;fill-opacity:1"
+       id="layer14"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="layer15"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="g71291"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="translate(-141.0002,-791)" />
+    <g
+       id="g4953"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="translate(-141.0002,-791)" />
+    <g
+       transform="translate(0,-4.7813)"
+       id="g871">
+      <g
+         transform="translate(-141.0002,-791)"
+         style="display:inline"
+         id="layer9-56" />
+      <g
+         transform="translate(-141.0002,-791)"
+         style="display:inline"
+         id="layer10-2" />
+      <g
+         transform="translate(-141.0002,-791)"
+         id="layer11-9" />
+      <g
+         transform="translate(-141.0002,-791)"
+         style="display:inline"
+         id="layer13-1" />
+      <g
+         transform="translate(-141.0002,-791)"
+         id="layer14-2" />
+      <g
+         transform="translate(-141.0002,-791)"
+         style="display:inline"
+         id="layer15-7" />
+      <g
+         transform="translate(-141.0002,-791)"
+         style="display:inline"
+         id="g71291-0" />
+      <g
+         transform="translate(-141.0002,-791)"
+         style="display:inline"
+         id="g4953-9" />
+      <g
+         id="g1410"
+         transform="translate(3,3)"
+         style="fill:#00a2e4;fill-opacity:1">
+        <g
+           id="layer9-5"
+           style="display:inline;fill:#00a2e4;fill-opacity:1"
+           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+        <g
+           id="layer10-6"
+           style="display:inline;fill:#00a2e4;fill-opacity:1"
+           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+        <g
+           style="fill:#00a2e4;fill-opacity:1"
+           id="layer11-2"
+           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+        <g
+           id="layer13-9"
+           style="display:inline;fill:#00a2e4;fill-opacity:1"
+           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+        <g
+           style="fill:#00a2e4;fill-opacity:1"
+           id="layer14-1"
+           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+        <g
+           id="layer15-2"
+           style="display:inline;fill:#00a2e4;fill-opacity:1"
+           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+        <g
+           id="g71291-7"
+           style="display:inline;fill:#00a2e4;fill-opacity:1"
+           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+        <g
+           id="g4953-0"
+           style="display:inline;fill:#00a2e4;fill-opacity:1"
+           transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+        <path
+           sodipodi:nodetypes="cccccccc"
+           style="opacity:1;fill:#00a2e4;fill-opacity:1;stroke-width:1.99999988"
+           inkscape:connector-curvature="0"
+           id="path4"
+           d="m 13,4 c 0,0 2,2.0000001 9,12 H 18.000001 L 18,22 H 8 l 3e-7,-6 H 4 C 11,6.0000002 13,4 13,4 Z" />
+      </g>
+    </g>
+    <g
+       id="layer12-3"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="matrix(2,0,0,2,-281.9377,-1618.339)">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00a2e4;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
+         d="m 146.46885,822 v -2 h 5 v 2 z"
+         id="path16534-6" />
+    </g>
   </g>
 </svg>

--- a/gnome-shell/src/key-shift-latched-uppercase.svg
+++ b/gnome-shell/src/key-shift-latched-uppercase.svg
@@ -29,8 +29,8 @@
      id="namedview19"
      showgrid="false"
      inkscape:zoom="14.75"
-     inkscape:cx="-12.813559"
-     inkscape:cy="18.847458"
+     inkscape:cx="6.1694918"
+     inkscape:cy="18.033899"
      inkscape:window-x="78"
      inkscape:window-y="27"
      inkscape:window-maximized="0"
@@ -93,17 +93,17 @@
      id="g4953" />
   <g
      transform="matrix(2,0,0,2,-282.0004,-1614.2187)"
-     style="display:inline;fill:#3eb34f;fill-opacity:0.94117647"
+     style="display:inline;fill:#19b6ee;fill-opacity:1"
      id="layer12">
     <path
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3eb34f;fill-opacity:0.94117647;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#19b6ee;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
        d="m 147,818 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
        id="path16532"
        inkscape:connector-curvature="0" />
     <path
        id="path16534"
        d="m 147,822 v -2 h 3.9377 v 2 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3eb34f;fill-opacity:0.94117647;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#19b6ee;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
        inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/gnome-shell/src/key-shift-uppercase.svg
+++ b/gnome-shell/src/key-shift-uppercase.svg
@@ -8,13 +8,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="32"
-   viewBox="0 0 32 32"
+   width="26"
+   viewBox="0 0 26 26"
    version="1.1"
    id="svg7384"
-   height="32"
+   height="26"
    sodipodi:docname="key-shift-uppercase.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,17 +24,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1850"
-     inkscape:window-height="908"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
      id="namedview18"
      showgrid="false"
      inkscape:zoom="14.75"
-     inkscape:cx="-16.832158"
-     inkscape:cy="7.4237289"
-     inkscape:window-x="70"
+     inkscape:cx="-4.677966"
+     inkscape:cy="13.423729"
+     inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg7384" />
+     inkscape:current-layer="svg7384"
+     inkscape:pagecheckerboard="true" />
   <metadata
      id="metadata90">
     <rdf:RDF>
@@ -62,43 +63,75 @@
     </linearGradient>
   </defs>
   <g
-     transform="translate(-141.0002,-791)"
+     transform="translate(-141.0002,-797)"
      style="display:inline"
      id="layer9" />
   <g
-     transform="translate(-141.0002,-791)"
+     transform="translate(-141.0002,-797)"
      style="display:inline"
      id="layer10" />
   <g
-     transform="translate(-141.0002,-791)"
+     transform="translate(-141.0002,-797)"
      id="layer11" />
   <g
-     transform="translate(-141.0002,-791)"
+     transform="translate(-141.0002,-797)"
      style="display:inline"
      id="layer13" />
   <g
-     transform="translate(-141.0002,-791)"
+     transform="translate(-141.0002,-797)"
      id="layer14" />
   <g
-     transform="translate(-141.0002,-791)"
+     transform="translate(-141.0002,-797)"
      style="display:inline"
      id="layer15" />
   <g
-     transform="translate(-141.0002,-791)"
+     transform="translate(-141.0002,-797)"
      style="display:inline"
      id="g71291" />
   <g
-     transform="translate(-141.0002,-791)"
+     transform="translate(-141.0002,-797)"
      style="display:inline"
      id="g4953" />
   <g
-     transform="matrix(2,0,0,2,-282.0008,-1614.2187)"
-     style="display:inline;fill:#19b6ee;fill-opacity:1"
-     id="layer12">
+     id="g1410"
+     style="fill:#00a2e4;fill-opacity:1">
+    <g
+       id="layer9-5"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+    <g
+       id="layer10-6"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+    <g
+       style="fill:#00a2e4;fill-opacity:1"
+       id="layer11-2"
+       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+    <g
+       id="layer13-9"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+    <g
+       style="fill:#00a2e4;fill-opacity:1"
+       id="layer14-1"
+       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+    <g
+       id="layer15-2"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+    <g
+       id="g71291-7"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
+    <g
+       id="g4953-0"
+       style="display:inline;fill:#00a2e4;fill-opacity:1"
+       transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)" />
     <path
-       id="path16548"
-       d="m 147.0002,820 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#19b6ee;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
-       inkscape:connector-curvature="0" />
+       sodipodi:nodetypes="cccccccc"
+       style="opacity:1;fill:#00a2e4;fill-opacity:1;stroke-width:1.99999988"
+       inkscape:connector-curvature="0"
+       id="path4"
+       d="m 13,4 c 0,0 2,2.0000001 9,12 h -3.999999 v 6 C 8.0000003,22 16.562803,22 8.0000003,22 V 16 H 4 C 11,6.0000002 13,4 13,4 Z" />
   </g>
 </svg>

--- a/gnome-shell/src/key-shift-uppercase.svg
+++ b/gnome-shell/src/key-shift-uppercase.svg
@@ -24,14 +24,14 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1842"
+     inkscape:window-width="1850"
      inkscape:window-height="908"
      id="namedview18"
      showgrid="false"
      inkscape:zoom="14.75"
-     inkscape:cx="-4.8321584"
-     inkscape:cy="7.7288136"
-     inkscape:window-x="78"
+     inkscape:cx="-16.832158"
+     inkscape:cy="7.4237289"
+     inkscape:window-x="70"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg7384" />
@@ -93,12 +93,12 @@
      id="g4953" />
   <g
      transform="matrix(2,0,0,2,-282.0008,-1614.2187)"
-     style="display:inline;fill:#3eb34f;fill-opacity:0.94117647"
+     style="display:inline;fill:#19b6ee;fill-opacity:1"
      id="layer12">
     <path
        id="path16548"
        d="m 147.0002,820 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3eb34f;fill-opacity:0.94117647;stroke:none;stroke-width:2;marker:none;enable-background:new"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#19b6ee;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
        inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/gnome-shell/src/key-shift.svg
+++ b/gnome-shell/src/key-shift.svg
@@ -8,13 +8,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="32"
-   viewBox="0 0 32 32"
+   width="26"
+   viewBox="0 0 26 26"
    version="1.1"
    id="svg7384"
-   height="32"
+   height="26"
    sodipodi:docname="key-shift.svg"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,8 +24,8 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1400"
-     inkscape:window-height="1034"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
      id="namedview4569"
      showgrid="false"
      fit-margin-top="0"
@@ -33,12 +33,13 @@
      fit-margin-right="0"
      fit-margin-bottom="0"
      inkscape:zoom="14.75"
-     inkscape:cx="1.5993763"
-     inkscape:cy="5"
+     inkscape:cx="3.1925966"
+     inkscape:cy="13.135593"
      inkscape:window-x="0"
-     inkscape:window-y="55"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg7384" />
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384"
+     inkscape:pagecheckerboard="true" />
   <metadata
      id="metadata90">
     <rdf:RDF>
@@ -66,43 +67,41 @@
     </linearGradient>
   </defs>
   <g
-     transform="translate(-143.8754,-788)"
-     style="display:inline"
+     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
+     style="display:inline;fill:#f7f7f7;fill-opacity:1"
      id="layer9" />
   <g
-     transform="translate(-143.8754,-788)"
-     style="display:inline"
+     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
+     style="display:inline;fill:#f7f7f7;fill-opacity:1"
      id="layer10" />
   <g
-     transform="translate(-143.8754,-788)"
-     id="layer11" />
+     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
+     id="layer11"
+     style="fill:#f7f7f7;fill-opacity:1" />
   <g
-     transform="translate(-143.8754,-788)"
-     style="display:inline"
+     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
+     style="display:inline;fill:#f7f7f7;fill-opacity:1"
      id="layer13" />
   <g
-     transform="translate(-143.8754,-788)"
-     id="layer14" />
+     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
+     id="layer14"
+     style="fill:#f7f7f7;fill-opacity:1" />
   <g
-     transform="translate(-143.8754,-788)"
-     style="display:inline"
+     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
+     style="display:inline;fill:#f7f7f7;fill-opacity:1"
      id="layer15" />
   <g
-     transform="translate(-143.8754,-788)"
-     style="display:inline"
+     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
+     style="display:inline;fill:#f7f7f7;fill-opacity:1"
      id="g71291" />
   <g
-     transform="translate(-143.8754,-788)"
-     style="display:inline"
+     transform="matrix(0.87804878,0,0,0.87804878,-125.99425,-694.33537)"
+     style="display:inline;fill:#f7f7f7;fill-opacity:1"
      id="g4953" />
-  <g
-     transform="matrix(2,0,0,2,-282.0008,-1614.2187)"
-     style="display:inline"
-     id="layer12">
-    <path
-       id="path16548"
-       d="m 147.0002,820 v -4 h -3.1248 l 5.125,-5.7813 5.125,5.7813 h -3.1875 v 4 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:new"
-       inkscape:connector-curvature="0" />
-  </g>
+  <path
+     d="m 13,4 c 0,0 2,2.0000001 9,12 h -3.999999 v 6 C 8.0000003,22 16.562803,22 8.0000003,22 V 16 H 4 C 11,6.0000002 13,4 13,4 Z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     style="opacity:1;fill:#ffffff;stroke-width:1.99999988"
+     sodipodi:nodetypes="cccccccc" />
 </svg>


### PR DESCRIPTION
- until now some assets where not taken from the yaru paths but from the upstream shell theme
- using links to the build assets fixes this
- needs eventually a correct absolute path to the yaru resource in the future
- using blue for the shift keys
- using green for enter key
- adds white enter key asset
![grafik](https://user-images.githubusercontent.com/15329494/64233220-e5d7a300-cef3-11e9-8e98-a6e27b73204d.png)



Closes https://github.com/ubuntu/yaru/issues/1475

@3v1n0 @didrocks please review this paths - are the assets still converted into gresources like this? And if not, is this a problem?
Why did I change the paths? Because previously our asset **were not loaded at all** but some fallback to the upstream gnome theme happened
Thus this PR was needed to load out checkboxes:
https://github.com/ubuntu/yaru/pull/1472

@ubuntujaggers @madsrh @clobrano please see if you like this colours