### PR TITLE
Lighter headerbar v8

### DIFF
--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -100,10 +100,8 @@ headerbar,
     $_btn_backdrop_border: darken($headerbar_border_color, 3%);
 
     @include button(normal, $_headerbar_button_bg, $headerbar_fg_color);
-    //border-color: lighten($_headerbar_button_bg, 6%);
-    //box-shadow: 0px 1px darken($_headerbar_button_bg, 10%);
-    //box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
-    box-shadow: inset 0 1px 0 0px lighten($_headerbar_button_bg, 8%);
+    box-shadow: inset 0 1px 0 0px lighten($_headerbar_button_bg, 8%),
+                inset 0 -1px 0 0px lighten($_headerbar_button_bg, 3%);
 
     &.flat {
       @include button(undecorated);
@@ -111,7 +109,6 @@ headerbar,
 
     &:hover {
       @include button(hover, lighten($_headerbar_button_bg, 4%), $headerbar_fg_color);
-      //border-color: lighten($_headerbar_button_bg, 6%);
       box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
     }
 
@@ -120,32 +117,27 @@ headerbar,
       $_bg: if($variant==light, darken($headerbar_bg_color, 1%), lighten($headerbar_bg_color, 1%));
       @include button(active, $_bg, $headerbar_fg_color);
       border-color: $_bg;
-      // double inset box-shadow to fix the "pinch round border" issue
       box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%),
                   inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
-      //border-color: $_dark_border_color;
-      //background-image: image(darken($_bg, 9%));
     }
     &:checked,
     &.toggle:checked {
-      @include button(hover, lighten($_headerbar_button_bg, 7%), $headerbar_fg_color);
-      //border-color: lighten($_headerbar_button_bg, 6%);
-      //box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
-      box-shadow: inset 0 1px 0 0px lighten($_headerbar_button_bg, 8%);
+      @include button(hover, darken($headerbar_bg_color, 10%), $headerbar_fg_color);
     }
 
     &:backdrop {
-
-      &.flat,
-      & {
+      &,
+      &.flat {
           @include button(backdrop, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
 
           -gtk-icon-effect: none;
           border-color: $_btn_backdrop_border;
 
           &:active,
-          &:checked {
-            $_bg: if($variant=='light', darken($backdrop_headerbar_bg_color, 9%), lighten($backdrop_headerbar_bg_color, 2%));
+          &.toggle:active,
+          &:checked,
+          &.toggle:checked {
+            $_bg: if($variant=='light', lighten($backdrop_headerbar_bg_color, 5%), lighten($backdrop_headerbar_bg_color, 5%));
             @include button(backdrop-active, $_bg, $backdrop_headerbar_fg_color);
             border-color: $_btn_backdrop_border;
           }
@@ -158,7 +150,6 @@ headerbar,
             &:active,
             &:checked {
               @include button(backdrop-insensitive-active, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
-
               border-color: $_btn_backdrop_border;
             }
         }

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -137,7 +137,7 @@ headerbar,
           &.toggle:active,
           &:checked,
           &.toggle:checked {
-            $_bg: if($variant=='light', lighten($backdrop_headerbar_bg_color, 5%), lighten($backdrop_headerbar_bg_color, 5%));
+            $_bg: if($variant=='light', darken($backdrop_headerbar_bg_color, 8%), $backdrop_headerbar_bg_color);
             @include button(backdrop-active, $_bg, $backdrop_headerbar_fg_color);
             border-color: $_btn_backdrop_border;
           }

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -1,7 +1,7 @@
 @import 'ubuntu-colors';
 
 $small_radius: 4px;
-$_headerbar_button_bg: lighten($headerbar_bg_color, 6%);
+$_headerbar_button_bg: lighten($headerbar_bg_color, 4%);
 $_dark_border_color: rgb(20, 19, 19);
 
 // copied from drawing, modified the gradients here to have less diff in drawing
@@ -100,8 +100,9 @@ headerbar,
     $_btn_backdrop_border: darken($headerbar_border_color, 3%);
 
     @include button(normal, $_headerbar_button_bg, $headerbar_fg_color);
-    border-color: lighten($_headerbar_button_bg, 6%);
-    box-shadow: 0px 1px darken($_headerbar_button_bg, 10%);
+    //border-color: lighten($_headerbar_button_bg, 6%);
+    //box-shadow: 0px 1px darken($_headerbar_button_bg, 10%);
+    box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
 
     &.flat {
       @include button(undecorated);
@@ -109,7 +110,8 @@ headerbar,
 
     &:hover {
       @include button(hover, lighten($_headerbar_button_bg, 5%), $headerbar_fg_color);
-      border-color: lighten($_headerbar_button_bg, 6%);
+      //border-color: lighten($_headerbar_button_bg, 6%);
+      box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
     }
 
     &:active,
@@ -118,7 +120,8 @@ headerbar,
     &.toggle:active {
       $_bg: if($variant==light, darken($headerbar_bg_color, 1%), lighten($headerbar_bg_color, 1%));
       @include button(active, $_bg, $headerbar_fg_color);
-      border-color: lighten($_headerbar_button_bg, 6%);
+      border-color: $_bg;// lighten($_headerbar_button_bg, 6%);
+      box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
       //border-color: $_dark_border_color;
       //background-image: image(darken($_bg, 9%));
     }

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -120,8 +120,10 @@ headerbar,
     &.toggle:active {
       $_bg: if($variant==light, darken($headerbar_bg_color, 1%), lighten($headerbar_bg_color, 1%));
       @include button(active, $_bg, $headerbar_fg_color);
-      border-color: $_bg;// lighten($_headerbar_button_bg, 6%);
-      box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
+      border-color: $_bg;
+      // double inset box-shadow to fix the "pinch round border" issue
+      box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%),
+                  inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
       //border-color: $_dark_border_color;
       //background-image: image(darken($_bg, 9%));
     }

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -112,7 +112,7 @@ headerbar,
       @include button(hover, lighten($_headerbar_button_bg, 4%), $headerbar_fg_color);
       @if $variant == 'light' {
         box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
-     }
+      }
     }
     &:active,
     &:checked,
@@ -166,20 +166,26 @@ headerbar,
 
     // Suggested and Destructive Action buttons, need to overwrite them again here
     // copied from common, disabled buttons bg color changed to match the headerbar
-    @each $b_type,
-    $b_color in (suggested-action, $suggested_bg_color),
-    (destructive-action, $destructive_color) {
+    @each $b_type, $b_color in (suggested-action, $suggested_bg_color),
+                               (destructive-action, $destructive_color) {
       &.#{$b_type} {
         @include button(normal, $b_color, white);
-
+        border-color: $b_color;
+        @if $variant == 'light' {
+          box-shadow: inset 0 1px 0 0px lighten($b_color, 8%),
+                      inset 0 -1px 0 0px lighten($b_color, 3%);
+        }
         &.flat {
           @include button(undecorated);
-
           color: $b_color;
         }
 
         &:hover {
           @include button(hover, $b_color, white);
+          border-color: $b_color;
+          @if $variant == 'light' {
+            box-shadow: inset 0 0 0 1px lighten($b_color, 6%);
+          }
         }
 
         &:active,
@@ -338,6 +344,10 @@ headerbar,
     filechooser .path-bar.linked>button,
     .path-bar button {
       @include button(normal, $suggested_bg_color, $selected_fg_color);
+      @if $variant == 'light' {
+        box-shadow: inset 0 1px 0 0px lighten($suggested_bg_color, 8%),
+                    inset 0 -1px 0 0px lighten($suggested_bg_color, 3%);
+      }
 
       &.flat {
         @include button(undecorated);
@@ -345,6 +355,9 @@ headerbar,
 
       &:hover {
         @include button(hover, $suggested_bg_color, $selected_fg_color);
+        @if $variant == 'light' {
+          box-shadow: inset 0 0 0 1px lighten($suggested_bg_color, 6%);
+        }
       }
 
       &:active,

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -100,25 +100,29 @@ headerbar,
     $_btn_backdrop_border: darken($headerbar_border_color, 3%);
 
     @include button(normal, $_headerbar_button_bg, $headerbar_fg_color);
-    box-shadow: inset 0 1px 0 0px lighten($_headerbar_button_bg, 8%),
-                inset 0 -1px 0 0px lighten($_headerbar_button_bg, 3%);
-
+    @if $variant == 'light' {
+      box-shadow: inset 0 1px 0 0px lighten($_headerbar_button_bg, 8%),
+                  inset 0 -1px 0 0px lighten($_headerbar_button_bg, 3%);
+    }
     &.flat {
       @include button(undecorated);
     }
 
     &:hover {
       @include button(hover, lighten($_headerbar_button_bg, 4%), $headerbar_fg_color);
-      box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
+      @if $variant == 'light' {
+        box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
+     }
     }
-
     &:active,
     &.toggle:active {
       $_bg: if($variant==light, darken($headerbar_bg_color, 1%), lighten($headerbar_bg_color, 1%));
       @include button(active, $_bg, $headerbar_fg_color);
       border-color: $_bg;
-      box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%),
-                  inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
+      @if $variant == 'light' {
+        box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%),
+                    inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
+      }
     }
     &:checked,
     &.toggle:checked {

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -121,7 +121,7 @@ headerbar,
       $_bg: if($variant==light, darken($headerbar_bg_color, 1%), lighten($headerbar_bg_color, 1%));
       @include button(active, $_bg, $headerbar_fg_color);
       border-color: black;
-    } 
+    }
 
     &:backdrop {
       &,
@@ -282,16 +282,16 @@ headerbar,
         background-color: $headerbar_bg_color;
         border-color: $_dark_border_color;
       }
-  
+
       &:checked {
         color: $selected_fg_color;
         border-color: transparentize($suggested_bg_color, 0.6);
         background-color: $suggested_bg_color;
       }
-  
+
       slider {
         border-color: $_dark_border_color;
-        
+
         &:checked {
           border-color: $suggested_border_color;
         }
@@ -300,7 +300,7 @@ headerbar,
           border-color: $_dark_border_color;
           @include button(insensitive, $headerbar_bg_color);
         }
-      }      
+      }
     }
   }
 

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -102,21 +102,20 @@ headerbar,
     @include button(normal, $_headerbar_button_bg, $headerbar_fg_color);
     //border-color: lighten($_headerbar_button_bg, 6%);
     //box-shadow: 0px 1px darken($_headerbar_button_bg, 10%);
-    box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
+    //box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
+    box-shadow: inset 0 1px 0 0px lighten($_headerbar_button_bg, 8%);
 
     &.flat {
       @include button(undecorated);
     }
 
     &:hover {
-      @include button(hover, lighten($_headerbar_button_bg, 5%), $headerbar_fg_color);
+      @include button(hover, lighten($_headerbar_button_bg, 4%), $headerbar_fg_color);
       //border-color: lighten($_headerbar_button_bg, 6%);
       box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
     }
 
     &:active,
-    &:checked,
-    &.toggle:checked,
     &.toggle:active {
       $_bg: if($variant==light, darken($headerbar_bg_color, 1%), lighten($headerbar_bg_color, 1%));
       @include button(active, $_bg, $headerbar_fg_color);
@@ -126,6 +125,13 @@ headerbar,
                   inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
       //border-color: $_dark_border_color;
       //background-image: image(darken($_bg, 9%));
+    }
+    &:checked,
+    &.toggle:checked {
+      @include button(hover, lighten($_headerbar_button_bg, 7%), $headerbar_fg_color);
+      //border-color: lighten($_headerbar_button_bg, 6%);
+      //box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
+      box-shadow: inset 0 1px 0 0px lighten($_headerbar_button_bg, 8%);
     }
 
     &:backdrop {

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -115,19 +115,13 @@ headerbar,
      }
     }
     &:active,
-    &.toggle:active {
+    &:checked,
+    &.toggle:active
+    &.toggle:checked {
       $_bg: if($variant==light, darken($headerbar_bg_color, 1%), lighten($headerbar_bg_color, 1%));
       @include button(active, $_bg, $headerbar_fg_color);
-      border-color: $_bg;
-      @if $variant == 'light' {
-        box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%),
-                    inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
-      }
-    }
-    &:checked,
-    &.toggle:checked {
-      @include button(hover, darken($headerbar_bg_color, 10%), $headerbar_fg_color);
-    }
+      border-color: black;
+    } 
 
     &:backdrop {
       &,

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -1,7 +1,7 @@
 @import 'ubuntu-colors';
 
 $small_radius: 4px;
-$_headerbar_button_bg: lighten($headerbar_bg_color, 4%);
+$_headerbar_button_bg: lighten($headerbar_bg_color, 6%);
 $_dark_border_color: rgb(20, 19, 19);
 
 // copied from drawing, modified the gradients here to have less diff in drawing

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -118,7 +118,7 @@ headerbar,
     &:checked,
     &.toggle:active
     &.toggle:checked {
-      $_bg: if($variant==light, darken($headerbar_bg_color, 1%), lighten($headerbar_bg_color, 1%));
+      $_bg: if($variant==light, lighten($headerbar_bg_color, 3%), lighten($headerbar_bg_color, 1%));
       @include button(active, $_bg, $headerbar_fg_color);
       border-color: black;
     }

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -1,8 +1,8 @@
 @import 'ubuntu-colors';
 
 $small_radius: 4px;
-$_headerbar_button_bg: lighten($headerbar_bg_color, 4%);
-$_dark_border_color: rgb(20, 19, 19);;
+$_headerbar_button_bg: lighten($headerbar_bg_color, 6%);
+$_dark_border_color: rgb(20, 19, 19);
 
 // copied from drawing, modified the gradients here to have less diff in drawing
 @mixin yaru_headerbar_fill($c:$headerbar_color, $hc:$top_hilight, $ov: none) {
@@ -100,52 +100,56 @@ headerbar,
     $_btn_backdrop_border: darken($headerbar_border_color, 3%);
 
     @include button(normal, $_headerbar_button_bg, $headerbar_fg_color);
+    border-color: lighten($_headerbar_button_bg, 6%);
+    box-shadow: 0px 1px darken($_headerbar_button_bg, 10%);
 
     &.flat {
       @include button(undecorated);
     }
 
     &:hover {
-      @include button(hover, lighten($headerbar_bg_color, 8%), $headerbar_fg_color);
+      @include button(hover, lighten($_headerbar_button_bg, 5%), $headerbar_fg_color);
+      border-color: lighten($_headerbar_button_bg, 6%);
     }
 
     &:active,
     &:checked,
     &.toggle:checked,
     &.toggle:active {
-      $_bg: lighten($headerbar_bg_color, if($variant==light, 0%, 1%));
+      $_bg: if($variant==light, darken($headerbar_bg_color, 1%), lighten($headerbar_bg_color, 1%));
       @include button(active, $_bg, $headerbar_fg_color);
-      border-color: rgb(20, 19, 19);
-      background-image: image(darken($_bg, 9%));
+      border-color: lighten($_headerbar_button_bg, 6%);
+      //border-color: $_dark_border_color;
+      //background-image: image(darken($_bg, 9%));
     }
 
     &:backdrop {
 
       &.flat,
       & {
-        @include button(backdrop, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
+          @include button(backdrop, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
 
-        -gtk-icon-effect: none;
-        border-color: $_btn_backdrop_border;
-
-        &:active,
-        &:checked {
-          $_bg: if($variant=='light', darken($backdrop_headerbar_bg_color, 9%), lighten($backdrop_headerbar_bg_color, 2%));
-          @include button(backdrop-active, $_bg, $backdrop_headerbar_fg_color);
-          border-color: $_btn_backdrop_border;
-        }
-
-        &:disabled {
-          @include button(backdrop-insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $backdrop_headerbar_fg_color);
-
+          -gtk-icon-effect: none;
           border-color: $_btn_backdrop_border;
 
           &:active,
           &:checked {
-            @include button(backdrop-insensitive-active, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
-
+            $_bg: if($variant=='light', darken($backdrop_headerbar_bg_color, 9%), lighten($backdrop_headerbar_bg_color, 2%));
+            @include button(backdrop-active, $_bg, $backdrop_headerbar_fg_color);
             border-color: $_btn_backdrop_border;
           }
+
+          &:disabled {
+            @include button(backdrop-insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $backdrop_headerbar_fg_color);
+
+            border-color: $_btn_backdrop_border;
+
+            &:active,
+            &:checked {
+              @include button(backdrop-insensitive-active, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
+
+              border-color: $_btn_backdrop_border;
+            }
         }
       }
     }

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -101,7 +101,8 @@ headerbar,
 
     @include button(normal, $_headerbar_button_bg, $headerbar_fg_color);
     @if $variant == 'light' {
-      box-shadow: inset 0 1px 0 0px lighten($_headerbar_button_bg, 8%),
+      box-shadow: 0 1px 2px darken($headerbar_bg_color, 4%),
+                  inset 0 1px 0 0px lighten($_headerbar_button_bg, 8%),
                   inset 0 -1px 0 0px lighten($_headerbar_button_bg, 3%);
     }
     &.flat {
@@ -111,7 +112,8 @@ headerbar,
     &:hover {
       @include button(hover, lighten($_headerbar_button_bg, 4%), $headerbar_fg_color);
       @if $variant == 'light' {
-        box-shadow: inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
+        box-shadow: 0 1px 2px darken($headerbar_bg_color, 4%),
+                    inset 0 0 0 1px lighten($_headerbar_button_bg, 6%);
       }
     }
     &:active,
@@ -172,7 +174,8 @@ headerbar,
         @include button(normal, $b_color, white);
         border-color: $b_color;
         @if $variant == 'light' {
-          box-shadow: inset 0 1px 0 0px lighten($b_color, 8%),
+          box-shadow: 0 1px 2px darken($headerbar_bg_color, 4%),
+                      inset 0 1px 0 0px lighten($b_color, 8%),
                       inset 0 -1px 0 0px lighten($b_color, 3%);
         }
         &.flat {
@@ -184,7 +187,8 @@ headerbar,
           @include button(hover, $b_color, white);
           border-color: $b_color;
           @if $variant == 'light' {
-            box-shadow: inset 0 0 0 1px lighten($b_color, 6%);
+            box-shadow: 0 1px 2px darken($headerbar_bg_color, 4%),
+                        inset 0 0 0 1px lighten($b_color, 6%);
           }
         }
 

--- a/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
@@ -25,7 +25,7 @@ $terminal_fg_color: white;
 $terminal_borders_color: darken($terminal_bg_color, 10%);
 
 // Widget Colors
-$headerbar_bg_color: #2B2929;
+$headerbar_bg_color: #3E3C3C;
 $menubar_bg_color: $headerbar_bg_color;
 $headerbar_fg_color: $porcelain;
 $headerbar_border_color: lighten($headerbar_bg_color, 8%);

--- a/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
@@ -25,7 +25,7 @@ $terminal_fg_color: white;
 $terminal_borders_color: darken($terminal_bg_color, 10%);
 
 // Widget Colors
-$headerbar_bg_color: #424040;
+$headerbar_bg_color: #323030;
 $menubar_bg_color: $headerbar_bg_color;
 $headerbar_fg_color: $porcelain;
 $headerbar_border_color: lighten($headerbar_bg_color, 8%);

--- a/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
@@ -25,7 +25,7 @@ $terminal_fg_color: white;
 $terminal_borders_color: darken($terminal_bg_color, 10%);
 
 // Widget Colors
-$headerbar_bg_color: #3E3C3C;
+$headerbar_bg_color: #323030;
 $menubar_bg_color: $headerbar_bg_color;
 $headerbar_fg_color: $porcelain;
 $headerbar_border_color: lighten($headerbar_bg_color, 8%);

--- a/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/light/gtk-3.20/_ubuntu-colors.scss
@@ -25,7 +25,7 @@ $terminal_fg_color: white;
 $terminal_borders_color: darken($terminal_bg_color, 10%);
 
 // Widget Colors
-$headerbar_bg_color: #323030;
+$headerbar_bg_color: #424040;
 $menubar_bg_color: $headerbar_bg_color;
 $headerbar_fg_color: $porcelain;
 $headerbar_border_color: lighten($headerbar_bg_color, 8%);


### PR DESCRIPTION
Alternative to #1478, that preserves better the original Yaru dark style. Base headerbar color is #323030 instead of #424040 from #1478, plus a series of hints to keep buttons more visible

![image](https://user-images.githubusercontent.com/2883614/64522088-87e2fb00-d2f9-11e9-9ec3-3dd857498db4.png)
![image](https://user-images.githubusercontent.com/2883614/64522110-96311700-d2f9-11e9-9004-6953a86e064b.png)

