### PR TITLE
Darken progress blue in dark themes

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -140,8 +140,8 @@ StScrollBar {
   -barlevel-height: 0.2em;
   -barlevel-background-color: transparentize($fg_color, 0.9);; //background of the trough
   -barlevel-border-color: $borders_color; //trough border color
-  -barlevel-active-background-color: if($variant == 'light', $blue, darken($blue, 4%)); //active trough fill
-  -barlevel-active-border-color: if($variant == 'light', $blue, darken($blue, 4%)); //active trough border
+  -barlevel-active-background-color: if($variant == 'light', $blue, darken($blue, 8%)); //active trough fill
+  -barlevel-active-border-color: if($variant == 'light', $blue, darken($blue, 8%)); //active trough border
   -barlevel-overdrive-color: $destructive_color;
   -barlevel-overdrive-border-color: darken($destructive_color,10%);
   -barlevel-overdrive-separator-width: 0.2em;
@@ -659,7 +659,7 @@ StScrollBar {
     height: 0.6em;
     -barlevel-height: 0.3em;
     -barlevel-background-color: transparentize($osd_fg_color, 0.9);
-    -barlevel-active-background-color: if($variant == 'light', $blue, darken($blue, 4%));
+    -barlevel-active-background-color: if($variant == 'light', $blue, darken($blue, 8%));
     -barlevel-overdrive-color: $destructive_color;
     -barlevel-overdrive-separator-width: 0.2em;
   }

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -140,8 +140,8 @@ StScrollBar {
   -barlevel-height: 0.2em;
   -barlevel-background-color: transparentize($fg_color, 0.9);; //background of the trough
   -barlevel-border-color: $borders_color; //trough border color
-  -barlevel-active-background-color: $blue; //active trough fill
-  -barlevel-active-border-color: $blue; //active trough border
+  -barlevel-active-background-color: if($variant == 'light', $blue, darken($blue, 4%)); //active trough fill
+  -barlevel-active-border-color: if($variant == 'light', $blue, darken($blue, 4%)); //active trough border
   -barlevel-overdrive-color: $destructive_color;
   -barlevel-overdrive-border-color: darken($destructive_color,10%);
   -barlevel-overdrive-separator-width: 0.2em;
@@ -659,7 +659,7 @@ StScrollBar {
     height: 0.6em;
     -barlevel-height: 0.3em;
     -barlevel-background-color: transparentize($osd_fg_color, 0.9);
-    -barlevel-active-background-color: $blue;
+    -barlevel-active-background-color: if($variant == 'light', $blue, darken($blue, 4%));
     -barlevel-overdrive-color: $destructive_color;
     -barlevel-overdrive-separator-width: 0.2em;
   }

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -72,7 +72,7 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 //special cased widget colors
 $suggested_bg_color: $green;
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 40%));
-$progress_bg_color: if($variant == 'light', $blue, darken($blue, 4%));
+$progress_bg_color: if($variant == 'light', $blue, darken($blue, 8%));
 $progress_border_color: $progress_bg_color;
 $checkradio_bg_color: $suggested_bg_color;
 $checkradio_fg_color: #ffffff;

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -72,7 +72,7 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 //special cased widget colors
 $suggested_bg_color: $green;
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 40%));
-$progress_bg_color: $blue;
+$progress_bg_color: if($variant == 'light', $blue, darken($blue, 4%));
 $progress_border_color: $progress_bg_color;
 $checkradio_bg_color: $suggested_bg_color;
 $checkradio_fg_color: #ffffff;


### PR DESCRIPTION
- $selected_bg_color darkens by 8% in the dark theme
- $progress_bg_color didn't, thus being a bit too bright in the dark themes
- darkening it also by 4% fixes this

Result is a slightly darker blue in the dark theme
![image](https://user-images.githubusercontent.com/15329494/68126171-79891800-ff13-11e9-8ec5-a5adbd6c9e7a.png)
Comparison to the light theme:
![image](https://user-images.githubusercontent.com/15329494/68126205-8c035180-ff13-11e9-87a2-c25330e42789.png)


@clobrano and/or @madsrh and/or @ubuntujaggers please see if you like this