### PR TITLE
Include shell themes in the shell Debian package, not the gtk package.

### DIFF
--- a/debian/yaru-theme-gnome-shell.install
+++ b/debian/yaru-theme-gnome-shell.install
@@ -1,1 +1,3 @@
 usr/share/gnome-shell/
+usr/share/themes/Yaru/gnome-shell
+usr/share/themes/Yaru-dark/gnome-shell/

--- a/debian/yaru-theme-gtk.install
+++ b/debian/yaru-theme-gtk.install
@@ -1,1 +1,9 @@
-usr/share/themes/
+usr/share/themes/Yaru-light/
+usr/share/themes/Yaru/gtk-2.0/
+usr/share/themes/Yaru/gtk-3.0/
+usr/share/themes/Yaru/gtk-3.20/
+usr/share/themes/Yaru/index.theme
+usr/share/themes/Yaru-dark/gtk-2.0/
+usr/share/themes/Yaru-dark/gtk-3.0/
+usr/share/themes/Yaru-dark/gtk-3.20/
+usr/share/themes/Yaru-dark/index.theme


### PR DESCRIPTION
Requires #1596

Include the dark shell theme, and the link to the light shell theme, both in the shell debian package instead of the gtk package.

Tested on Ubuntu 19.10. I initially tried leaving the light shell theme in `/usr/share/themes/Yaru/gnome-shell`, but `dpkg` complained about `/usr/share/gnome-shell/theme/Yaru/gnome-shell.css` not existing - I suppose whatever tool was at work here was not able to follow symlinks. So #1596 looks to be necessary and not just a matter of good form.