### PR TITLE
Ubuntu dock transparency changes

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -50,7 +50,7 @@ $hover_fg_color: lighten($selected_fg_color, .25);
 $active_fg_color: transparentize($selected_fg_color, .5);
 
 $panel_bg_color: lighten(#181818, 2%);
-$dash_bg_color: $panel_bg_color;
+$dash_bg_color: transparentize($panel_bg_color, 0.3);
 $panel-alpha-value: 0.6;
 $panel_opaque_value: 0.0;
 


### PR DESCRIPTION
- adaptive transparency stopped to work with gnome shell 3.32
- a permanently opaque dock looks quiet heavy in "window not maximized" situations
- adding a soft transparency lowers the heavyness of the dock/panel combination a bit

Before:
![image](https://user-images.githubusercontent.com/15329494/64767071-0bc4ff00-d515-11e9-95ac-49420b8a8f51.png)
![beforemax](https://user-images.githubusercontent.com/15329494/64766981-dddfba80-d514-11e9-80ff-41bf6de16f07.png)

After:
![image_2019-09-12_03-57-35](https://user-images.githubusercontent.com/15329494/64766749-8b9e9980-d514-11e9-98f6-3246f6dff0bf.png)
![image_2019-09-12_03-58-22](https://user-images.githubusercontent.com/15329494/64766750-8b9e9980-d514-11e9-9d4f-78861a09cd66.png)
![image_2019-09-12_04-02-36](https://user-images.githubusercontent.com/15329494/64766752-8c373000-d514-11e9-863b-37fe4005fc51.png)
![image_2019-09-12_04-03-51](https://user-images.githubusercontent.com/15329494/64766753-8c373000-d514-11e9-80b5-577451ee9f57.png)
![doc_2019-09-12_04-19-17](https://user-images.githubusercontent.com/15329494/64766767-91947a80-d514-11e9-871d-277c927ad445.png)
