### PR TITLE
Remove dowstream check/radio flattening

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -107,36 +107,6 @@ button.titlebutton:not(.appmenu) {
   }
 }
 
-// make checks and radios more flat, remove this when upstream flattens their cheks/radios
-check,
-radio {
-
-  &,
-  &:hover,
-  &:active,
-  &:checked,
-  &:disabled {
-
-    &:not(.selected) {
-      box-shadow: none;
-      background-image: none;
-      -gtk-icon-shadow: none;
-    }
-  }
-
-
-  &:not(:backdrop):checked:not(.selected) {
-    border-color: $checkradio_bg_color;
-    background-image: image($checkradio_bg_color);
-    color: $checkradio_fg_color;
-  }
-
-  &:not(:backdrop):disabled:checked {
-    background-image: image(mix($checkradio_bg_color, $insensitive_bg_color, 50%));
-    border-color: mix($checkradio_bg_color, $insensitive_bg_color, 50%);
-  }
-}
-
 // upstream headerbar is not exactly perfect, thus a tiny change to the bg and border colors
 headerbar {
   &, &.titlebar:not(headerbar) {


### PR DESCRIPTION
- Which was a little bit rushed in the process of introducing Yaru 2.0 (by me! /selfslap)
- Resulting in some unstyled and transparent states and backgrounds
- We expect further modernization of checks/radios upstream instead

Closes https://github.com/ubuntu/yaru/issues/1584

New/old/unmodified upstream look:

![grafik](https://user-images.githubusercontent.com/15329494/67429124-c7328600-f5df-11e9-948a-6ab11cefb2bf.png)

![grafik](https://user-images.githubusercontent.com/15329494/67429145-d3b6de80-f5df-11e9-8477-054718fbd4a8.png)
