### PR TITLE
Sync bg_color with gtk popover colors

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -3,7 +3,7 @@
 @import "ubuntu-colors";
 
 $base_color: if($variant == 'light', #ffffff, lighten(desaturate($jet, 20%), 10%));
-$bg_color: if($variant == 'light',#F5F6F7, darken($inkstone, 1%));
+$bg_color: if($variant == 'light',lighten(#F5F6F7,1%), darken($inkstone, 1%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 
 $selected_fg_color: #ffffff;


### PR DESCRIPTION
Visibly there are only dialogues, popovers and notifications using the bg_color in the shell
Brightening the gtk popovers by 1% needs brightening of the bg_color in the shell because there is no variable for the popup background color in the shell

![image_2019-09-11_12-33-21](https://user-images.githubusercontent.com/15329494/64691511-1a6ad200-d493-11e9-9af0-9ec9974dc9e9.png)


![grafik](https://user-images.githubusercontent.com/15329494/64691252-8f89d780-d492-11e9-9f3c-b4ef3b58308e.png)
