### PR TITLE
Remove text and iconshadows for headerbar and buttons

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -13,14 +13,10 @@ $_titlebutton_height: 24px;
                                   to(transparent));
 }
 
-// with a flatter headerbar and buttons, we dont need that heavy shadows in the headerbar
-headerbar * {
+// with a flatter headerbar and buttons, we dont need that heavy shadows, remove this when upstream agrees
+headerbar *, button * {
   text-shadow: none;
   -gtk-icon-shadow: none;
-}
-// same for the rest of the theme, but not axe the icon shadows, otherwise things don't work
-* {
-  text-shadow: none;
 }
 
 // blue spinner


### PR DESCRIPTION
They are actually already gone for the headerbar buttons.
I think I used the wildcard wrong, this should be the correct way of removing them.

+ Removing also the icon shadows since we already have icon shadows for full color icons (they dont have that shadows in icon upstream)