### PR TITLE
When building with communitheme_compat, link the dark varient as well

### DIFF
--- a/communitheme-compat/install-compat.sh
+++ b/communitheme-compat/install-compat.sh
@@ -15,3 +15,7 @@ install -m755 -d "${datadir}/themes/Communitheme"
 for file in index.theme gtk-2.0 gtk-3.0 gtk-3.20; do
     ln -s "../Yaru/${file}" "${datadir}/themes/Communitheme/${file}"
 done
+install -m755 -d "${datadir}/themes/Communitheme-dark"
+for file in index.theme gtk-2.0 gtk-3.0 gtk-3.20; do
+    ln -s "../Yaru-dark/${file}" "${datadir}/themes/Communitheme-dark/${file}"
+done


### PR DESCRIPTION
gtk-common-themes builds with communitheme_compat=true.  This was missing the dark variant, so theming is broken on snaps when the user has communitheme-dark set as their gtk theme.