### PR TITLE
Adapt shell toggle to gtk switch

### DIFF
--- a/gnome-shell/src/toggle-off.svg
+++ b/gnome-shell/src/toggle-off.svg
@@ -1,1 +1,113 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="46" height="22"><g transform="translate(0 -291.18)"><rect style="marker:none;font-variant-east_asian:normal" width="44.446" height="20.911" x=".625" y="291.715" rx="10.455" ry="10.073" fill="#e1dedb" stroke="#cdc7c2" stroke-linecap="round" stroke-linejoin="round"/><rect ry="10.455" rx="10.455" y="291.715" x=".543" height="20.911" width="21.143" style="marker:none;font-variant-east_asian:normal" fill="#f8f7f7" stroke="#aa9f98" stroke-linecap="round" stroke-linejoin="round"/><g transform="matrix(.97148 0 0 1 1658.914 -2552.91)" stroke-width="1.015" stroke-linecap="round" stroke-linejoin="round"><rect ry="13.17" rx="13.556" y="1234.681" x="-1242.732" height="26" width="49.409" style="marker:none" fill="#e1dedb" stroke="#cdc7c2"/><rect style="marker:none" width="26.763" height="26" x="-1242.732" y="1234.769" rx="13.511" ry="13.126" fill="#f8f7f7" stroke="#aa9f98"/></g><g transform="matrix(.97148 0 0 1 1658.914 -2512.91)" stroke-width="1.015" stroke="#2b73cc"><rect style="marker:none" width="49.409" height="26" x="-1242.732" y="1234.681" rx="13.556" ry="13.17" fill="#3081e3"/><rect ry="13.126" rx="13.511" y="1234.769" x="-1220.086" height="26" width="26.763" style="marker:none" fill="#f8f7f7" stroke-linecap="round" stroke-linejoin="round"/></g></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="46"
+   height="22"
+   version="1.1"
+   id="svg20"
+   sodipodi:docname="toggle-off.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata26">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs24" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1111"
+     inkscape:window-height="712"
+     id="namedview22"
+     showgrid="false"
+     inkscape:zoom="7.5652174"
+     inkscape:cx="18.571839"
+     inkscape:cy="10.074713"
+     inkscape:window-x="180"
+     inkscape:window-y="189"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg20" />
+  <rect
+     id="rect2"
+     ry="10.073"
+     rx="10.455"
+     y="0.53499633"
+     x="0.625"
+     height="20.910999"
+     width="44.445999"
+     style="fill:#dcdfe3;stroke:#c2c8ce;stroke-linecap:round;stroke-linejoin:round;marker:none;fill-opacity:1;stroke-opacity:1" />
+  <rect
+     id="rect4"
+     style="fill:#fbfbfc;stroke:#b3bbc3;stroke-linecap:round;stroke-linejoin:round;marker:none;fill-opacity:1;stroke-opacity:1"
+     width="21.143"
+     height="20.910999"
+     x="0.54299998"
+     y="0.53499633"
+     rx="10.455"
+     ry="10.455" />
+  <g
+     style="stroke-width:1.01499999;stroke-linecap:round;stroke-linejoin:round"
+     id="g10"
+     transform="matrix(0.97148,0,0,1,1658.914,-2844.09)">
+    <rect
+       id="rect6"
+       style="fill:#e1dedb;stroke:#cdc7c2;marker:none"
+       width="49.409"
+       height="26"
+       x="-1242.7321"
+       y="1234.681"
+       rx="13.556"
+       ry="13.17" />
+    <rect
+       id="rect8"
+       ry="13.126"
+       rx="13.511"
+       y="1234.769"
+       x="-1242.7321"
+       height="26"
+       width="26.763"
+       style="fill:#f8f7f7;stroke:#aa9f98;marker:none" />
+  </g>
+  <g
+     style="stroke:#2b73cc;stroke-width:1.01499999"
+     id="g16"
+     transform="matrix(0.97148,0,0,1,1658.914,-2804.09)">
+    <rect
+       id="rect12"
+       ry="13.17"
+       rx="13.556"
+       y="1234.681"
+       x="-1242.7321"
+       height="26"
+       width="49.409"
+       style="fill:#3081e3;marker:none" />
+    <rect
+       id="rect14"
+       style="fill:#f8f7f7;stroke-linecap:round;stroke-linejoin:round;marker:none"
+       width="26.763"
+       height="26"
+       x="-1220.0861"
+       y="1234.769"
+       rx="13.511"
+       ry="13.126" />
+  </g>
+</svg>


### PR DESCRIPTION
- change the color values of the shell theme toggle-off asset to match the unchecked gtk switches, was previously using the upstream colors

![Screenshot from 2019-09-10 05-12-23](https://user-images.githubusercontent.com/15329494/64602620-1d7b9a80-d38d-11e9-86af-41a2dcd18f2f.png)
![Screenshot from 2019-09-10 05-36-03](https://user-images.githubusercontent.com/15329494/64602622-1d7b9a80-d38d-11e9-814b-4c99ee1cdf34.png)
