### PR TITLE
[HOLD] apps: increase difference between gnome-weather buttons

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -528,7 +528,7 @@ UnityDecoration {
   -UnityDecoration-title-indent: 0px;
   -UnityDecoration-title-fade: 0px;
   -UnityDecoration-title-alignment: 0;
-  
+
   // Unity "titlebars"
   .top {
     border: none;
@@ -571,7 +571,7 @@ UnityPanelWidget, .unity-panel {
     border-width: 0 1px;
     color: $panel_fg_color;
     background-color: transparent;
-    
+
     &:hover, *:hover {
       box-shadow: inset 0 -2px 0 0 $selected_bg_color;
       background-color: transparent;

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -412,6 +412,18 @@ terminal-window {
   //removes the black background for picture tiles
   .documents-scrolledwin.frame.frame widget flowboxchild.tile { background-color: transparent; }
 
+
+/****************
+* GNOME Weather *
+*****************/
+
+#weather-page-content-view button.radio.text-button {
+  background-image: none;
+  background-color: $bg_color;
+  &:hover { background-color: lighten($jet, 20%); }
+  &:checked { background-color: $jet; }
+}
+
   /***********
    * Firefox *
    ***********/


### PR DESCRIPTION
Currently it is hard to differentiate between checked and unchecked
buttons in gnome weather, since the (dark) colors are very similar. In a
previous Yaru version, this app was customized for this very same
reason.

Adding back button customization in apps scss file, using the same logic
Yaru dark buttons have (darker means checked, lighter means unchecked),
forcing the colors a little bit, since the bright color around the
buttons (if the weather is clear, the background is blue sky).

closes LP:1807508

Before
![image](https://user-images.githubusercontent.com/2883614/70528345-49561a00-1b4e-11ea-9e95-fc469b0a8b1a.png)

After
![image](https://user-images.githubusercontent.com/2883614/70525910-ad75df80-1b48-11ea-9237-1d5ff34f48d8.png)
