### PR TITLE
Hover/Active color changes

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -32,8 +32,8 @@ $panel-corner-radius: 0;
 
 $_trough_color: transparentize($fg_color, 0.9);
 $_bubble_borders_color: lighten($borders_color, if($variant=='light', 0%, 5%));
-$_hover_bg_color: lighten($bg_color,if($variant=='light', 5%, 3%));
-$_active_bg_color: if($variant == 'light', darken($bg_color, 14%), darken($bg_color, 9%));
+$_hover_bg_color: transparentize($fg_color, 0.85);
+$_active_bg_color: transparentize($fg_color, 0.80);
 
 $font-size: 11;
 $font-family: Ubuntu, Cantarell, Sans-Serif;
@@ -566,12 +566,12 @@ StScrollBar {
       font-weight: bold;
     }
     &.selected {
-      background-color: transparentize(white, if($variant=='light', 0.2, 0.9));
+      background-color: $_hover_bg_color;
       color: $fg_color;
     }
     &:active { 
-      background-color: $selected_bg_color;
-      color: $selected_fg_color;
+      background-color: $_active_bg_color;
+      color: $fg_color;
      }
     &:insensitive { color: transparentize($fg_color,.5); }
   }
@@ -1212,8 +1212,8 @@ StScrollBar {
       padding: 14px;
     }
     &:active { 
-      background-color: $selected_bg_color;
-      color: $selected_fg_color;
+      background-color: $_active_bg_color;
+      color: $fg_color;
     }
 
     & > StIcon { icon-size: 16px; }

--- a/gtk/src/light/gtk-3.20/_colors.scss
+++ b/gtk/src/light/gtk-3.20/_colors.scss
@@ -20,8 +20,8 @@ $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
 $menu_color: if($variant == 'light', $base_color, mix($bg_color, $base_color, 20%));
-$popover_bg_color: $bg_color;
-$popover_hover_color: lighten($bg_color, 5%);
+$popover_bg_color: lighten($bg_color, if($variant == 'light', 1%, 0%));
+$popover_hover_color: transparentize($fg_color, 0.85);
 
 $scrollbar_bg_color: if($variant == 'light', mix($bg_color, $fg_color, 80%), mix($base_color, $bg_color, 50%));
 $scrollbar_slider_color: mix($fg_color, $bg_color, 60%);

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -590,3 +590,16 @@ switch {
     }
   }
 }
+
+// we prefered our gray hover for menus and popovers, orange is a very strong color
+menu,
+.menu,
+.context-menu {
+  menuitem {
+
+    &:hover {
+      color: $fg_color;
+      background-color: $popover_hover_color;
+    }
+  }
+}


### PR DESCRIPTION
- use hover/active colors from bionic for the shell's popups and the gtk themes's menus and popovers (not for buttons)
- lighten up popover bg by 1%

![grafik](https://user-images.githubusercontent.com/15329494/64485815-6284bd00-d225-11e9-92bf-57d38e6aea5a.png)

![grafik](https://user-images.githubusercontent.com/15329494/64485819-6d3f5200-d225-11e9-8c56-f36c1111db59.png)

![grafik](https://user-images.githubusercontent.com/15329494/64485831-8c3de400-d225-11e9-8c53-5e6e8fb5c166.png)

![grafik](https://user-images.githubusercontent.com/15329494/64485842-965fe280-d225-11e9-9dc6-e496736ce283.png)
