### PR TITLE
Gtk and shell theme post 19.10 ui freeze fixes

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -212,7 +212,7 @@
 
     &:active .overview-icon,
     &:checked .overview-icon {
-      // when clicking on an app
+      background-color: $base_active_color; box-shadow: none;
     }
 
     &.focused .overview-icon {

--- a/gtk/src/light/gtk-3.20/_colors.scss
+++ b/gtk/src/light/gtk-3.20/_colors.scss
@@ -2,19 +2,19 @@
 // it gets @if ed depending on $variant
 @import 'ubuntu-colors';
 
-$base_color: if($variant == 'light', #ffffff, lighten(desaturate(#181818, 20%), 10%));
+$base_color: if($variant == 'light', #ffffff, lighten(desaturate($jet, 20%), 10%));
 $text_color: if($variant == 'light', black, white);
-$bg_color: if($variant == 'light', #F5F6F7, darken(#3d3d3d, 1%));
-$fg_color: if($variant == 'light', #3d3d3d, #f7f7f7);
+$bg_color: if($variant == 'light', #F5F6F7, darken($inkstone, 1%));
+$fg_color: if($variant == 'light', $inkstone, $porcelain);
 
 $selected_fg_color: #ffffff;
-$selected_bg_color: if($variant == 'light', #E95420, darken(#E95420, 4%));
+$selected_bg_color: if($variant == 'light', $orange, darken($orange, 4%));
 
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
 $borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 9%));
 $alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 18%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
-$link_color: if($variant == 'light', darken(#19B6EE, 10%), lighten(#19B6EE, 20%));
+$link_color: if($variant == 'light', darken($blue, 10%), lighten($blue, 20%));
 $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
@@ -70,7 +70,7 @@ $backdrop_scrollbar_slider_color: mix($backdrop_fg_color, $backdrop_bg_color, 40
 $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdrop_bg_color, $backdrop_base_color, 20%));
 
 //special cased widget colors
-$suggested_bg_color: $success_color;
+$suggested_bg_color: $green;
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
 $progress_bg_color: $blue;
 $progress_border_color: $progress_bg_color;

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -4,6 +4,7 @@ $small_radius: 4px;
 $_base_hover_color: transparentize($fg_color, 0.85);
 $_base_active_color: transparentize($fg_color, 0.75);
 
+// Helper mixin for the titlebuttons
 @mixin draw_circle($c, $size:24px) {
   $button_size: $size + 2px * 2;
   $circle_size: 20px / $button_size / 2;
@@ -46,8 +47,8 @@ switch {
   }
 }
 
-// titlebutton
-button.titlebutton.maximize,  button.titlebutton.minimize, button.titlebutton.close {
+// yaru titlebuttons, optimized for the compact headerbar
+button.titlebutton:not(.appmenu) {
 
   &,
   &:hover,
@@ -70,36 +71,41 @@ button.titlebutton.maximize,  button.titlebutton.minimize, button.titlebutton.cl
   min-width: 24px;
   padding: 2px;
 
-  &.maximize, &.minimize {
+  headerbar &,
+  .titlebar &,
+  headerbar.selection-mode &,
+  & {
+    &.maximize, &.minimize {
 
-    &, &:backdrop {
+      &, &:backdrop {
+        &:hover {
+          @include draw_circle($_base_hover_color);
+        }
+  
+        &:active {
+          @include draw_circle($_base_active_color);
+        }
+      }
+    }
+  
+    &.close {
+      color: $selected_fg_color;
+      @include draw_circle($selected_bg_color);
+  
       &:hover {
-        @include draw_circle($_base_hover_color);
+        @include draw_circle($selected_bg_color);
+        @include draw_circle(lighten($selected_bg_color, 5%));
       }
-
+    
       &:active {
-        @include draw_circle($_base_active_color);
+        @include draw_circle($selected_bg_color);
+        @include draw_circle(darken($selected_bg_color, 5%));
       }
-    }
-  }
-
-  &.close {
-    color: $selected_fg_color;
-    @include draw_circle($selected_bg_color);
-
-    &:hover {
-      @include draw_circle($selected_bg_color);
-      @include draw_circle(lighten($selected_bg_color, 5%));
-    }
-
-    &:active {
-      @include draw_circle($selected_bg_color);
-      @include draw_circle(darken($selected_bg_color, 5%));
-    }
-
-    &:backdrop {
-      @include draw_circle(lighten($inkstone, if($variant=='light', 40%, 10%)));
-      &:hover { @include draw_circle(lighten($inkstone, if($variant=='light', 45%, 15%))); }
+    
+      &:backdrop {
+        @include draw_circle(lighten($inkstone, if($variant=='light', 40%, 10%)));
+        &:hover { @include draw_circle(lighten($inkstone, if($variant=='light', 45%, 15%))); }
+      }
     }
   }
 }

--- a/gtk/src/light/gtk-3.20/_tweaks.scss
+++ b/gtk/src/light/gtk-3.20/_tweaks.scss
@@ -1,11 +1,9 @@
-@import 'ubuntu-colors';
-
-$small_radius: 4px;
 $_base_hover_color: transparentize($fg_color, 0.85);
 $_base_active_color: transparentize($fg_color, 0.75);
+$_titlebutton_height: 24px;
 
 // Helper mixin for the titlebuttons
-@mixin draw_circle($c, $size:24px) {
+@mixin draw_circle($c, $size:$_titlebutton_height) {
   $button_size: $size + 2px * 2;
   $circle_size: 20px / $button_size / 2;
 
@@ -66,9 +64,9 @@ button.titlebutton:not(.appmenu) {
     }
   }
 
-  border-radius: $small_radius;
-  min-height: 24px;
-  min-width: 24px;
+  // Important - otherwise the circle size is wrong
+  min-height: $_titlebutton_height;
+  min-width: $_titlebutton_height;
   padding: 2px;
 
   headerbar &,


### PR DESCRIPTION
Two actual fixes (actually quiet important):

- use our titlebuttons also in the selection-mode, accidentally they were unstyled
- use a transparent active effect for clicking on a not-selected app in the dock

And some organization (not so important):

- Organize _tweaks.scss
-> remove import of ubuntu-colors because it's already imported into _colors.scss
-> remove small_radius which is no longer needed, new corresponding upstream variable is $button_radius in _common.scss
-> use a $_titlebutton_height for both the min sizes of the titlebuttons and the draw_circle mixin to avoid mistakes

- Use ubuntu-colors in colors
-> actually use the colors we imported instead of using the same hexvalue

Merge either after 19.10 or when we got UI freeze exceptions for this OR if not needed because it is not a design change but bug fixes merge when @iainlane thinks it is okay :smile_cat: 