### PR TITLE
script: Add sync script for Nautilus

### DIFF
--- a/gtk/upstream/nautilus/Adwaita.css
+++ b/gtk/upstream/nautilus/Adwaita.css
@@ -1,0 +1,219 @@
+.nautilus-window,
+.nautilus-window notebook,
+.nautilus-window notebook > stack {
+    background: @theme_base_color;
+}
+
+.nautilus-canvas-item {
+    border-radius: 5px;
+}
+
+.nautilus-canvas-item.dim-label,
+.nautilus-list-dim-label {
+    color: mix (@theme_fg_color, @theme_bg_color, 0.50);
+}
+
+.nautilus-canvas-item.dim-label:selected,
+.nautilus-list-dim-label:selected {
+    color: mix (@theme_selected_fg_color, @theme_selected_bg_color, 0.20);
+}
+
+/* Toolbar */
+
+/* Here we use the .button background-image colors from Adwaita, but ligthen them,
+ * since is not possible to use lighten () in common css. */
+@keyframes needs_attention_keyframes {
+    0% {background-image: linear-gradient(to bottom, #fafafa, #ededed 40%,  #e0e0e0); border-color: @borders; }
+    /* can't do animation-direction, so holding the color on two keyframes */
+    30% {background-image: linear-gradient(to bottom, @theme_base_color, @theme_base_color, @theme_base_color); border-color: @theme_fg_color; }
+    90% {background-image: linear-gradient(to bottom, @theme_base_color, @theme_base_color, @theme_base_color); border-color: @theme_fg_color; }
+    100% {background-image: linear-gradient(to bottom, #fafafa, #ededed 40%,  #e0e0e0); border-color: @borders; }
+}
+
+.nautilus-operations-button-needs-attention {
+  animation: needs_attention_keyframes 2s ease-in-out;
+}
+.nautilus-operations-button-needs-attention-multiple {
+  animation: needs_attention_keyframes 3s ease-in-out;
+  animation-iteration-count: 3;
+}
+
+.disclosure-button {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+/* Path bar */
+
+.nautilus-path-bar button { /* undecorate the buttons */
+  margin: 0px;
+}
+
+.nautilus-path-bar button:not(:checked) image { opacity: 0.8; } /* dim the icon when not checked */
+
+.path-bar-box {
+  transition: border 200ms;
+  transition: background-color 200ms;
+  border-radius: 5px;
+}
+
+.path-bar-box.width-maximized {
+  border: 1px @borders solid;
+  background-color: @theme_bg_color;
+}
+
+.path-bar-box.width-maximized button:first-child {
+    border-radius: 5px 0px 0px 5px;
+    border-width: 0px 1px 0px 0px;
+}
+
+.path-bar-box.width-maximized button:not(:first-child) {
+    border-width: 0px 1px 0px 1px;
+    border-radius: 0px 0px 0px 0px;
+}
+
+/* Make the tags fit into the box */
+entry.search > * {
+  margin: 5px;
+}
+
+/* Sidebar */
+
+.nautilus-window .sidebar-row:selected {
+    background: mix(@theme_bg_color, @theme_fg_color, 0.07);
+}
+
+.nautilus-window .sidebar-row:selected,
+.nautilus-window .sidebar-row:selected image,
+.nautilus-window .sidebar-row:selected label {
+    color: mix(@theme_fg_color, @theme_text_color, 0.5);
+}
+
+.nautilus-window .sidebar-row:selected:backdrop {
+    background: mix(@theme_unfocused_bg_color, @theme_unfocused_fg_color, 0.07);
+}
+
+.nautilus-window .sidebar-row:selected:backdrop,
+.nautilus-window .sidebar-row:selected:backdrop label {
+    color: mix(@theme_unfocused_fg_color, @theme_unfocused_text_color, 0.15);
+}
+
+/* Floating status bar */
+.floating-bar {
+  padding: 1px;
+  background-color: @theme_base_color;
+  border-width: 1px;
+  border-style: solid solid none;
+  border-color: @borders;
+  border-radius: 3px 3px 0 0;
+}
+
+.floating-bar.bottom.left { /* axes left border and border radius */
+  border-left-style: none;
+  border-top-left-radius: 0;
+}
+.floating-bar.bottom.right { /* axes right border and border radius */
+  border-right-style: none;
+  border-top-right-radius: 0;
+}
+
+.floating-bar:backdrop {
+  background-color: @theme_unfocused_base_color;
+  border-color: @unfocused_borders;
+}
+
+.floating-bar button {
+  padding: 0px;
+}
+
+@define-color disk_space_unknown #888a85;
+@define-color disk_space_used #729fcf;
+@define-color disk_space_free #eeeeec;
+
+.disk-space-display {
+    border-style: solid;
+    border-width: 2px;
+}
+
+.disk-space-display.unknown {
+    background-color: @disk_space_unknown;
+    border-color: shade(@disk_space_unknown, 0.7);
+    color: @disk_space_unknown;
+}
+.disk-space-display.unknown.border {
+    color: shade(@disk_space_unknown, 0.7);
+}
+
+.disk-space-display.used {
+    background-color: @disk_space_used;
+    border-color: shade(@disk_space_used, 0.7);
+    color: @disk_space_used;
+}
+.disk-space-display.used.border {
+    color: shade(@disk_space_used, 0.7);
+}
+
+.disk-space-display.free {
+    background-color: @disk_space_free;
+    border-color: shade(@disk_space_free, 0.7);
+    color: @disk_space_free;
+}
+.disk-space-display.free.border {
+    color: shade(@disk_space_free, 0.7);
+}
+
+/* View */
+.nautilus-list-view .view {
+    border-bottom: 1px solid @theme_bg_color;
+}
+
+.search-information {
+  background-color: @theme_selected_bg_color;
+  color:white;
+  padding:2px;
+}
+
+/* Hide superfluous treeview drop target indication */
+.nautilus-list-view .view.dnd {
+    border-style: none;
+}
+
+@define-color conflict_bg #fef6b6;
+
+.conflict-row {
+    background: @conflict_bg;
+    color: black;
+}
+
+.conflict-row:hover {
+    background-color: shade(@conflict_bg, 0.9);
+}
+
+.conflict-row:selected {
+  background: @theme_selected_bg_color;
+  color: @theme_selected_fg_color;
+}
+
+/* Icon view */
+flowboxchild:selected {
+  background-color:transparent;
+}
+
+.icon-background {
+  background-color:black;
+  border-color:#4a90d9;
+  border-style:solid;
+  border-width:0px;
+}
+
+flowboxchild > .icon-item-background {
+  padding:4px;
+}
+flowboxchild:selected > .icon-item-background {
+  padding:4px;
+  background-color:#4a90d9;
+  border-color:#4a90d9;
+  border-style:solid;
+  border-width:0px;
+  border-radius:4px 4px 4px 4px;
+}

--- a/gtk/upstream/nautilus/nautilus-custom-css.sync
+++ b/gtk/upstream/nautilus/nautilus-custom-css.sync
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# -*- coding: UTF-8 -*-
+## Helper script to sync custom css that Nautilus uses for Adwaita only
+## usage:
+##
+##      nautilus-custom-css.sh --destination <path>
+##
+## options:
+##    -d, --destination <path>    Destination folder - [default:.]
+# CLInt GENERATED_CODE: start
+# Default values
+_destination=.
+
+# Converting long-options into short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+"--destination") set -- "$@" "-d";;
+  *) set -- "$@" "$arg"
+  esac
+done
+
+function print_illegal() {
+    echo Unexpected flag in command line \"$@\"
+}
+
+# Parsing flags and arguments
+while getopts 'hd:' OPT; do
+    case $OPT in
+        h) sed -ne 's/^## \(.*\)/\1/p' $0
+           exit 1 ;;
+        d) _destination=$OPTARG ;;
+        \?) print_illegal $@ >&2;
+            echo "---"
+            sed -ne 's/^## \(.*\)/\1/p' $0
+            exit 1
+            ;;
+    esac
+done
+# CLInt GENERATED_CODE: end
+
+wget_check=`which wget | wc -l`
+[ $wget_check == 0 ] && echo "install wget" && exit 1
+
+css=https://gitlab.gnome.org/GNOME/nautilus/raw/master/src/resources/css/Adwaita.css
+
+[ ! -d ${_destination} ] && echo ${_destination} folder does not exists && exit 1
+
+wget ${css} -O ${_destination}/Adwaita.css


### PR DESCRIPTION
Nautilus uses a custom CSS specifically for Adwaita with some modification
that Yaru needs as well. To make it easier to look for changes, this
commit adds a script that download such css from Nautilus repo.

Also adding current version of Nautilus' css (Adwaita.css) for future
comparison.