### PR TITLE
overwrite softlinks so install-compat can handle multiple builds

### DIFF
--- a/communitheme-compat/install-compat.sh
+++ b/communitheme-compat/install-compat.sh
@@ -13,13 +13,13 @@ install -m644 "${srcdir}/communitheme-sounds.theme" "${datadir}/sounds/communith
 
 install -m755 -d "${datadir}/themes/Communitheme"
 for file in index.theme gtk-2.0 gtk-3.0 gtk-3.20; do
-    ln -s "../Yaru/${file}" "${datadir}/themes/Communitheme/${file}"
+    ln -sfn "../Yaru/${file}" "${datadir}/themes/Communitheme/${file}"
 done
 install -m755 -d "${datadir}/themes/Communitheme-dark"
 for file in index.theme gtk-2.0 gtk-3.0 gtk-3.20; do
-    ln -s "../Yaru-dark/${file}" "${datadir}/themes/Communitheme-dark/${file}"
+    ln -sfn "../Yaru-dark/${file}" "${datadir}/themes/Communitheme-dark/${file}"
 done
 install -m755 -d "${datadir}/themes/Communitheme-light"
 for file in index.theme gtk-2.0 gtk-3.0 gtk-3.20; do
-    ln -s "../Yaru-light/${file}" "${datadir}/themes/Communitheme-light/${file}"
+    ln -sfn "../Yaru-light/${file}" "${datadir}/themes/Communitheme-light/${file}"
 done


### PR DESCRIPTION
`install-compat.sh` currently fails the second time you build Yaru because the softlinks already exist.

This PR fixed that by forcing `ln` to overwrite the existing softlinks.