### PR TITLE
Ensure shell-theme link can be created when using DESTDIR

### DIFF
--- a/gnome-shell/src/install-shell.sh
+++ b/gnome-shell/src/install-shell.sh
@@ -2,6 +2,8 @@
 # -*- coding: UTF-8 -*-
 
 project_name="$1"
-prefix="${MESON_INSTALL_DESTDIR_PREFIX}/share"
+destdir_prefix="${MESON_INSTALL_DESTDIR_PREFIX}/share"
+install_prefix="${MESON_INSTALL_PREFIX}/share"
 
-ln -sf "${prefix}/themes/${project_name}/gnome-shell" "${prefix}/gnome-shell/theme/${project_name}"
+mkdir -p "${destdir_prefix}/gnome-shell/theme/"
+ln -sf "${install_prefix}/themes/${project_name}/gnome-shell" "${destdir_prefix}/gnome-shell/theme/${project_name}"


### PR DESCRIPTION
When creating a package (such as on Arch Linux) using:

`DESTDIR="${pkgdir}" ninja -C build install`

to install all files to `${pkgdir}` for later installation onto an
actual system, ensure the symlink to the shell theme can be created.

The link target should point to a location in `MESON_INSTALL_PREFIX`,
but the link itself should be in `MESON_INSTALL_DESTDIR_PREFIX`.
Furthermore, the link's parent directory needs to be created within
`MESON_INSTALL_DESTDIR_PREFIX` if it does not exist.

Fixes #1583