### PR TITLE
Nautilus custom code

### DIFF
--- a/gtk/src/light/gtk-3.20/_apps.scss
+++ b/gtk/src/light/gtk-3.20/_apps.scss
@@ -120,15 +120,34 @@ $small_radius: 4px;
       }
     }
 
+    // custom code from nautilus Adwaita.css for entries and the pathbar
     entry.search > * {
       margin: 5px;
     }
-  }
-  
-  .nautilus-desktop-window {
-    .nautilus-desktop.view {
-      color: $selected_fg_color;
-      text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
+
+    .nautilus-path-bar button { /* undecorate the buttons */
+      margin: 0px;
+    }
+
+    .path-bar-box {
+      transition: border 200ms;
+      transition: background-color 200ms;
+      border-radius: $button_radius;
+    }    
+
+    .path-bar-box.width-maximized {
+      border: 1px solid $borders_color;
+      background-color: $bg_color;
+    }
+    
+    .path-bar-box.width-maximized button:first-child {
+        border-radius: $button_radius 0px 0px $button_radius;
+        border-width: 0px 1px 0px 0px;
+    }
+    
+    .path-bar-box.width-maximized button:not(:first-child) {
+        border-width: 0px 1px 0px 1px;
+        border-radius: 0px 0px 0px 0px;
     }
   }
 


### PR DESCRIPTION
- re-inserting custom code from https://gitlab.gnome.org/GNOME/nautilus/blob/master/src/resources/css/Adwaita.css#L60 for the maximized pathbar because this code is only loaded if the theme is Adwaita or Adwaita-dark
- remove the old nautilus window, which is no longer existant for 3.30+

![Screenshot from 2019-09-10 04-22-12](https://user-images.githubusercontent.com/15329494/64597103-223b5100-d383-11e9-878c-f84ea43b6b03.png)
![Screenshot from 2019-09-10 04-21-43](https://user-images.githubusercontent.com/15329494/64597104-223b5100-d383-11e9-9163-3cdc3332e405.png)


Closes https://github.com/ubuntu/yaru/issues/1500