### PR TITLE
shell: fix shell installation directories

### DIFF
--- a/gnome-shell/meson.build
+++ b/gnome-shell/meson.build
@@ -1,3 +1,4 @@
+gnomeshell_default_theme_dir = join_paths(get_option('datadir'), 'gnome-shell', 'theme')
 gnomeshell_alt_themes_dir = join_paths(get_option('datadir'), 'themes')
 
 subdir('src')

--- a/gnome-shell/src/install-shell.sh
+++ b/gnome-shell/src/install-shell.sh
@@ -5,5 +5,5 @@ project_name="$1"
 destdir_prefix="${MESON_INSTALL_DESTDIR_PREFIX}/share"
 install_prefix="${MESON_INSTALL_PREFIX}/share"
 
-mkdir -p "${destdir_prefix}/gnome-shell/theme/"
-ln -sf "${install_prefix}/themes/${project_name}/gnome-shell" "${destdir_prefix}/gnome-shell/theme/${project_name}"
+mkdir -p "${destdir_prefix}/themes/${project_name}"
+ln -sf "${install_prefix}/gnome-shell/theme/${project_name}" "${destdir_prefix}/themes/${project_name}/gnome-shell"

--- a/gnome-shell/src/light/meson.build
+++ b/gnome-shell/src/light/meson.build
@@ -1,5 +1,5 @@
 # destination directory
-install_dir = join_paths(gnomeshell_alt_themes_dir, meson.project_name(), 'gnome-shell')
+install_dir = join_paths(gnomeshell_default_theme_dir, meson.project_name())
 
 # generate .css files
 theme_sources = files([


### PR DESCRIPTION
Currently yaru gnome-shell theme is installed in the themes directory
/usr/share/themes/<themenane>/gnome-shell, which is where User-Themes
extension looks for 3rd party themes and a symlink is created under
/usr/share/gnome-shell/theme, where Gnome-shell looks for the session's
default theme.

Other than not being formally correct (the default theme should go into
the gnome-shell session's folder), this creates a dependency of the
gnome-shell-theme debian package from the gtk-theme package, that
creates the <themes>/Yaru folder first.

To fix the form and void adding dependency between packages (ideally,
gnome-shell could be installed without the gtk part), Yaru will be
installed under gnome-shell directory and the symlink will be created in
the themes directory, together with the installation of and Yaru-dark
shell, which is the alternative.

closes #1591 

- [ ] test deb package installation