### PR TITLE
gtk2: use same color for menu in gtk2 and gtk3

### DIFF
--- a/gtk/src/dark/gtk-2.0/gtkrc
+++ b/gtk/src/dark/gtk-2.0/gtkrc
@@ -20,7 +20,7 @@ gtk-color-scheme = "selected_fg_color:#FFFFFF\nselected_bg_color:#E95420"
 # Insensitive foreground/background
 gtk-color-scheme = "insensitive_fg_color:#969696\ninsensitive_bg_color:#383838"
 # Menus
-gtk-color-scheme = "menu_color:#252525\nmenubar_bg:#2B2929"
+gtk-color-scheme = "menu_color:#252525\nmenubar_bg:#3A3A3A"
 gtk-color-scheme = "menubar_fg:#F7F7F7\nmenubar_insensitive_fg:#CCCCCC"
 # Links
 gtk-color-scheme = "link_color:#2194bd\nvisited_link_color:#c97c5b"


### PR DESCRIPTION
This PR fixes the menubar color for dark variant (I picked the color from the given picture in #1539)

closes #1539