### PR TITLE
[bionic] apps: fix desktop icon color label

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -128,6 +128,13 @@ $ambiance: null !default;
     }
   }
 
+  .nautilus-desktop-window {
+    .nautilus-desktop.view {
+      color: $selected_fg_color;
+      text-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
+    }
+  }
+
 /************
  * Terminal *
  ************/


### PR DESCRIPTION
On bionic, desktop icons keep the same label style they have in the
application, which is grey in light variants and so not clearly visible
on a wallpaper.

Re apply white color to desktop icon label color and a dark shadow to
improve contrast on bright wallpapers.

close #1552