### PR TITLE
Re-add adwaita custom code for search entries

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -119,6 +119,10 @@ $small_radius: 4px;
         outline-color: white;
       }
     }
+
+    entry.search > * {
+      margin: 5px;
+    }
   }
   
   .nautilus-desktop-window {


### PR DESCRIPTION
- copy search entry custom code for nautilus that is only loaded if Adwaita is the current gtk theme https://gitlab.gnome.org/GNOME/nautilus/blob/master/src/resources/css/Adwaita.css#L77

![grafik](https://user-images.githubusercontent.com/15329494/64590215-4f99f600-d3a7-11e9-8b5c-241e6c9fd6f0.png)

@madsrh and/or @clobrano okay like this? Or further improvements?

Closes https://github.com/ubuntu/yaru/issues/1497