### PR TITLE
sounds: provide system-ready sound

### DIFF
--- a/sounds/src/stereo/system-ready.oga
+++ b/sounds/src/stereo/system-ready.oga
@@ -1,0 +1,1 @@
+desktop-login.oga


### PR DESCRIPTION
system-ready sound was not provided in yaru-theme-sound, preventing
ubiquity to play it when the system is ready.

Provide system-ready as symlink to desktop-login

closes LP: #1848217
closes #1575