### PR TITLE
unity: install assets with meson build system

### DIFF
--- a/gtk/src/default/meson.build
+++ b/gtk/src/default/meson.build
@@ -11,3 +11,4 @@ configure_file(input : '../index.theme.in',
 subdir('gtk-2.0')
 subdir('gtk-3.0')
 subdir('gtk-3.20')
+subdir('unity')

--- a/gtk/src/default/unity/meson.build
+++ b/gtk/src/default/unity/meson.build
@@ -1,0 +1,38 @@
+gnome = import('gnome')
+sassc = find_program('sassc')
+
+unity_dir = join_paths(theme_dir, 'unity')
+
+unity_assets = [
+  'close_focused_normal.svg',
+  'close_focused_prelight.svg',
+  'close_focused_pressed.svg',
+  'close.svg',
+  'close_unfocused_prelight.svg',
+  'close_unfocused_pressed.svg',
+  'close_unfocused.svg',
+  'maximize_focused_normal.svg',
+  'maximize_focused_prelight.svg',
+  'maximize_focused_pressed.svg',
+  'maximize.svg',
+  'maximize_unfocused_prelight.svg',
+  'maximize_unfocused_pressed.svg',
+  'maximize_unfocused.svg',
+  'minimize_focused_normal.svg',
+  'minimize_focused_prelight.svg',
+  'minimize_focused_pressed.svg',
+  'minimize.svg',
+  'minimize_unfocused_prelight.svg',
+  'minimize_unfocused_pressed.svg',
+  'minimize_unfocused.svg',
+  'unmaximize_focused_normal.svg',
+  'unmaximize_focused_prelight.svg',
+  'unmaximize_focused_pressed.svg',
+  'unmaximize.svg',
+  'unmaximize_unfocused_prelight.svg',
+  'unmaximize_unfocused_pressed.svg',
+  'unmaximize_unfocused.svg',
+]
+
+# Install stub CSS files
+install_data(unity_assets, install_dir: unity_dir)

--- a/gtk/src/install-theme.sh
+++ b/gtk/src/install-theme.sh
@@ -12,3 +12,5 @@ for ver in gtk-3.0 gtk-3.20; do
   ln -sf "../../${project_name}/${ver}/gtk-dark.css" "${theme_dir}/${ver}/gtk-dark.css"
   ln -sf "../../${project_name}/${ver}/gtk.gresource" "${theme_dir}/${ver}/gtk.gresource"
 done
+
+ln -sf "../${project_name}/unity" "${theme_dir}/unity"


### PR DESCRIPTION
Add missing build configuration for Unity assets

Light and Dark variant assets are installed as symlink to the default
theme.

see #1670 