### PR TITLE
Four missing symbols including application-x-addon

### DIFF
--- a/icons/Suru/scalable/actions/favorite-new-symbolic.svg
+++ b/icons/Suru/scalable/actions/favorite-new-symbolic.svg
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='14.99815' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='15.013766' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-333.98643,185.99815)'/>
+  <g id='layer2' style='display:inline' transform='translate(-92.986234,-181.00185)'/>
+  <g id='layer4' style='display:inline' transform='translate(-92.986234,-181.00185)'/>
+  <g id='g1812' style='display:inline' transform='translate(-92.986234,-181.00185)'/>
+  <g id='g6217' style='display:inline' transform='translate(-92.986234,-181.00185)'/>
+  <g id='layer3' style='display:inline' transform='translate(-92.986234,-181.00185)'/>
+  <g id='g1833' style='display:inline' transform='translate(-92.986234,-181.00185)'/>
+  <g id='layer1' style='display:inline' transform='translate(-92.986234,-181.00185)'>
+    <path d='m 105,191 v 2 h -2 v 1 h 2 v 2 h 1 v -2 h 2 v -1 h -2 v -2 z' id='path5525' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00079155;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
+    <path d='m 99.996094,181.00195 -0.002,0.002 -0.002,0.002 c -0.84339,1.81 -1.494685,3.65486 -1.865235,4.78516 -1.21897,0.001 -3.227075,0.0466 -5.140625,0.29492 l 0.002,0.002 v 0.002 l 0.002,0.002 v 0.002 c 1.46077,1.36145 3.01412,2.55023 3.97461,3.25195 -0.37586,1.15956 -0.953484,3.08375 -1.308594,4.98047 h 0.002 0.002 0.002 0.002 c 1.746321,-0.96862 3.358096,-2.07875 4.322266,-2.77539 0.516664,0.37482 1.221324,0.86833 2.013674,1.38477 V 192 191.66016 c -0.52772,-0.33086 -1.09696,-0.67943 -1.42578,-0.91797 l -0.585941,-0.42578 -0.585937,0.42382 c -0.47618,0.34406 -1.39658,0.8872 -2.13086,1.36719 0.23257,-0.85452 0.458442,-1.87904 0.644532,-2.45312 l 0.222656,-0.6875 -0.583984,-0.42774 c -0.474461,-0.34663 -1.275495,-1.05353 -1.958985,-1.60351 0.88455,-0.0429 1.929633,-0.14404 2.533203,-0.14453 l 0.722656,-0.002 0.226563,-0.6875 c 0.183,-0.55818 0.608152,-1.53769 0.919922,-2.35742 0.314125,0.82774 0.733065,1.7896 0.919925,2.36328 l 0.22461,0.6875 0.72265,0.002 c 0.58798,0.002 1.65244,0.10323 2.5293,0.14648 -0.69055,0.5548 -1.47671,1.25029 -1.96484,1.60547 l -0.58594,0.42578 0.22266,0.68945 c 0.0247,0.0767 0.0613,0.24261 0.0879,0.33594 h 1.04882 c -0.0587,-0.19116 -0.13354,-0.48109 -0.18554,-0.64258 0.9857,-0.71722 2.58245,-1.93425 3.98437,-3.25976 L 107,186.0957 h -0.002 l -0.002,-0.002 v -0.002 c -1.98208,-0.24282 -3.93743,-0.29179 -5.12695,-0.29492 -0.37742,-1.15879 -1.04412,-3.05264 -1.871093,-4.79493 z' id='path5498-3' style='color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.99940681;marker:none;enable-background:accumulate'/>
+  </g>
+</svg>

--- a/icons/Suru/scalable/emblems/emblem-system-symbolic.svg
+++ b/icons/Suru/scalable/emblems/emblem-system-symbolic.svg
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.079483' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16.014648' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-533.0002,107.07949)'/>
+  <g id='layer2' style='display:inline' transform='translate(-292,-259.92051)'/>
+  <g id='layer4' style='display:inline' transform='translate(-292,-259.92051)'/>
+  <g id='g1812' style='display:inline' transform='translate(-292,-259.92051)'>
+    
+    <path d='m 300.18165,261.00391 c -2.48304,-0.0657 -4.92247,1.19408 -6.24805,3.49218 -1.9281,3.3427 -0.77551,7.62899 2.57032,9.5625 3.34581,1.93352 7.63439,0.79191 9.5625,-2.55078 1.9281,-3.34269 0.77551,-7.63289 -2.57032,-9.5664 -1.04556,-0.60423 -2.1858,-0.90763 -3.31445,-0.9375 z M 300.00001,262 a 6,6 0 0 1 6,6 6,6 0 0 1 -6,6 6,6 0 0 1 -6,-6 6,6 0 0 1 6,-6 z' id='path2788' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.66666687;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
+    <path d='m 301.32238,259.92051 -2.63222,0.39327 v 1.35335 a 6.4893367,6.4774947 43.145679 0 1 2.63222,0.005 v -1.75146 z m -5.38585,1.19061 -2.00544,1.70491 0.98801,1.17757 a 6.4893367,6.4774947 43.145679 0 1 2.01736,-1.69076 z m 8.12867,0.0127 -0.99285,1.18353 a 6.4893367,6.4774947 43.145679 0 1 0.17056,0.0905 6.4893367,6.4774947 43.145679 0 1 1.84457,1.60287 l 1.00514,-1.19769 z m -11.60999,4.21684 -0.44056,2.59535 1.51535,0.26739 a 6.4893367,6.4774947 43.145679 0 1 0.45509,-2.59274 z m 15.08573,0.003 -1.5228,0.26851 a 6.4893367,6.4774947 43.145679 0 1 0.46365,2.59088 l 1.53286,-0.27 z m -13.68247,4.69464 -1.35149,0.78058 h -3.4e-4 l 1.33101,2.27098 1.33808,-0.77238 a 6.4893367,6.4774947 43.145679 0 1 -1.31723,-2.27918 z m 12.30081,0.003 a 6.4893367,6.4774947 43.145679 0 1 -0.53478,1.21481 6.4893367,6.4774947 43.145679 0 1 -0.77388,1.0692 l 1.33883,0.77313 1.30158,-2.28811 z m -9.55687,3.47164 -0.53479,1.4688 2.47953,0.88448 0.52585,-1.44534 a 6.4893367,6.4774947 43.145679 0 1 -2.30338,-0.79995 6.4893367,6.4774947 43.145679 0 1 -0.16721,-0.10799 z m 6.8133,0.0153 a 6.4893367,6.4774947 43.145679 0 1 -2.47468,0.89752 l 0.53031,1.45651 2.46761,-0.91651 z' id='path2790' style='color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.33333337;marker:none;enable-background:accumulate'/>
+    <path d='m 299.64845,263.01367 c -1.60235,0.11249 -3.12186,0.99052 -3.98242,2.48242 -1.37689,2.38706 -0.55308,5.45342 1.83593,6.83399 2.38903,1.38058 5.45319,0.56088 6.83008,-1.82617 1.37689,-2.38706 0.55308,-5.45145 -1.83594,-6.83203 -0.89588,-0.51773 -1.88625,-0.72569 -2.84765,-0.65821 z M 300.00001,264 a 4,4 0 0 1 4,4 4,4 0 0 1 -4,4 4,4 0 0 1 -4,-4 4,4 0 0 1 4,-4 z' id='path2792' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.66666681;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
+  </g>
+  <g id='g6217' style='display:inline' transform='translate(-292,-259.92051)'/>
+  <g id='layer3' style='display:inline' transform='translate(-292,-259.92051)'/>
+  <g id='g1833' style='display:inline' transform='translate(-292,-259.92051)'/>
+  <g id='layer1' style='display:inline' transform='translate(-292,-259.92051)'/>
+</svg>

--- a/icons/Suru/scalable/mimetypes/application-x-addon-symbolic.svg
+++ b/icons/Suru/scalable/mimetypes/application-x-addon-symbolic.svg
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.000015' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-613.0002,207)'/>
+  <g id='layer2' style='display:inline' transform='translate(-372,-160)'/>
+  <g id='layer4' style='display:inline' transform='translate(-372,-160)'>
+    
+    <path d='m 379,160 c -1.76282,0 -2,1 -2,1.5 0,0.5 0,1 0.25,1.5 H 377 373 v 4 1 0.5 c 0,0 1,-0.5 2,-0.5 0.5,0 1,0.5 1,1 0,0.5 -0.5,1 -1,1 -1,0 -2,-0.5 -2,-0.5 v 0.5 1 4 h 4 1 0.5 c 0,0 -0.5,-1 -0.5,-2 0,-0.5 0.5,-1 1,-1 0.5,0 1,0.5 1,1 0,1 -0.5,2 -0.5,2 h 0.5 1 4 v -4.25 c 0.5,0.25 1,0.25 1.5,0.25 0.54612,0 1.5,-0.23269 1.5,-2 0,-1.76282 -1,-2 -1.5,-2 -0.5,0 -1,0 -1.5,0.25 V 163 h -4 -0.25 c 0.25,-0.5 0.25,-1 0.25,-1.5 0,-0.54612 -0.23269,-1.5 -2,-1.5 z m 0,1 c 0.5,0 1,0.5 1,1 0,1 -0.5,2 -0.5,2 h 0.5 v 0.0312 l 4,-0.002 V 168.5 c 0,0 1,-0.5 2,-0.5 0.5,0 1,0.5 1,1 0,0.5 -0.5,1 -1,1 -1,0 -2,-0.5 -2,-0.5 v 4.46484 h -3.23633 C 380.99648,173.47658 381,172.98827 381,172.5 c 0,-0.54612 -0.23269,-1.5 -2,-1.5 -1.76282,0 -2,1 -2,1.5 0,0.48827 0.004,0.97658 0.23633,1.46484 h -3.21289 v -3.20507 C 374.51554,170.99811 375.00789,171 375.5,171 c 0.54612,0 1.5,-0.23269 1.5,-2 0,-1.76282 -1,-2 -1.5,-2 -0.49211,0 -0.98446,0.002 -1.47656,0.24023 V 164.0332 L 378,164.03125 V 164 h 0.5 c 0,0 -0.5,-1 -0.5,-2 0,-0.5 0.5,-1 1,-1 z' id='rect9178' style='opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.88059698'/>
+  </g>
+  <g id='g1812' style='display:inline' transform='translate(-372,-160)'/>
+  <g id='g6217' style='display:inline' transform='translate(-372,-160)'/>
+  <g id='layer3' style='display:inline' transform='translate(-372,-160)'/>
+  <g id='g1833' style='display:inline' transform='translate(-372,-160)'/>
+  <g id='layer1' style='display:inline' transform='translate(-372,-160)'/>
+</svg>

--- a/icons/Suru/scalable/status/volume-warning-symbolic.svg
+++ b/icons/Suru/scalable/status/volume-warning-symbolic.svg
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-1173.0002,327)'>
+    <path class='warning' d='m 1185.4807,-317.27148 c -0.1497,0.007 -0.2866,0.0909 -0.3614,0.2207 l -3.0605,5.39648 c -0.1666,0.29121 0.043,0.65406 0.3789,0.6543 h 6.125 c 0.3355,-2.4e-4 0.5455,-0.36309 0.3789,-0.6543 l -3.0586,-5.39648 c -0.082,-0.14267 -0.238,-0.22829 -0.4023,-0.2207 z M 1185.0002,-316 h 1 v 0.16797 c 0,0.34851 -0.016,0.6673 -0.047,0.95703 -0.031,0.28973 -0.069,0.58107 -0.1152,0.875 h -0.666 c -0.052,-0.29393 -0.094,-0.58527 -0.125,-0.875 -0.031,-0.29393 -0.047,-0.61271 -0.047,-0.95703 z m 0.5,3 c 0.2761,0 0.5,0.22386 0.5,0.5 0,0.27614 -0.2239,0.5 -0.5,0.5 -0.2761,0 -0.5,-0.22386 -0.5,-0.5 0,-0.27614 0.2239,-0.5 0.5,-0.5 z' id='path2409' style='color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#fdc92b;fill-rule:evenodd;stroke:none'/>
+    
+    <path d='m 1181.0002,-325.66602 -3.5,3.66602 h -2.6289 c 0,0 -0.8711,0.89365 -0.8711,3.00195 0,2.10835 0.8711,2.99805 0.8711,2.99805 h 2.6289 l 3.5,3.66602 z m 4.6445,1.47071 -0.707,0.70703 0.3535,0.35351 c 1.1254,1.12536 1.7578,2.6507 1.7578,4.24219 0,0.51608 -0.073,1.02289 -0.2011,1.51367 l 0.664,1.17188 c 0.3508,-0.84344 0.5371,-1.75442 0.5371,-2.68555 0,-1.85632 -0.7382,-3.6366 -2.0508,-4.94922 z m -2.1211,2.12109 -0.707,0.70703 0.3535,0.35352 c 0.5628,0.56274 0.8789,1.32525 0.8789,2.12109 0,0.79584 -0.3161,1.55836 -0.8789,2.1211 l -0.3535,0.35351 0.5078,0.50781 0.9278,-1.63671 v -0.004 c 0.1653,-0.28707 0.4244,-0.49385 0.7246,-0.61133 0.045,-0.23976 0.072,-0.48318 0.072,-0.73047 0,-1.06067 -0.4219,-2.07813 -1.1719,-2.82813 z' id='path2418' style='display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:4.36363602;stroke-miterlimit:4;stroke-dasharray:none'/>
+    
+  </g>
+  <g id='layer2' style='display:inline' transform='translate(-932.00004,-40)'/>
+  <g id='layer4' style='display:inline' transform='translate(-932.00004,-40)'/>
+  <g id='g1812' style='display:inline' transform='translate(-932.00004,-40)'/>
+  <g id='g6217' style='display:inline' transform='translate(-932.00004,-40)'/>
+  <g id='layer3' style='display:inline' transform='translate(-932.00004,-40)'/>
+  <g id='g1833' style='display:inline' transform='translate(-932.00004,-40)'/>
+  <g id='layer1' style='display:inline' transform='translate(-932.00004,-40)'/>
+</svg>

--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -32,9 +32,9 @@
      inkscape:window-height="704"
      id="namedview88"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="565.29708"
-     inkscape:cy="254.38213"
+     inkscape:zoom="0.5"
+     inkscape:cx="543.03159"
+     inkscape:cy="355.1342"
      inkscape:window-x="70"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -5603,24 +5603,6 @@
          id="path7649" />
     </g>
     <g
-       id="g14519"
-       inkscape:label="application-x-addon">
-      <path
-         sodipodi:nodetypes="ssssssssssccccccccccccc"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 384.79792,173.80393 c 2.93211,-2.93212 2.93211,-7.66974 0,-10.60185 -2.9321,-2.9321 -7.66974,-2.9321 -10.60184,0 -2.9321,2.93211 -2.9321,7.66974 0,10.60185 2.9321,2.9321 7.66974,2.9321 10.60184,0 z m -0.75727,-0.75728 c -2.50939,2.50938 -6.5779,2.50938 -9.08729,0 -2.50938,-2.5094 -2.50938,-6.57791 0,-9.08729 2.50939,-2.50938 6.5779,-2.50938 9.08729,0 2.50938,2.50939 2.50938,6.5779 0,9.08729 z M 383,169 v -1 h -3 v -3 h -1 v 3 h -3 v 1.07095 L 379,169 v 3 h 1 v -3 z"
-         id="path2911-0"
-         inkscape:connector-curvature="0" />
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920917;marker:none;enable-background:accumulate"
-         id="rect5082-2"
-         width="16"
-         height="16"
-         x="160.00002"
-         y="-388"
-         transform="rotate(90)" />
-    </g>
-    <g
        transform="translate(-220,-300)"
        style="display:inline"
        id="g6905"
@@ -5763,6 +5745,27 @@
            inkscape:connector-curvature="0" />
       </g>
     </g>
+    <g
+       id="g9404"
+       inkscape:label="application-x-addon">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920917;marker:none;enable-background:accumulate"
+         id="rect5082-2"
+         width="16"
+         height="16"
+         x="160.00002"
+         y="-388"
+         transform="rotate(90)" />
+      <path
+         id="rect9178"
+         d="M 379 160 C 377.23718 160 377 161 377 161.5 C 377 162 377 162.5 377.25 163 L 377 163 L 373 163 L 373 167 L 373 168 L 373 168.5 C 373 168.5 374 168 375 168 C 375.5 168 376 168.5 376 169 C 376 169.5 375.5 170 375 170 C 374 170 373 169.5 373 169.5 L 373 170 L 373 171 L 373 175 L 377 175 L 378 175 L 378.5 175 C 378.5 175 378 174 378 173 C 378 172.5 378.5 172 379 172 C 379.5 172 380 172.5 380 173 C 380 174 379.5 175 379.5 175 L 380 175 L 381 175 L 385 175 L 385 170.75 C 385.5 171 386 171 386.5 171 C 387.04612 171 388 170.76731 388 169 C 388 167.23718 387 167 386.5 167 C 386 167 385.5 167 385 167.25 L 385 163 L 381 163 L 380.75 163 C 381 162.5 381 162 381 161.5 C 381 160.95388 380.76731 160 379 160 z M 379 161 C 379.5 161 380 161.5 380 162 C 380 163 379.5 164 379.5 164 L 380 164 L 380 164.03125 L 384 164.0293 L 384 168.5 C 384 168.5 385 168 386 168 C 386.5 168 387 168.5 387 169 C 387 169.5 386.5 170 386 170 C 385 170 384 169.5 384 169.5 L 384 173.96484 L 380.76367 173.96484 C 380.99648 173.47658 381 172.98827 381 172.5 C 381 171.95388 380.76731 171 379 171 C 377.23718 171 377 172 377 172.5 C 377 172.98827 377.00352 173.47658 377.23633 173.96484 L 374.02344 173.96484 L 374.02344 170.75977 C 374.51554 170.99811 375.00789 171 375.5 171 C 376.04612 171 377 170.76731 377 169 C 377 167.23718 376 167 375.5 167 C 375.00789 167 374.51554 167.00189 374.02344 167.24023 L 374.02344 164.0332 L 378 164.03125 L 378 164 L 378.5 164 C 378.5 164 378 163 378 162 C 378 161.5 378.5 161 379 161 z "
+         style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.88059698" />
+    </g>
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.88059698"
+       d="m 37.000005,161.8409 c 0.0563,0.63849 0.70217,1.00368 1.07337,1.46106 0.0504,0.29176 -0.17818,0.72957 0.0525,0.93403 0.6373,-0.0241 1.29641,0.048 1.92016,-0.036 0.0902,-0.34949 -0.22831,-0.80601 0.16486,-1.04226 0.34797,-0.42923 0.92087,-0.83249 0.91351,-1.43458 -0.33704,-1.28644 -2.0768,-2.00092 -3.19543,-1.20744 -0.44712,0.30238 -0.93207,0.74917 -0.92896,1.32519 z"
+       id="path9266-5-3"
+       inkscape:connector-curvature="0" />
   </g>
   <g
      style="display:inline"
@@ -7247,25 +7250,6 @@
       </g>
     </g>
     <g
-       transform="translate(-79.99996,240)"
-       style="display:inline"
-       id="g3608-1"
-       inkscape:label="applications-graphics">
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 615.99414,222 c -1.2582,0.0145 -2.17889,-0.0306 -2.93164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 C 612.05994,223.82148 612,224.34239 612,225 v 7 c 0,0.65761 0.0599,1.17853 0.22461,1.61719 0.16467,0.43866 0.46152,0.79039 0.83789,0.99804 0.75275,0.41532 1.67345,0.3702 2.93164,0.38477 h 0.004 8.0039 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37637,-0.20766 0.67322,-0.55938 0.83789,-0.99804 C 627.93952,233.17852 628,232.65761 628,232 v -7 c 0,-0.65761 -0.0599,-1.17852 -0.22461,-1.61719 -0.16466,-0.43866 -0.46152,-0.79038 -0.83789,-0.99804 -0.75275,-0.41534 -1.67344,-0.37025 -2.93164,-0.38477 h -0.004 -8.0039 z m 2.90234,1.0918 c 1.74896,-0.004 3.49727,-0.001 5.2461,0.0215 0.86117,0.14671 2.16104,-0.34154 2.67383,0.66797 0.25574,2.92399 0.0694,5.88197 0.1289,8.81836 -0.0871,0.38019 -0.18482,1.14361 -0.73047,1.12891 -3.53641,0.23538 -7.09146,0.10846 -10.63476,0.13476 -0.78646,-0.11198 -1.99991,0.2903 -2.4043,-0.6914 -0.1705,-2.4656 -0.0888,-4.94964 -0.0898,-7.43555 0.12175,-0.84105 -0.29598,-2.06451 0.6875,-2.51172 1.6892,-0.21162 3.40839,-0.0775 5.12304,-0.13281 z M 625,224 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 z m -5,1 c -2.216,0 -4,1.784 -4,4 0,2.216 1.784,4 4,4 2.216,0 4,-1.784 4,-4 0,-2.216 -1.784,-4 -4,-4 z m 0,1 c 1.662,0 3,1.338 3,3 0,1.662 -1.338,3 -3,3 -1.662,0 -3,-1.338 -3,-3 0,-1.662 1.338,-3 3,-3 z"
-         id="path1817-7-8"
-         inkscape:connector-curvature="0" />
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.66653478;marker:none;enable-background:accumulate"
-         id="rect1819-4-7"
-         width="16"
-         height="15.999999"
-         x="219.99994"
-         y="-628"
-         transform="rotate(90)" />
-    </g>
-    <g
        transform="translate(240,380)"
        style="display:inline"
        id="g2540-0"
@@ -7357,6 +7341,37 @@
            d="m 637.23966,470.10483 c -0.39616,0.81476 -0.8234,1.61568 -1.1814,2.44824 0.0157,0.22101 0.0951,0.42162 0.36097,0.34558 2.24872,0.0833 4.5576,0.0452 6.81005,0.0165 0.22666,-0.0498 0.70118,0.13229 0.68872,-0.26758 0.004,-0.40578 -0.34814,-0.75739 -0.48025,-1.14216 -0.58319,-1.17243 -1.16627,-2.34491 -1.74936,-3.51738 -1.132,0 -2.264,0 -3.396,0 -0.35091,0.70561 -0.70182,1.41121 -1.05273,2.11682 z"
            inkscape:connector-curvature="0" />
       </g>
+    </g>
+    <g
+       inkscape:label="applications-graphics"
+       id="g7667-7"
+       style="display:inline;stroke-width:6"
+       transform="matrix(0,-0.16660075,-0.16666667,0,605.56037,532.97154)">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:24;marker:none;enable-background:accumulate"
+         id="rect7659-0"
+         width="96.037987"
+         height="96"
+         x="-438.00244"
+         y="345.36221"
+         transform="scale(-1,1)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7661-9"
+         d="m 419.99535,372.36221 c 0,4.97056 -4.03102,9 -9.00357,9 -4.97253,0 -9.00357,-4.02944 -9.00357,-9 0,-4.97056 4.03104,-9 9.00357,-9 4.97255,0 9.00357,4.02943 9.00357,9 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:36;marker:none;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         id="path7663-3"
+         d="m 432.0001,435.36221 h -84.03324 v -84 h 84.03324 z m -6.0024,-5.99999 v -72 h -60.02374 v 72 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:24;marker:none;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="ccccccc"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:36;marker:none;enable-background:accumulate"
+         d="m 404.98941,405.36221 -33.01305,18 v -16.30902 -31.69098 l 27.01068,15 -9.00356,6 z"
+         id="path7665-6"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
   <g
@@ -10116,35 +10131,6 @@
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          inkscape:connector-curvature="0" />
     </g>
-    <g
-       id="layer9-6"
-       label="status"
-       style="display:inline"
-       transform="translate(-201.00024,487)" />
-    <g
-       id="layer2-2"
-       style="display:inline"
-       transform="translate(39.99996,120)" />
-    <g
-       id="layer4-6"
-       style="display:inline"
-       transform="translate(39.99996,120)" />
-    <g
-       id="g1812-1"
-       style="display:inline"
-       transform="translate(39.99996,120)" />
-    <g
-       id="g6217-8"
-       style="display:inline"
-       transform="translate(39.99996,120)" />
-    <g
-       id="layer3-7"
-       style="display:inline"
-       transform="translate(39.99996,120)" />
-    <g
-       id="layer1-9"
-       style="display:inline"
-       transform="translate(39.99996,120)" />
     <g
        id="g3570"
        inkscape:label="evince">


### PR DESCRIPTION
While I was editing source-symbolic, I took the opportunity to export four symbols that were exporting but had been missed for some reason (possibly because they were untracked).  Closes #1608 .

favorite-new-symbolic:

![image](https://user-images.githubusercontent.com/38893390/68755365-4ecc4d00-0600-11ea-96b4-c8e37e53edd4.png)

emblem-system-symbolic:

![image](https://user-images.githubusercontent.com/38893390/68755405-5986e200-0600-11ea-8594-5d0d59a03c7d.png)

application-x-addon-symbolic:

![image](https://user-images.githubusercontent.com/38893390/68755429-63104a00-0600-11ea-9a86-7ce2517de7bd.png)

volume-warning-symbolic:

![image](https://user-images.githubusercontent.com/38893390/68755471-702d3900-0600-11ea-8e96-53b5cd8df50f.png)
