### PR TITLE
Fix for grey Remmina panel icon that doesn't use symlink

### DIFF
--- a/icons/Suru/scalable/apps/remmina-panel.svg
+++ b/icons/Suru/scalable/apps/remmina-panel.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   id="svg7384"
+   version="1.1"
+   width="16"
+   sodipodi:docname="remmina-panel.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     id="namedview9496"
+     showgrid="true"
+     inkscape:zoom="10.429825"
+     inkscape:cx="8.0479394"
+     inkscape:cy="8"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384">
+    <inkscape:grid
+       type="xygrid"
+       id="grid10041" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata20854">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title></dc:title>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         id="stop4528"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4"
+       osb:paint="gradient">
+      <stop
+         id="stop3602-7"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1" />
+      <stop
+         id="stop3604-6"
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <g
+     id="layer9"
+     label="status"
+     style="display:inline"
+     transform="translate(-753.00024,147)" />
+  <g
+     id="layer2"
+     style="display:inline"
+     transform="translate(-512.00004,-220)" />
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(-512.00004,-220)" />
+  <g
+     id="g1812"
+     style="display:inline"
+     transform="translate(-512.00004,-220)" />
+  <g
+     id="g6217"
+     style="display:inline"
+     transform="translate(-512.00004,-220)" />
+  <g
+     id="layer3"
+     style="display:inline"
+     transform="translate(-512.00004,-220)" />
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(-512.00004,-220)" />
+  <path
+     style="opacity:1;fill:#f5f6f7;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 8,-1e-5 a 8,8 0 0 0 -8,8 8,8 0 0 0 0.58984,3 8,8 0 0 0 0.0234,0.0508 L 2.35738,10.02345 A 6,6 0 0 1 2,7.99999 a 6,6 0 0 1 6,-6 6,6 0 0 1 4.50977,2.05273 L 14.25586,3.02538 A 8,8 0 0 0 13,1.75585 a 8,8 0 0 0 -0.004,-0.002 8,8 0 0 0 -0.47265,-0.3418 8,8 0 0 0 -0.17188,-0.125 8,8 0 0 0 -0.01,-0.006 8,8 0 0 0 -0.37305,-0.21484 8,8 0 0 0 -0.32813,-0.1875 8,8 0 0 0 -0.38867,-0.17774 8,8 0 0 0 -0.32031,-0.14453 8,8 0 0 0 -0.0117,-0.004 8,8 0 0 0 -0.49804,-0.16796 8,8 0 0 0 -0.24805,-0.084 8,8 0 0 0 -0.0117,-0.002 8,8 0 0 0 -0.41602,-0.0957 8,8 0 0 0 -0.37109,-0.082 8,8 0 0 0 -0.60156,-0.0762 8,8 0 0 0 -0.17188,-0.0215 8,8 0 0 0 -0.006,0 A 8,8 0 0 0 8,-1e-5 Z m -4,4 V 5.80077 L 6,6.99999 4,8.19921 v 0.85937 0.94141 l 5,-3 z M 15.38672,4.94921 13.64258,5.97655 A 6,6 0 0 1 14,7.99999 a 6,6 0 0 1 -6,6 6,6 0 0 1 -4.50977,-2.05273 L 1.74414,12.9746 A 8,8 0 0 0 3,14.24413 a 8,8 0 0 0 0.004,0.002 8,8 0 0 0 0.47265,0.3418 8,8 0 0 0 0.18164,0.13086 8,8 0 0 0 0.37305,0.21484 8,8 0 0 0 0.32813,0.1875 8,8 0 0 0 0.38867,0.17774 8,8 0 0 0 0.33203,0.14844 8,8 0 0 0 0.49804,0.16796 8,8 0 0 0 0.25977,0.0859 8,8 0 0 0 0.41602,0.0957 8,8 0 0 0 0.37109,0.082 8,8 0 0 0 0.60156,0.0762 8,8 0 0 0 0.17188,0.0215 8,8 0 0 0 0.006,0 A 8,8 0 0 0 8,15.99999 a 8,8 0 0 0 8,-8 8,8 0 0 0 -0.58984,-3 8,8 0 0 0 -0.0234,-0.0508 z M 12,5.99999 l -5,3 5,3 V 10.19921 L 10,8.99999 12,7.80077 V 6.9414 Z"
+     id="rect5597"
+     inkscape:connector-curvature="0" />
+</svg>


### PR DESCRIPTION
This seems to work fine:

![image](https://user-images.githubusercontent.com/38893390/68309723-be918380-00a6-11ea-9ad7-ee1253c593c7.png)

...but I notice that the symbol isn't great anyway, so I'll try to draw a clearer one for both positions when I get chance :+1: 