### PR TITLE
Add symlinks for remmina - needs testing

### DIFF
--- a/icons/Suru/scalable/apps/remmina-panel.svg
+++ b/icons/Suru/scalable/apps/remmina-panel.svg
@@ -1,0 +1,1 @@
+remmina-symbolic.svg

--- a/icons/src/symlinks/symbolic/apps.list
+++ b/icons/src/symlinks/symbolic/apps.list
@@ -84,6 +84,7 @@ power-statistics-symbolic.svg org.gnome.PowerStats-symbolic.svg
 preferences-system-power-symbolic.svg gnome-power-manager-symbolic.svg
 preferences-desktop-online-accounts-symbolic.svg goa-panel-symbolic.svg
 remmina-symbolic.svg org.remmina.Remmina-symbolic.svg
+remmina-symbolic.svg remmina-panel.svg
 rhythmbox-symbolic.svg org.gnome.Rhythmbox-symbolic.svg
 root-terminal-app-symbolic.svg gksu-root-terminal-symbolic.svg
 screenshot-app-symbolic.svg applets-screenshooter-symbolic.svg


### PR DESCRIPTION
![Screenshot from 2019-11-05 14-31-09](https://user-images.githubusercontent.com/15329494/68212515-f5e62e80-ffd9-11e9-984b-49e4d537cfe5.png)

With the symlink the panel icon uses our symbolic icon... but...
We should eventually test if the "gray" means "not connected" and if the color of the panel icon changes on connection. I can't do this right now, but maybe later or @clobrano 

Closes #1329 