### PR TITLE
Adapt gtk2 menucolor to gtk3

### DIFF
--- a/gtk/src/default/gtk-2.0/gtkrc
+++ b/gtk/src/default/gtk-2.0/gtkrc
@@ -20,7 +20,7 @@ gtk-color-scheme = "selected_fg_color:#ffffff\nselected_bg_color:#E95420"
 # Insensitive foreground/background
 gtk-color-scheme = "insensitive_fg_color:#8b8e8f\ninsensitive_bg_color:#f1f1f1"
 # Menus
-gtk-color-scheme = "menu_color:white\nmenubar_bg:white"
+gtk-color-scheme = "menu_color:white\nmenubar_bg:#f5f6f7"
 gtk-color-scheme = "menubar_fg:#3d3d3d\nmenubar_insensitive_fg:#3d3d3d"
 # Links
 gtk-color-scheme = "link_color:#19B6EE\nvisited_link_color:#0b7196"

--- a/gtk/src/light/gtk-2.0/gtkrc
+++ b/gtk/src/light/gtk-2.0/gtkrc
@@ -20,7 +20,7 @@ gtk-color-scheme = "selected_fg_color:#ffffff\nselected_bg_color:#E95420"
 # Insensitive foreground/background
 gtk-color-scheme = "insensitive_fg_color:#8b8e8f\ninsensitive_bg_color:#f1f1f1"
 # Menus
-gtk-color-scheme = "menu_color:white\nmenubar_bg:white"
+gtk-color-scheme = "menu_color:white\nmenubar_bg:#f5f6f7"
 gtk-color-scheme = "menubar_fg:#3d3d3d\nmenubar_insensitive_fg:#3d3d3d"
 # Links
 gtk-color-scheme = "link_color:#19B6EE\nvisited_link_color:#0b7196"


### PR DESCRIPTION
Closes #1539 

![grafik](https://user-images.githubusercontent.com/15329494/67902408-679d2300-fb69-11e9-9998-cd9a9e8ea36c.png)

![grafik](https://user-images.githubusercontent.com/15329494/67902444-7c79b680-fb69-11e9-831c-d19d99360d71.png)


((( @clobrano do you think we could rather symlink the gtk2 folder from the mixed theme to the light theme or vice versa? Otherwise one needs to change both gtk2 versions )))