### PR TITLE
Yaru app gtk theme code changes

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -86,16 +86,6 @@ $small_radius: 4px;
       &:backdrop { background-color: if($variant=='light', #EEEFF0, $backdrop_base_color);} // It should be _backdrop_color(white); but that does not work.
     }
   
-    @at-root %remove_folder_icon_tint,
-    scrolledwindow widget.view:selected {
-      // reduces orangeness of selected folder icons
-      background-color: rgba(255, 255, 255, 0.1); // folder icon is tinted based on this
-                                                  // near transparent white results in no tint
-                                                  // completely transparent tints the icon black
-      background-image: image($selected_bg_color); // label background becomes this
-      border-radius: $small_radius;
-    }
-  
     .nautilus-list-view .view {
       border-bottom: 1px solid transparentize($borders_color, 0.8);
   
@@ -230,7 +220,7 @@ terminal-window {
   box > list row.list-box-app-row {
       border: none;
   }
-  
+
   //Used as update count in GNOME software
   .counter-label {
     margin-top: 2px;
@@ -354,8 +344,7 @@ terminal-window {
   
     .view {
       // imports nautilus tweaks
-      // dim icons in backdrop and have only labels be colored when selected
-      &:selected { @extend %remove_folder_icon_tint; }
+      // dim icons in backdrop
       &:backdrop { @extend %dim_icons_in_backdrop; }
     }
   

--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -159,8 +159,6 @@ terminal-window {
     notebook {
         scrollbar {
             // inherits from scrollbar
-            $_scrollbar_bg: darken($headerbar_bg_color, 5%);
-            $_scrollbar_bc: darken($terminal_borders_color, 5%);
             background-color: transparent;
             border-color: transparent;
 
@@ -175,15 +173,8 @@ terminal-window {
                 margin: 0;
                 border-width: 3px;
 
-                $c: $terminal_fg_color;
-                background-color: gtkalpha(currentColor, 0.3);
-
-                &:hover:active {
-                    background-color: gtkalpha(currentColor, 0.4);
-                }
-
                 &:backdrop {
-                    background-color: gtkalpha(currentColor, 0.7);
+                  background-color: gtkalpha(currentColor, 0.1);
                 }
 
                 &:disabled {
@@ -240,25 +231,8 @@ terminal-window {
       border: none;
   }
   
-  // Star color can not be set, so this gives the stars a background in the dark theme
-//   .star{
-//     @if $variant=='dark'{
-//       border-radius: $small_radius;
-//       box-shadow: inset 0 0 10px 10px #fdfdfd;
-//     }
-//   }
-  
-  // Background color can not be set, so use a inset-box-shadow
-  .application-details-infobar {
-    box-shadow: inset 0 0 100px 100px $base_color;
-  }
-  
-  .category_page_header_filter_box  {
-      box-shadow: inset 0 0 100px 100px $base_color;
-  }
-
   //Used as update count in GNOME software
-.counter-label {
+  .counter-label {
     margin-top: 2px;
     margin-bottom: 2px;
     border-width: 0px;


### PR DESCRIPTION
- remove forced scrollbar colors to make them more visible in the dafult colors but also to make them visible in all color combinations if the user doesnt take the system colors

Gnome software app css:
- remove the commented code for stars which we decided to not ship since it does not really fix the problems of hardly seeable stars in the dark theme and rather makes it look ugly
- also remove code for the infobar in the shell extension tab because it is no longer needed after the upstream refresh

Nautilus:
 Remove nautilus css that stopped working

- in nautilus 3.28 we had made selected folders in the main view to only color the label in orange and not the whole icon+image. This stopped working with nautilus 3.30, thus we can remove the code.
upstream bug: https://gitlab.gnome.org/GNOME/nautilus/issues/786


Closes https://github.com/ubuntu/yaru/issues/1490