### PR TITLE
When building with communitheme_compat, link the light variant

### DIFF
--- a/communitheme-compat/install-compat.sh
+++ b/communitheme-compat/install-compat.sh
@@ -19,3 +19,7 @@ install -m755 -d "${datadir}/themes/Communitheme-dark"
 for file in index.theme gtk-2.0 gtk-3.0 gtk-3.20; do
     ln -s "../Yaru-dark/${file}" "${datadir}/themes/Communitheme-dark/${file}"
 done
+install -m755 -d "${datadir}/themes/Communitheme-light"
+for file in index.theme gtk-2.0 gtk-3.0 gtk-3.20; do
+    ln -s "../Yaru-light/${file}" "${datadir}/themes/Communitheme-light/${file}"
+done


### PR DESCRIPTION
gtk-common-themes builds with communitheme_compat=true. This was missing the light variant, so theming is broken on snaps when the user has communitheme-light set as their gtk theme.