### PR TITLE
apps: Fix invisible menuitems in Firefox under Yaru-ambiance

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -420,7 +420,11 @@ terminal-window {
     menu, .menu,.context-menu { border-radius: 0; }
 
     @if $ambiance {
-      menubar, .menubar { background-color: $headerbar_bg_color; color:$headerbar_fg_color; }
+      menubar,
+      .menubar,
+      menubar > menuitem:hover,
+      { background-color: $headerbar_bg_color; color:$headerbar_fg_color; }
+
     }
 
     // Adapt scrollbars a bit more to the GTK Scrollbar styling


### PR DESCRIPTION
Firefox uses ~menubar~ headerbar colors for unfocused tabs in no-titlebar mode, this requires
a dark menubar, but also menuitems require the same style, otherwise they are invisible
(dark text on dark background)

closes #1548