### PR TITLE
Remove the dedicated hb styling from tweaks

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -107,15 +107,6 @@ button.titlebutton:not(.appmenu) {
   }
 }
 
-// upstream headerbar is not exactly perfect, thus a tiny change to the bg and border colors
-headerbar {
-  &, &.titlebar:not(headerbar) {
-    border-color: if($variant=='light', #c8c9ca, lighten($alt_borders_color, 8%));
-
-    @include headerbar_fill(if($variant=='light', #e7eaed, darken($bg_color, 10%)));
-  }
-}
-
 // we prefered our gray hover for menus and popovers, orange is a very strong color
 menu,
 .menu,


### PR DESCRIPTION
- this leaves room for further coloring the WHOLE toolkit via $bg_color in _colors.scss

![image_2019-11-03_18-32-32](https://user-images.githubusercontent.com/15329494/68091660-87db2380-fe82-11e9-9fb4-7d6517b91315.png)
![image_2019-11-03_18-33-24](https://user-images.githubusercontent.com/15329494/68091661-87db2380-fe82-11e9-8db1-c579ee663f30.png)
