### PR TITLE
Darken dark theme switch border

### DIFF
--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -71,7 +71,7 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 
 //special cased widget colors
 $suggested_bg_color: $green;
-$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
+$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 40%));
 $progress_bg_color: $blue;
 $progress_border_color: $progress_bg_color;
 $checkradio_bg_color: $suggested_bg_color;


### PR DESCRIPTION
- upstream has a darker primary accent color (quiet darkish blue)

![image](https://user-images.githubusercontent.com/15329494/67962661-b0062080-fbfd-11e9-8308-605e49b960f2.png)


- our switch color is a quiet bright green
- darkening the border for the dark theme thus needs to be a bit stronger, resulting in a much less blurry and more **crisp** border

Before:
![switchkaka](https://user-images.githubusercontent.com/15329494/67962404-5867b500-fbfd-11e9-8ec8-ac4381e7bd4f.png)

After:
![switchbetter](https://user-images.githubusercontent.com/15329494/67962430-5f8ec300-fbfd-11e9-9ae2-53f7a04d0dce.png)

It's a change inside _colors.scss which we changed anyways for our needs.
It's just a change of the value, no variable was added or removed, and common was not touched.

@madsrh @clobrano @ubuntujaggers 
anyone or everyone of you please see if you like this
(tip: click the images, looking at those dark pictures in a white window is not good)