### PR TITLE
Icon theme: improvements to categories

### DIFF
--- a/icons/Suru/scalable/categories/applications-graphics-symbolic.svg
+++ b/icons/Suru/scalable/categories/applications-graphics-symbolic.svg
@@ -1,35 +1,70 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata20854'>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg10"
+   sodipodi:docname="applications-graphics-symbolic.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata16">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:title/>
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient4526' osb:paint='solid'>
-      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
-      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
-      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
-    </linearGradient>
-  </defs>
-  <g id='layer9' label='status' style='display:inline' transform='translate(-773.00024,-92.999939)'/>
-  <g id='layer2' style='display:inline' transform='translate(-532.00004,-459.99994)'/>
-  <g id='layer4' style='display:inline' transform='translate(-532.00004,-459.99994)'/>
-  <g id='g1812' style='display:inline' transform='translate(-532.00004,-459.99994)'/>
-  <g id='g6217' style='display:inline' transform='translate(-532.00004,-459.99994)'/>
-  <g id='layer3' style='display:inline' transform='translate(-532.00004,-459.99994)'>
-    <path d='m 535.99418,462 c -1.2582,0.0145 -2.17889,-0.0306 -2.93164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 -0.16467,0.43867 -0.22461,0.95958 -0.22461,1.61719 v 7 c 0,0.65761 0.0599,1.17853 0.22461,1.61719 0.16467,0.43866 0.46152,0.79039 0.83789,0.99804 0.75275,0.41532 1.67345,0.3702 2.93164,0.38477 h 0.004 8.0039 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37637,-0.20766 0.67322,-0.55938 0.83789,-0.99804 0.16395,-0.43867 0.22443,-0.95958 0.22443,-1.61719 v -7 c 0,-0.65761 -0.0599,-1.17852 -0.22461,-1.61719 -0.16466,-0.43866 -0.46152,-0.79038 -0.83789,-0.99804 -0.75275,-0.41534 -1.67344,-0.37025 -2.93164,-0.38477 h -0.004 -8.0039 z m 2.90234,1.0918 c 1.74896,-0.004 3.49727,-10e-4 5.2461,0.0215 0.86117,0.14671 2.16104,-0.34154 2.67383,0.66797 0.25574,2.92399 0.0694,5.88197 0.1289,8.81836 -0.0871,0.38019 -0.18482,1.14361 -0.73047,1.12891 -3.53641,0.23538 -7.09146,0.10846 -10.63476,0.13476 -0.78646,-0.11198 -1.99991,0.2903 -2.4043,-0.6914 -0.1705,-2.4656 -0.0888,-4.94964 -0.0898,-7.43555 0.12175,-0.84105 -0.29598,-2.06451 0.6875,-2.51172 1.6892,-0.21162 3.40839,-0.0775 5.12304,-0.13281 z M 545.00004,464 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 z m -5,1 c -2.216,0 -4,1.784 -4,4 0,2.216 1.784,4 4,4 2.216,0 4,-1.784 4,-4 0,-2.216 -1.784,-4 -4,-4 z m 0,1 c 1.662,0 3,1.338 3,3 0,1.662 -1.338,3 -3,3 -1.662,0 -3,-1.338 -3,-3 0,-1.662 1.338,-3 3,-3 z' id='path1817-7-8' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
-    
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="784"
+     inkscape:window-height="480"
+     id="namedview12"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg10" />
+  <g
+     color="#000"
+     fill="gray"
+     id="g8">
+    <path
+       d="M11.5 3a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"
+       overflow="visible"
+       style="marker:none"
+       id="path2" />
+    <path
+       d="M1 1v14h14V1zm1 1h12v10H2z"
+       overflow="visible"
+       style="marker:none"
+       id="path4" />
+    <path
+       d="M6 5.5L3 11h8L8.5 6.5 7.5 8z"
+       overflow="visible"
+       style="marker:none"
+       id="path6" />
   </g>
-  <g id='g1833' style='display:inline' transform='translate(-532.00004,-459.99994)'/>
-  <g id='layer1' style='display:inline' transform='translate(-532.00004,-459.99994)'/>
 </svg>

--- a/icons/Suru/scalable/categories/applications-utilities-symbolic.svg
+++ b/icons/Suru/scalable/categories/applications-utilities-symbolic.svg
@@ -1,36 +1,123 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata20854'>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   id="svg7384"
+   version="1.1"
+   width="16"
+   sodipodi:docname="applications-utilities-symbolic.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     id="namedview8927"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-4.4067797"
+     inkscape:cy="8"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata20854">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:title/>
+      <cc:Work
+         rdf:about="">
+        <dc:title></dc:title>
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient id='linearGradient4526' osb:paint='solid'>
-      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         id="stop4528"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
-      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
-      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    <linearGradient
+       id="linearGradient3600-4"
+       osb:paint="gradient">
+      <stop
+         id="stop3602-7"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1" />
+      <stop
+         id="stop3604-6"
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1" />
     </linearGradient>
   </defs>
-  <g id='layer9' label='status' style='display:inline' transform='translate(-813.0002,-93)'/>
-  <g id='layer2' style='display:inline' transform='translate(-572,-460)'/>
-  <g id='layer4' style='display:inline' transform='translate(-572,-460)'/>
-  <g id='g1812' style='display:inline' transform='translate(-572,-460)'/>
-  <g id='g6217' style='display:inline' transform='translate(-572,-460)'/>
-  <g id='layer3' style='display:inline' transform='translate(-572,-460)'>
-    
-    <path d='m 583,476 -0.47852,-0.92188 c -0.51103,-0.98528 -0.88042,-1.94206 -1.12695,-2.66601 -0.24655,-0.72395 -0.35422,-1.1466 -0.38281,-1.27149 L 581,471.08398 V 461 c 0,0 0,-1 1,-1 h 2 c 0,0 1,0 1,1 v 10.08398 l -0.0117,0.0566 c -0.0281,0.12211 -0.13628,0.54745 -0.38281,1.27149 -0.24654,0.72403 -0.6165,1.68142 -1.12695,2.66601 z m -0.20898,-3.04297 h 0.41601 c 0.13936,-0.31482 0.29412,-0.64939 0.37695,-0.89258 C 583.8091,471.40325 584.00085,470.99332 584,471 h -2 c -0.002,-0.009 0.18894,0.40341 0.41406,1.06445 0.0829,0.24312 0.2376,0.57775 0.37696,0.89258 z M 582,463 h 2 v -2 h -2 z' id='path2428-2' style='font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.26892218'/>
-    <path d='m 575,460 v 0.5 14.5 h 5 v -12 -1 -2 z m 1,1 h 3 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -3 z' id='rect2452-6' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
-  </g>
-  <g id='g1833' style='display:inline' transform='translate(-572,-460)'/>
-  <g id='layer1' style='display:inline' transform='translate(-572,-460)'/>
+  <g
+     id="layer9"
+     label="status"
+     style="display:inline"
+     transform="translate(-773.00024,-92.999939)" />
+  <g
+     id="layer2"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="g1812"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="g6217"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="g1833"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <path
+     style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 3.99215,0 C 3.94195,0 3.89645,0.015 3.84762,0.0195 4.06253,0.0165 4.20489,0.0033 4.4941,0 Z M 4.50582,0 C 5.76402,0.0145 6.18471,-0.0306 6.93746,0.38477 7.31383,0.59243 7.61069,0.94415 7.77535,1.38281 7.94006,1.82148 7.99996,2.34239 7.99996,3 v 1 h 3 V 3.75391 c 0,-1.10799 0.446,-1.75391 1,-1.75391 0.554,0 1,0.64592 1,1.75391 V 4 c 1.108,0 2,-1.392 2,-2.5 0,-1.108 -0.892,-1.5 -2,-1.5 z"
+     id="rect6717"
+     inkscape:connector-curvature="0" />
+  <path
+     id="path1817-9-6-6"
+     d="M 4.4941,0 C 3.2359,0.0145 2.81521,-0.0306 2.06246,0.38477 1.68609,0.59243 1.38923,0.94415 1.22457,1.38281 1.0599,1.82148 0.99996,2.34239 0.99996,3 v 10 c 0,0.65761 0.0599,1.17858 0.22461,1.61719 0.16468,0.43861 0.46153,0.78852 0.83789,0.99609 C 2.81518,16.02841 2.736,15.98493 3.9941,16 h 0.002 0.50391 0.50391 0.002 C 6.26402,15.9849 6.18484,16.0284 6.93756,15.61328 7.31392,15.40571 7.61077,15.0558 7.77545,14.61719 7.93996,14.17858 7.99996,13.65761 7.99996,13 V 3 C 7.99996,2.34239 7.94006,1.82148 7.77535,1.38281 7.61069,0.94415 7.31383,0.59243 6.93746,0.38477 6.18471,-0.0306 5.76402,0.0145 4.50582,0 h -0.004 -0.002 -0.002 z m 0.006,1 C 5.75863,1.0147 6.08922,1.0598 6.45518,1.26172 6.63859,1.36291 6.74234,1.47447 6.83994,1.73438 6.93722,1.99425 6.99996,2.40761 6.99996,3 v 10 c 0,0.59239 -0.0628,1.0058 -0.16016,1.26562 -0.0975,0.25982 -0.20134,0.3715 -0.38476,0.47266 C 6.08906,14.9401 6.25859,14.9848 4.99996,15 h -0.006 -0.494 -0.49414 -0.0059 C 2.74133,14.9848 2.91086,14.9401 2.54488,14.73828 2.36146,14.63712 2.25766,14.52543 2.16012,14.26562 2.06274,14.0058 1.99996,13.59239 1.99996,13 V 3 c 0,-0.59239 0.0626,-1.00576 0.16016,-1.26562 C 2.25772,1.47447 2.36147,1.36291 2.54488,1.26172 2.91084,1.0598 3.24143,1.0147 4.49996,1 Z m 0,1 a 1.5,1.5 0 0 0 -1.5,1.5 1.5,1.5 0 0 0 1.5,1.5 1.5,1.5 0 0 0 1.5,-1.5 1.5,1.5 0 0 0 -1.5,-1.5 z m 0,1 a 0.5,0.5 0 0 1 0.5,0.5 0.5,0.5 0 0 1 -0.5,0.5 0.5,0.5 0 0 1 -0.5,-0.5 0.5,0.5 0 0 1 0.5,-0.5 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 8 5 L 8 9 C 9 9.5 11.10545 11.35059 14 12 C 13.08695 8.50878 10.5 6.5 8 5 z M 10.5 8 C 10.77614 8 11.19653 8.47678 11.375 8.6875 C 12.63024 10.92878 10.8237 9.22427 10 8.5 C 10 8.22386 10.22386 8 10.5 8 z "
+     id="rect6767" />
 </svg>

--- a/icons/Suru/scalable/categories/preferences-other-symbolic.svg
+++ b/icons/Suru/scalable/categories/preferences-other-symbolic.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   id="svg7384"
+   version="1.1"
+   width="16"
+   sodipodi:docname="preferences-other-symbolic.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     id="namedview8927"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata20854">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title></dc:title>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         id="stop4528"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4"
+       osb:paint="gradient">
+      <stop
+         id="stop3602-7"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1" />
+      <stop
+         id="stop3604-6"
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <g
+     id="layer9"
+     label="status"
+     style="display:inline"
+     transform="translate(-773.00024,-92.999939)" />
+  <g
+     id="layer2"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="g1812"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="g6217"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="g1833"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(-532.00004,-459.99994)" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.99539447;marker:none;enable-background:accumulate"
+     d="M 12.447266 0.08984375 C 10.535936 0.08984375 8.9863281 1.6349256 8.9863281 3.5410156 C 8.9863281 3.9364715 9.0780571 4.3199797 9.2011719 4.6738281 L 4.6914062 9.1816406 C 4.3344963 9.0575406 3.9481581 8.9648438 3.5488281 8.9648438 C 1.6374981 8.9648437 0.087890625 10.509936 0.087890625 12.416016 C 0.087890625 12.780216 0.1685875 13.135264 0.2734375 13.464844 L 2.2207031 11.523438 C 2.4143731 11.330287 2.6788906 11.214844 2.9316406 11.214844 C 3.1844006 11.214844 3.4488981 11.330288 3.6425781 11.523438 L 4.3222656 12.201172 C 4.7096156 12.587472 4.7096156 13.232851 4.3222656 13.619141 L 2.3125 15.621094 C 2.69488 15.766214 3.1153681 15.867188 3.5488281 15.867188 C 4.8844504 15.867188 6.0304565 15.104955 6.6074219 14 L 6 14 C 5.446 14 5 13.554 5 13 L 5 11 C 5 10.446 5.446 10 6 10 L 8.0703125 10 L 10.123047 7.9492188 C 10.125622 7.9492431 10.128284 7.9491863 10.130859 7.9492188 L 11.304688 6.7773438 C 11.661587 6.9014438 12.047936 6.9921875 12.447266 6.9921875 C 14.358596 6.9921875 15.908203 5.4470956 15.908203 3.5410156 C 15.908203 3.1427756 15.817799 2.7582538 15.693359 2.4023438 L 13.808594 4.28125 C 13.421244 4.66753 12.805309 4.66753 12.417969 4.28125 L 11.707031 3.5722656 C 11.319691 3.1859656 11.319691 2.5718169 11.707031 2.1855469 L 13.591797 0.30664062 C 13.234887 0.18252062 12.846596 0.08984375 12.447266 0.08984375 z "
+     id="path3908-8" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:block;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+     d="m 6.99433,10.99997 c -0.55117,0 -0.99482,0.44367 -0.99482,0.99481 v 0.0104 c 0,0.55114 0.44365,0.99481 0.99482,0.99481 h 0.0106 c 0.55117,0 0.99482,-0.44367 0.99482,-0.99481 v -0.0104 c 0,-0.55114 -0.44365,-0.99481 -0.99482,-0.99481 z m 2.99988,-10e-6 c -0.55117,0 -0.99482,0.44367 -0.99482,0.99481 v 0.0104 c 0,0.55114 0.44365,0.99481 0.99482,0.99481 h 0.0106 c 0.55117,0 0.99482,-0.44367 0.99482,-0.99481 v -0.0104 c 0,-0.55114 -0.44365,-0.99481 -0.99482,-0.99481 z m 3,0 c -0.55117,0 -0.99482,0.44367 -0.99482,0.99481 v 0.0104 c 0,0.55114 0.44365,0.99481 0.99482,0.99481 h 0.0106 c 0.55117,0 0.99482,-0.44367 0.99482,-0.99481 v -0.0104 c 4e-5,-0.55114 -0.44361,-0.99481 -0.99478,-0.99481 z"
+     id="path2396-7"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sssssssssssssssssssssssscss" />
+</svg>

--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -32,13 +32,13 @@
      inkscape:window-height="704"
      id="namedview88"
      showgrid="false"
-     inkscape:zoom="1.4142136"
-     inkscape:cx="543.03159"
-     inkscape:cy="355.1342"
+     inkscape:zoom="5.6568544"
+     inkscape:cx="612.08976"
+     inkscape:cy="158.71861"
      inkscape:window-x="70"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g1833"
+     inkscape:current-layer="layer3"
      showborder="true"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
@@ -4495,7 +4495,7 @@
          inkscape:connector-curvature="0"
          id="path1351-1"
          d="m 276.07542,-289.92479 1.99999,-1e-5 v 6 h -1.99999 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#da1636;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#fdc92b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          class="warning" />
       <rect
          y="-294.9248"
@@ -7248,32 +7248,6 @@
       </g>
     </g>
     <g
-       transform="translate(240,380)"
-       style="display:inline"
-       id="g2540-0"
-       inkscape:label="applications-utilities">
-      <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.99980229;marker:none;enable-background:accumulate"
-         id="rect2426-6"
-         width="16"
-         height="16"
-         x="80"
-         y="-348"
-         transform="rotate(90)" />
-      <path
-         sodipodi:nodetypes="cccccccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         id="path2428-2"
-         d="m 343,96 -0.47852,-0.921875 c -0.51103,-0.985285 -0.88042,-1.942066 -1.12695,-2.666016 -0.24655,-0.723952 -0.35422,-1.146604 -0.38281,-1.271484 L 341,91.083984 V 81 c 0,0 0,-1 1,-1 h 2 c 0,0 1,0 1,1 v 10.083984 l -0.0117,0.05664 c -0.0281,0.122106 -0.13628,0.547446 -0.38281,1.271484 -0.24654,0.724037 -0.6165,1.681418 -1.12695,2.666016 z m -0.20898,-3.042969 h 0.41601 c 0.13936,-0.314817 0.29412,-0.649389 0.37695,-0.892578 C 343.8091,91.403255 344.00085,90.993322 344,91 h -2 c -0.002,-0.0089 0.18894,0.403415 0.41406,1.064453 0.0829,0.24312 0.2376,0.577748 0.37696,0.892578 z M 342,83 h 2 v -2 h -2 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.26892218" />
-      <path
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         id="rect2452-6"
-         d="M 335,80 V 80.5 95 h 5 V 83 82 80 Z m 1,1 h 3 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -1 v 1 h 1 v 1 h -3 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    </g>
-    <g
        transform="matrix(0.99983741,0,0,0.99709409,512.00676,-245.89608)"
        id="g4948"
        style="display:inline;enable-background:new"
@@ -7370,6 +7344,66 @@
          d="m 404.98941,405.36221 -33.01305,18 v -16.30902 -31.69098 l 27.01068,15 -9.00356,6 z"
          id="path7665-6"
          inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="translate(-39.79835,1.0351563e-6)"
+       style="display:inline"
+       id="g6805"
+       inkscape:label="applications-utilities">
+      <g
+         inkscape:label="applications-utilities"
+         id="g2578-3"
+         style="display:inline"
+         transform="translate(40.000039,240)">
+        <rect
+           transform="rotate(90)"
+           y="-588"
+           x="219.99994"
+           height="15.999999"
+           width="16"
+           id="rect1819-1-7"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:0.66653478;marker:none;enable-background:accumulate" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         id="rect6717"
+         d="m 615.99219,460 c -0.0502,0 -0.0957,0.015 -0.14453,0.0195 0.21491,-0.003 0.35727,-0.0162 0.64648,-0.0195 z m 0.51367,0 c 1.2582,0.0145 1.67889,-0.0306 2.43164,0.38477 0.37637,0.20766 0.67323,0.55938 0.83789,0.99804 C 619.9401,461.82148 620,462.34239 620,463 v 1 h 3 v -0.24609 C 623,462.64592 623.446,462 624,462 c 0.554,0 1,0.64592 1,1.75391 V 464 c 1.108,0 2,-1.392 2,-2.5 0,-1.108 -0.892,-1.5 -2,-1.5 z"
+         style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 616.49414,460 c -1.2582,0.0145 -1.67889,-0.0306 -2.43164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 C 613.05994,461.82148 613,462.34239 613,463 v 10 c 0,0.65761 0.0599,1.17858 0.22461,1.61719 0.16468,0.43861 0.46153,0.78852 0.83789,0.99609 0.75272,0.41513 0.67354,0.37165 1.93164,0.38672 h 0.002 0.50391 0.50391 0.002 c 1.2581,-0.0151 1.17892,0.0284 1.93164,-0.38672 0.37636,-0.20757 0.67321,-0.55748 0.83789,-0.99609 C 619.94,474.17858 620,473.65761 620,473 v -10 c 0,-0.65761 -0.0599,-1.17852 -0.22461,-1.61719 -0.16466,-0.43866 -0.46152,-0.79038 -0.83789,-0.99804 -0.75275,-0.41537 -1.17344,-0.37027 -2.43164,-0.38477 h -0.004 -0.002 -0.002 z m 0.006,1 c 1.25853,0.0147 1.58912,0.0598 1.95508,0.26172 0.18341,0.10119 0.28716,0.21275 0.38476,0.47266 C 618.93726,461.99425 619,462.40761 619,463 v 10 c 0,0.59239 -0.0628,1.0058 -0.16016,1.26562 -0.0975,0.25982 -0.20134,0.3715 -0.38476,0.47266 C 618.0891,474.9401 618.25863,474.9848 617,475 H 616.994 616.5 616.00586 616 c -1.25863,-0.0152 -1.0891,-0.0599 -1.45508,-0.26172 -0.18342,-0.10116 -0.28722,-0.21285 -0.38476,-0.47266 C 614.06278,474.0058 614,473.59239 614,473 v -10 c 0,-0.59239 0.0626,-1.00576 0.16016,-1.26562 0.0976,-0.25991 0.20135,-0.37147 0.38476,-0.47266 C 614.91088,461.0598 615.24147,461.0147 616.5,461 Z m 0,1 a 1.5,1.5 0 0 0 -1.5,1.5 1.5,1.5 0 0 0 1.5,1.5 1.5,1.5 0 0 0 1.5,-1.5 1.5,1.5 0 0 0 -1.5,-1.5 z m 0,1 a 0.5,0.5 0 0 1 0.5,0.5 0.5,0.5 0 0 1 -0.5,0.5 0.5,0.5 0 0 1 -0.5,-0.5 0.5,0.5 0 0 1 0.5,-0.5 z"
+         id="path1817-9-6-6" />
+      <path
+         style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 620.20117,465 v 4 c 1,0.5 3.10545,2.35059 6,3 -0.91305,-3.49122 -3.5,-5.5 -6,-7 z m 2.5,3 c 0.27614,0 0.69653,0.47678 0.875,0.6875 1.25524,2.24128 -0.5513,0.53677 -1.375,-0.1875 0,-0.27614 0.22386,-0.5 0.5,-0.5 z"
+         transform="translate(-0.20165,-1.0351563e-6)"
+         id="rect6767"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="translate(-19.79835,1.0351563e-6)"
+       style="display:inline"
+       id="g7125"
+       inkscape:label="preferences-other">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.99539447;marker:none;enable-background:accumulate"
+         d="M 624.65039 460.08984 C 622.73906 460.08984 621.18945 461.63493 621.18945 463.54102 C 621.18945 463.93647 621.28118 464.31998 621.4043 464.67383 L 616.89453 469.18164 C 616.53762 469.05754 616.15128 468.96484 615.75195 468.96484 C 613.84062 468.96484 612.29102 470.50994 612.29102 472.41602 C 612.29102 472.78022 612.37171 473.13526 612.47656 473.46484 L 614.42188 471.52344 C 614.61555 471.33029 614.88006 471.21484 615.13281 471.21484 C 615.38557 471.21484 615.65007 471.33029 615.84375 471.52344 L 616.52344 472.20117 C 616.91079 472.58747 616.91079 473.23285 616.52344 473.61914 L 614.51562 475.62109 C 614.89801 475.76621 615.31849 475.86719 615.75195 475.86719 C 617.08744 475.86719 618.23157 475.10477 618.80859 474 L 618.20117 474 C 617.64717 474 617.20117 473.554 617.20117 473 L 617.20117 471 C 617.20117 470.446 617.64717 470 618.20117 470 L 620.27344 470 L 622.32617 467.94922 C 622.32817 467.94924 622.33004 467.94919 622.33203 467.94922 L 623.50781 466.77734 C 623.86471 466.90144 624.25106 466.99219 624.65039 466.99219 C 626.56172 466.99219 628.11133 465.4471 628.11133 463.54102 C 628.11133 463.14278 628.01897 462.75825 627.89453 462.40234 L 626.00977 464.28125 C 625.62242 464.66753 625.00648 464.66753 624.61914 464.28125 L 623.9082 463.57227 C 623.52086 463.18597 623.52086 462.57182 623.9082 462.18555 L 625.79297 460.30664 C 625.43606 460.18252 625.04972 460.08984 624.65039 460.08984 z "
+         transform="translate(19.79835,-1.0351563e-6)"
+         id="path3908-8" />
+      <rect
+         y="460.00003"
+         x="632.00049"
+         height="16"
+         width="16"
+         id="rect4445-9"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+      <path
+         sodipodi:nodetypes="sssssssssssssssssssssssscss"
+         inkscape:connector-curvature="0"
+         id="path2396-7"
+         d="M 638.99482,471 C 638.44365,471 638,471.44367 638,471.99481 v 0.0104 c 0,0.55114 0.44365,0.99481 0.99482,0.99481 h 0.0106 c 0.55117,0 0.99482,-0.44367 0.99482,-0.99481 v -0.0104 c 0,-0.55114 -0.44365,-0.99481 -0.99482,-0.99481 z m 2.99988,-10e-6 c -0.55117,0 -0.99482,0.44367 -0.99482,0.99481 v 0.0104 c 0,0.55114 0.44365,0.99481 0.99482,0.99481 h 0.0106 c 0.55117,0 0.99482,-0.44367 0.99482,-0.99481 v -0.0104 c 0,-0.55114 -0.44365,-0.99481 -0.99482,-0.99481 z m 3,0 c -0.55117,0 -0.99482,0.44367 -0.99482,0.99481 v 0.0104 c 0,0.55114 0.44365,0.99481 0.99482,0.99481 h 0.0106 c 0.55117,0 0.99482,-0.44367 0.99482,-0.99481 v -0.0104 c 4e-5,-0.55114 -0.44361,-0.99481 -0.99478,-0.99481 z"
+         style="color:#000000;clip-rule:nonzero;display:block;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new" />
     </g>
   </g>
   <g


### PR DESCRIPTION
This PR has the following changes:

- applications-utilities-symbolic has changed from pencil/ruler to a Swiss army knife, to more closely follow Adwaita;
- applications-graphics is now a picture instead of a camera (although the Software Centre category is called Graphics & Photography, the same icon is used for Art & Design in Snap Store and a camera is a bit odd there);
- There's a new icon for preferences-other-symbolic (far right in following image)...  it's not amazing but hopefully will do for now?

![image](https://user-images.githubusercontent.com/38893390/70620182-74a03e00-1c0e-11ea-98d9-117a1a5880e5.png)

This is how the categories now look in Software Centre - click to see them sharply, the image is slightly shrunk in this github post:

![image](https://user-images.githubusercontent.com/38893390/70620252-aca78100-1c0e-11ea-9288-4c43f5a4ae33.png)

No idea why the app picks up the help icon for Science instead of my lovely test tube  :(  but there's not a symlink for it in categories or anything.