### PR TITLE
Unity/window borders fix

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -528,7 +528,7 @@ UnityDecoration {
   -UnityDecoration-title-indent: 0px;
   -UnityDecoration-title-fade: 0px;
   -UnityDecoration-title-alignment: 0;
-  
+
   // Unity "titlebars"
   .top {
     border: none;
@@ -571,7 +571,7 @@ UnityPanelWidget, .unity-panel {
     border-width: 0 1px;
     color: $panel_fg_color;
     background-color: transparent;
-    
+
     &:hover, *:hover {
       box-shadow: inset 0 -2px 0 0 $selected_bg_color;
       background-color: transparent;

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -512,7 +512,7 @@ $titlebar_bg_color: $headerbar_bg_color;
 $titlebar_fg_color: $headerbar_fg_color;
 
 UnityDecoration {
-  -UnityDecoration-extents: 24px 1px 1px 1px;
+  -UnityDecoration-extents: 28px 0px 0px 0px;
   -UnityDecoration-input-extents: 10px;
 
   -UnityDecoration-shadow-offset-x: 1px;
@@ -554,6 +554,7 @@ UnityDecoration {
 
   // this is the window border outside of the titlebar!
   .left, .right, .bottom {
+    border: none;
     background-color: transparent;
     &:backdrop { background-color: transparent; }
   }

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -527,7 +527,7 @@ UnityDecoration {
 
   -UnityDecoration-title-indent: 0px;
   -UnityDecoration-title-fade: 0px;
-  -UnityDecoration-title-alignment: 0;
+  -UnityDecoration-title-alignment: 0.5;
 
   // Unity "titlebars"
   .top {


### PR DESCRIPTION
Some improvements on Unity side

- remove titlebar borders, to align with window border which is none
- center align title in titlebar, as in latest GTK apps
- some little apps.scss cleanup (whitespaces)


Before
![Screenshot from 2019-12-16 13-17-35](https://user-images.githubusercontent.com/2883614/70906428-a5b1b180-2006-11ea-9210-b0420e402999.png)


After
![Screenshot from 2019-12-16 13-18-45](https://user-images.githubusercontent.com/2883614/70906434-aa766580-2006-11ea-8457-969ec010ae1d.png)

