### PR TITLE
Adding white dot symbolic for media-record

### DIFF
--- a/icons/Suru/scalable/actions/media-record-symbolic.svg
+++ b/icons/Suru/scalable/actions/media-record-symbolic.svg
@@ -1,3 +1,36 @@
-<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg">
-    <path class="error" d="M8 1a7 7 0 0 0-7 7 7 7 0 0 0 7 7 7 7 0 0 0 7-7 7 7 0 0 0-7-7zm0 1a6 6 0 0 1 6 6 6 6 0 0 1-6 6 6 6 0 0 1-6-6 6 6 0 0 1 6-6zm0 1a5 5 0 0 0-5 5 5 5 0 0 0 5 5 5 5 0 0 0 5-5 5 5 0 0 0-5-5z" fill="#da1636"/>
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.000032' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-333.00025,127)'/>
+  <g id='layer2' style='display:inline' transform='translate(-92.000046,-240)'/>
+  <g id='layer4' style='display:inline' transform='translate(-92.000046,-240)'/>
+  <g id='g1812' style='display:inline' transform='translate(-92.000046,-240)'/>
+  <g id='g6217' style='display:inline' transform='translate(-92.000046,-240)'/>
+  <g id='layer3' style='display:inline' transform='translate(-92.000046,-240)'/>
+  <g id='g1833' style='display:inline' transform='translate(-92.000046,-240)'/>
+  <g id='layer1' style='display:inline' transform='translate(-92.000046,-240)'>
+    
+    
+    <path d='m 100,242 c -3.313708,0 -6,2.68629 -6,6 0,3.31371 2.686292,6 6,6 3.31371,0 6,-2.68629 6,-6 0,-3.31371 -2.68629,-6 -6,-6 z' id='path7742-3' style='display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1'/>
+  </g>
 </svg>

--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -32,13 +32,13 @@
      inkscape:window-height="704"
      id="namedview88"
      showgrid="true"
-     inkscape:zoom="4"
-     inkscape:cx="554.54468"
-     inkscape:cy="289.79217"
+     inkscape:zoom="4.0000001"
+     inkscape:cx="105.7762"
+     inkscape:cy="303.44589"
      inkscape:window-x="70"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g1833"
+     inkscape:current-layer="layer1"
      showborder="true"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
@@ -6711,35 +6711,6 @@
            inkscape:connector-curvature="0" />
       </g>
     </g>
-    <g
-       id="layer9-5"
-       label="status"
-       style="display:inline"
-       transform="translate(-141.0002,347)" />
-    <g
-       id="layer2-6"
-       style="display:inline"
-       transform="translate(100,-20)" />
-    <g
-       id="layer4-2"
-       style="display:inline"
-       transform="translate(100,-20)" />
-    <g
-       id="g1812-9"
-       style="display:inline"
-       transform="translate(100,-20)" />
-    <g
-       id="g6217-1"
-       style="display:inline"
-       transform="translate(100,-20)" />
-    <g
-       id="g1833-7"
-       style="display:inline"
-       transform="translate(100,-20)" />
-    <g
-       id="layer1-0"
-       style="display:inline"
-       transform="translate(100,-20)" />
   </g>
   <g
      style="display:inline"
@@ -9244,35 +9215,6 @@
          style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
     <g
-       id="layer9-3"
-       label="status"
-       style="display:inline"
-       transform="translate(-201.0002,367)" />
-    <g
-       id="layer2-67"
-       style="display:inline"
-       transform="translate(40)" />
-    <g
-       id="layer4-5"
-       style="display:inline"
-       transform="translate(40)" />
-    <g
-       id="g1812-3"
-       style="display:inline"
-       transform="translate(40)" />
-    <g
-       id="g6217-5"
-       style="display:inline"
-       transform="translate(40)" />
-    <g
-       id="layer3-6"
-       style="display:inline"
-       transform="translate(40)" />
-    <g
-       id="layer1-9"
-       style="display:inline"
-       transform="translate(40)" />
-    <g
        id="g7670"
        inkscape:label="remmina">
       <path
@@ -9999,25 +9941,6 @@
          id="path2667"
          d="m 301,195 v 0.5 9.5 h 4 v -10 z"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    </g>
-    <g
-       id="g2698"
-       inkscape:label="media-record"
-       transform="translate(-300,88)">
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920869;marker:none;enable-background:accumulate"
-         id="rect2677"
-         width="16"
-         height="15.999999"
-         x="152"
-         y="-408"
-         transform="rotate(90)" />
-      <path
-         id="path2688"
-         d="m 400,153 a 7,7 0 0 0 -7,7 7,7 0 0 0 7,7 7,7 0 0 0 7,-7 7,7 0 0 0 -7,-7 z m 0,1 a 6,6 0 0 1 6,6 6,6 0 0 1 -6,6 6,6 0 0 1 -6,-6 6,6 0 0 1 6,-6 z m 0,1 a 5,5 0 0 0 -5,5 5,5 0 0 0 5,5 5,5 0 0 0 5,-5 5,5 0 0 0 -5,-5 z"
-         style="opacity:1;fill:#da1636;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         class="error"
-         inkscape:connector-curvature="0" />
     </g>
     <g
        id="g2764"
@@ -12502,6 +12425,34 @@
          d="m 146.49023,140.99609 c -0.12976,0.004 -0.25303,0.0575 -0.34375,0.15039 l -0.48632,0.48633 c -0.21492,-0.10289 -0.45127,-0.1531 -0.68946,-0.14648 -0.38956,0.0113 -0.75941,0.17386 -1.03125,0.45312 l -1.64648,1.64649 -0.93945,-0.93946 c -0.0942,-0.0974 -0.2239,-0.15234 -0.35938,-0.15234 -0.44941,8e-5 -0.6706,0.54683 -0.34766,0.85938 l 0.93946,0.93945 -6.14649,6.14648 c -0.35526,0.34249 -0.50915,0.82822 -0.43945,1.29883 v 0.55469 l -1.85352,1.85351 0.70704,0.70704 L 135.70703,153 h 0.54492 c 0.47378,0.0725 0.96431,-0.081 1.3086,-0.43945 l 6.14648,-6.14649 0.93945,0.93946 c 0.47127,0.49023 1.19727,-0.23577 0.70704,-0.70704 l -0.93946,-0.93945 1.64649,-1.64648 c 0.45873,-0.44877 0.5812,-1.13965 0.30468,-1.71875 l 0.48829,-0.48828 c 0.32529,-0.31801 0.0914,-0.86991 -0.36329,-0.85743 z m -4.09375,3.90039 0.70704,0.70704 L 139.70703,149 h -1.41406 z"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="display:inline"
+       transform="translate(40,-240)"
+       inkscape:label="media-record"
+       id="g7746-3">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate"
+         id="rect7738-6"
+         width="16"
+         height="16"
+         x="480"
+         y="-68.000046"
+         transform="rotate(90)" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.99980217;marker:none;enable-background:accumulate"
+         id="rect7740-75"
+         width="16.000002"
+         height="16"
+         x="480.00003"
+         y="-68.000046"
+         transform="rotate(90)" />
+      <path
+         id="path7742-3"
+         d="m 60,482 c -3.313708,0 -6,2.68629 -6,6 0,3.31371 2.686292,6 6,6 3.313708,0 6,-2.68629 6,-6 0,-3.31371 -2.686292,-6 -6,-6 z"
+         style="display:inline;opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssss" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
I present my greatest artwork to date:

![image](https://user-images.githubusercontent.com/38893390/64490452-c5417d00-d254-11e9-80e4-717ed96528c3.png)

Which gives us:

![image](https://user-images.githubusercontent.com/38893390/64490467-e73aff80-d254-11e9-92e1-f853892a950b.png)

![image](https://user-images.githubusercontent.com/38893390/64490473-fae66600-d254-11e9-83c8-14efbe107e08.png)

Closes #1448.