### PR TITLE
apps: limit scrolledwindow backdrop opacity to Nautilus only

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -24,7 +24,7 @@ $ambiance: null !default;
 
     // Makes icons less bright in backdrop
     @at-root %dim_icons_in_backdrop,
-    *scrolledwindow:backdrop { opacity: 0.9; }
+    & *scrolledwindow:backdrop { opacity: 0.9; }
 
     paned box.floating-bar {
       background: $bg_color;


### PR DESCRIPTION
Setting the opacity for scrolledwindow in backdrop - to get opaque
icons under Nautilus in backdrop - breaks Tilix's backdrop transparency.

Limit the setting to Nautilus only fix the issue.

Close #1158

![image](https://user-images.githubusercontent.com/2883614/65757858-41263b00-e118-11e9-993e-3b254b908c52.png)
