### PR TITLE
"Yaru 3.0" - colour set sync, button overhaul and contrast improvements

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -56,3 +56,16 @@ $panel_opaque_value: 0.0;
 
 $dash-alpha-value: 0.6;
 $dash-opaque-alpha-value: 0.0;
+
+//special cased widget colors
+$suggested_bg_color: if($variant=='light', $green, darken($green, 5%));
+$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
+$progress_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
+$progress_border_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
+$checkradio_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
+$checkradio_fg_color: #ffffff;
+$switch_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
+$switch_border_color: if($variant=='light', darken($darkblue, 15%), darken(lighten($darkblue, 4%), 30%));
+$focus_border_color: darken($blue, if($variant=='light', 0%, 15%));
+$text_selected_bg_color: $orange;
+$text_selected_fg_color: #ffffff;

--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -3,7 +3,7 @@
 @import "ubuntu-colors";
 
 $base_color: if($variant == 'light', #ffffff, lighten(desaturate($jet, 20%), 10%));
-$bg_color: if($variant == 'light',lighten(#F5F6F7,1%), darken($inkstone, 1%));
+$bg_color: if($variant == 'light', #f7f7f7, lighten($inkstone, 0.5%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 
 $selected_fg_color: #ffffff;

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -140,8 +140,8 @@ StScrollBar {
   -barlevel-height: 0.2em;
   -barlevel-background-color: transparentize($fg_color, 0.9);; //background of the trough
   -barlevel-border-color: $borders_color; //trough border color
-  -barlevel-active-background-color: if($variant == 'light', $blue, darken($blue, 8%)); //active trough fill
-  -barlevel-active-border-color: if($variant == 'light', $blue, darken($blue, 8%)); //active trough border
+  -barlevel-active-background-color: $progress_bg_color; //active trough fill
+  -barlevel-active-border-color: $progress_bg_color; //active trough border
   -barlevel-overdrive-color: $destructive_color;
   -barlevel-overdrive-border-color: darken($destructive_color,10%);
   -barlevel-overdrive-separator-width: 0.2em;
@@ -665,8 +665,8 @@ StScrollBar {
   .level {
     height: 0.6em;
     -barlevel-height: 0.3em;
-    -barlevel-background-color: transparentize($osd_fg_color, 0.9);
-    -barlevel-active-background-color: if($variant == 'light', $blue, darken($blue, 8%));
+    -barlevel-background-color: transparent;
+    -barlevel-active-background-color: $progress_bg_color;
     -barlevel-overdrive-color: $destructive_color;
     -barlevel-overdrive-separator-width: 0.2em;
   }
@@ -790,7 +790,7 @@ StScrollBar {
   background-color: darken($bg_color, 2%);
   border-color: $_bubble_borders_color;
   box-shadow: none;
-  &:focus { border: 2px solid $selected_bg_color; }
+  &:focus { border: 2px solid $focus_border_color; }
 }
 
 %bubble-panel {

--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -25,7 +25,7 @@
 
 // entries
 
-@mixin entry($t, $fc:$selected_bg_color, $edge: $borders_edge) {
+@mixin entry($t, $fc:$focus_border_color, $edge: $borders_edge) {
 //
 // Entries drawing function
 //
@@ -44,9 +44,7 @@
 
   }
   @if $t==focus {
-    border-color: if($fc==$selected_bg_color,
-                     $selected_borders_color,
-                     darken($fc,35%));
+    border-color: $focus_border_color;
   }
   @if $t==hover { }
   @if $t==insensitive {
@@ -148,7 +146,7 @@
     color: $tc;
     text-shadow: 0 1px black;
     icon-shadow: 0 1px black;
-    box-shadow: inset 0px 0px 0px 2px $selected_bg_color;
+    box-shadow: inset 0px 0px 0px 2px $focus_border_color
     //border-color: $selected_bg_color;
   }
 

--- a/gnome-shell/src/gnome-shell-sass/_ubuntu-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_ubuntu-colors.scss
@@ -11,9 +11,11 @@ $silk: #CCC;
 $ash: #878787;
 
 // Utility
-$red: #ED3146;
+$red: #c7162b;
 $orange: #E95420;
-$yellow: #F89B0F;
-$green: #3EB34F;
+$yellow: #f99b11;
+$green: #0e8420;
 $blue: #19B6EE;
+$darkblue: #335280;
+$linkblue: #007aa6;
 $purple: #762572;

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -12,7 +12,7 @@ $selected_bg_color: if($variant == 'light', $orange, darken($orange, 4%));
 
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
 $borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
-$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 18%));
+$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 12%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: $linkblue;
 $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -2,9 +2,9 @@
 // it gets @if ed depending on $variant
 @import 'ubuntu-colors';
 
-$base_color: if($variant == 'light', #ffffff, lighten(desaturate($jet, 20%), 10%));
+$base_color: if($variant == 'light', #ffffff, lighten(desaturate($jet, 20%), 11%));
 $text_color: if($variant == 'light', black, white);
-$bg_color: if($variant == 'light', #f7f7f7, darken($inkstone, 1%));
+$bg_color: if($variant == 'light', #f7f7f7, lighten($inkstone, 0.5%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 
 $selected_fg_color: #ffffff;
@@ -14,7 +14,7 @@ $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%),
 $borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
 $alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 18%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
-$link_color: if($variant == 'light', darken($blue, 10%), lighten($blue, 20%));
+$link_color: $linkblue;
 $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
@@ -70,14 +70,14 @@ $backdrop_scrollbar_slider_color: mix($backdrop_fg_color, $backdrop_bg_color, 40
 $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdrop_bg_color, $backdrop_base_color, 20%));
 
 //special cased widget colors
-$suggested_bg_color: if($variant=='light', $green, darken($green, 15%));
-$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 40%));
-$progress_bg_color: $darkblue;
-$progress_border_color: darken($darkblue, if($variant=='light', 0%, 15%));
-$checkradio_bg_color: $darkblue;
+$suggested_bg_color: if($variant=='light', $green, darken($green, 5%));
+$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
+$progress_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
+$progress_border_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
+$checkradio_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
 $checkradio_fg_color: #ffffff;
-$switch_bg_color: $darkblue;
-$switch_border_color: darken($darkblue, if($variant=='light', 15%, 30%));
+$switch_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
+$switch_border_color: if($variant=='light', darken($darkblue, 15%), darken(lighten($darkblue, 4%), 30%));
 $focus_border_color: darken($blue, if($variant=='light', 0%, 15%));
-$text_selected_bg_color: $darkblue;
+$text_selected_bg_color: $orange;
 $text_selected_fg_color: #ffffff;

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -72,7 +72,12 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 //special cased widget colors
 $suggested_bg_color: if($variant=='light', $green, darken($green, 15%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 40%));
-$progress_bg_color: if($variant == 'light', $blue, darken($blue, 8%));
-$progress_border_color: $progress_bg_color;
-$checkradio_bg_color: $suggested_bg_color;
+$progress_bg_color: $darkblue;
+$progress_border_color: $darkblue;
+$checkradio_bg_color: $darkblue;
 $checkradio_fg_color: #ffffff;
+$switch_bg_color: $darkblue;
+$switch_border_color: darken($darkblue, if($variant=='light', 15%, 30%));
+$focus_border_color: darken($blue, if($variant=='light', 0%, 15%));
+$text_selected_bg_color: $darkblue;
+$text_selected_fg_color: #ffffff;

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -4,14 +4,14 @@
 
 $base_color: if($variant == 'light', #ffffff, lighten(desaturate($jet, 20%), 10%));
 $text_color: if($variant == 'light', black, white);
-$bg_color: if($variant == 'light', #F5F6F7, darken($inkstone, 1%));
+$bg_color: if($variant == 'light', #f7f7f7, darken($inkstone, 1%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 
 $selected_fg_color: #ffffff;
 $selected_bg_color: if($variant == 'light', $orange, darken($orange, 4%));
 
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 9%));
+$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
 $alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 18%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', darken($blue, 10%), lighten($blue, 20%));
@@ -73,7 +73,7 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 $suggested_bg_color: if($variant=='light', $green, darken($green, 15%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 40%));
 $progress_bg_color: $darkblue;
-$progress_border_color: $darkblue;
+$progress_border_color: darken($darkblue, if($variant=='light', 0%, 15%));
 $checkradio_bg_color: $darkblue;
 $checkradio_fg_color: #ffffff;
 $switch_bg_color: $darkblue;

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -22,14 +22,14 @@
 }
 
 // entries
-@function entry_focus_border($fc:$selected_bg_color) {
+@function entry_focus_border($fc:$focus_border_color) {
   @if $variant == 'light' { @return $fc; }
-  @else { @return if($fc==$selected_bg_color, $selected_borders_color, darken($fc, 35%)); }
+  @else { @return $focus_border_color }
 }
 
-@function entry_focus_shadow($fc:$selected_bg_color) { @return inset 0 0 0 1px $fc; }
+@function entry_focus_shadow($fc:$focus_border_color) { @return inset 0 0 0 1px $fc; }
 
-@mixin entry($t, $fc:$selected_bg_color, $edge: none) {
+@mixin entry($t, $fc:$focus_border_color, $edge: none) {
 //
 // Entries drawing function
 //

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -195,11 +195,11 @@
     color: $tc;
     outline-color: transparentize($tc, 0.7);
     border-color: if($c != $bg_color, _border_color($c), $borders_color);
-    border-bottom-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
-    $button_fill: if($variant == 'light', linear-gradient(to top, darken($c, 2%) 2px, $c), linear-gradient(to top, darken($c,1%) 2px, $c)) !global;
+    // border-bottom-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
+    $button_fill: if($variant == 'light', linear-gradient(to top, darken($c, 0%) 2px, $c), linear-gradient(to top, darken($c,0%) 2px, $c)) !global;
     background-image: $button_fill;
-    @include _button_text_shadow($tc, $c);
-    @include _shadows(inset 0 1px $_hilight_color, $_button_edge, $_button_shadow);
+    // @include _button_text_shadow($tc, $c);
+    @include _shadows(0 1px transparentize(black, 0.9));
   }
 
   @else if $t==hover {
@@ -220,7 +220,8 @@
       @include _button_text_shadow($tc,lighten($c, 6%));
       @include _shadows(inset 0 1px _button_hilight_color(darken($c, 2%)), $_button_edge, $_button_shadow);
     }
-    background-image: $button_fill;
+    box-shadow: 0 1px transparentize(black, 0.9);
+    background-image: image(lighten($c, 1%));
   }
 
   @if $t==normal-alt {
@@ -241,6 +242,8 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
+    box-shadow: 0 1px transparentize(black, 0.9);
+    background-image: image($c);
   }
 
   @else if $t==hover-alt {
@@ -260,7 +263,7 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    background-image: $button_fill;
+    background-image: image(lighten($c, 1%));
   }
 
   @else if $t==active {
@@ -600,23 +603,28 @@
 
   @if $t==normal  {
     background-clip: if($checked, border-box, padding-box);
-    background-image: linear-gradient(to bottom, lighten($c, 5%) 20%, $c 90%);
+    background-image: image(lighten($c, if($variant=='dark', if($c==$checkradio_bg_color, 0%, 5%), 0%)));
     border-color: $_border_color;
     box-shadow: 0 1px transparentize(black, 0.95);
     color: $tc;
   }
 
   @if $t==hover {
-    background-image: if($c == white, image(darken($c, 5%)), linear-gradient(to bottom, lighten($c, 9%) 10%, lighten($c, 4%) 90%));
+    background-image: image(if($c==$checkradio_bg_color, lighten($c, 7%), if($variant=='light', darken($c, 4%), lighten($c, 7%))));
+    border-color: if($c == $checkradio_bg_color, lighten($c, 7%), $alt_borders_color);
   }
 
   @if $t==active {
-    box-shadow: inset 0 1px 1px 0px if($variant == 'light', rgba(0, 0, 0, 0.2), black);
+    border-color: if($c==white, $_border_color, darken($c, 7%));
+    background-image: image(if($c==white, $_border_color, darken($c, 7%)));
+    box-shadow: none;
   }
 
   @if $t==insensitive {
     box-shadow: none;
-    color: transparentize($tc, 0.3);
+    color: $insensitive_fg_color;
+    border-color: $insensitive_borders_color;
+    background-image: image($insensitive_bg_color);
   }
 
   @if $t==backdrop {
@@ -627,7 +635,9 @@
 
   @if $t==backdrop-insensitive {
     box-shadow: none;
-    color: transparentize($tc, 0.3);
+    color: $backdrop_fg_color;
+    border-color: $insensitive_borders_color;
+    background-image: image($insensitive_bg_color);
   }
 }
 

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -501,7 +501,7 @@
 
   @if $ov != none { background: $c $ov, $gradient; }
   @else { background: $c $gradient; }
-  background: image(if($variant=='dark', lighten($c, 6%), $c));
+  background: image(if($variant=='dark', lighten($c, 3%), $c));
   box-shadow: inset 0 1px $hc; // top highlight
 }
 

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -196,7 +196,7 @@
     outline-color: transparentize($tc, 0.7);
     border-color: if($c != $bg_color, _border_color($c), $borders_color);
     // border-bottom-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
-    $button_fill: if($variant == 'light', linear-gradient(to top, darken($c, 0%) 2px, $c), linear-gradient(to top, darken($c,0%) 2px, $c)) !global;
+    $button_fill: if($variant == 'light', linear-gradient(to top, lighten($c, 2%) 2px, lighten($c, 2%)), linear-gradient(to top, lighten($c, 2%) 2px, lighten($c, 2%))) !global;
     background-image: $button_fill;
     // @include _button_text_shadow($tc, $c);
     @include _shadows(0 1px transparentize(black, 0.9));
@@ -220,8 +220,8 @@
       @include _button_text_shadow($tc,lighten($c, 6%));
       @include _shadows(inset 0 1px _button_hilight_color(darken($c, 2%)), $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, 0.9);
-    background-image: image(lighten($c, 1%));
+    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85));
+    background-image: image(lighten($c, 4%));
   }
 
   @if $t==normal-alt {
@@ -242,8 +242,8 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, 0.9);
-    background-image: image($c);
+    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85));
+    background-image: image(lighten($c, 4%));
   }
 
   @else if $t==hover-alt {
@@ -263,7 +263,8 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    background-image: image(lighten($c, 1%));
+    background-image: image(lighten($c, 6%));
+    box-shadow: 0 1px transparentize(black, 0.8);
   }
 
   @else if $t==active {

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -501,7 +501,7 @@
 
   @if $ov != none { background: $c $ov, $gradient; }
   @else { background: $c $gradient; }
-
+  background: image(if($variant=='dark', lighten($c, 6%), $c));
   box-shadow: inset 0 1px $hc; // top highlight
 }
 

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -218,7 +218,7 @@ headerbar,
 
       &:checked {
         color: $selected_fg_color;
-        border-color: transparentize($switch_bg_color, 0.6);
+        border-color: darken($darkblue, 40%);
         background-color: $switch_bg_color;
       }
 
@@ -226,7 +226,7 @@ headerbar,
         border-color: $_dark_border_color;
 
         &:checked {
-          border-color: $switch_border_color;
+          border-color: darken($darkblue, 40%);
         }
         &:disabled {
           background-color: $headerbar_bg_color;

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -218,15 +218,15 @@ headerbar,
 
       &:checked {
         color: $selected_fg_color;
-        border-color: transparentize($suggested_bg_color, 0.6);
-        background-color: $suggested_bg_color;
+        border-color: transparentize($switch_bg_color, 0.6);
+        background-color: $switch_bg_color;
       }
 
       slider {
         border-color: $_dark_border_color;
 
         &:checked {
-          border-color: $suggested_border_color;
+          border-color: $switch_border_color;
         }
         &:disabled {
           background-color: $headerbar_bg_color;

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -270,7 +270,24 @@ switch { font-size: 0 }
   }
 }
 
-// Dark blue text selection
+// Text selection - staying orange for 20.04 but with the variables we could easily change it here if we want to
 entry selection, text selection, label selection, textview.view text selection {
   &:focus, & { background-color: $text_selected_bg_color; color: $text_selected_fg_color; }
+}
+
+// Blue focus "ring" - upstream is also interested in this, so better get this into upstream at some time
+*:not(button) {
+  outline-color: $focus_border_color;
+  outline-style: solid;
+  outline-offset: -2px;
+  outline-width: 2px;
+  -gtk-outline-radius: $button-radius - 2;
+}
+// We need to re-evaluate where we want the ring though
+switch slider {
+  outline-color: $focus_border_color;
+  outline-style: solid;
+  outline-offset: -1px;
+  outline-width: 2px;
+  -gtk-outline-radius: 100%;
 }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -28,7 +28,7 @@ headerbar {
 // blue spinner
 spinner {
   &:not(:backdrop) {
-    color: $progress_bg_color;
+    color: $blue;
   }
 }
 
@@ -41,7 +41,7 @@ switch {
 
       &:backdrop { border-color: $selected_borders_color; }
 
-      slider { &:checked { border-color: $suggested_border_color; } }
+      slider { &:checked { border-color: $switch_border_color; } }
     }
   }
 }
@@ -173,3 +173,104 @@ menubar,
 
 // fix for gtk 3.28 switches to not show the on/off label
 switch { font-size: 0 }
+
+/**********
+ * Switch *
+ **********/
+ switch {
+  outline-offset: -4px;
+
+  // similar to the .scale
+  border: 1px solid $borders_color;
+  border-radius: 14px;
+  color: $fg_color;
+  background-color: $dark_fill;
+  text-shadow: 0 1px transparentize(black, 0.9);
+
+  &:checked {
+    color: $selected_fg_color;
+    border-color: $switch_border_color;
+    background-color: $switch_bg_color;
+    text-shadow: 0 1px transparentize($switch_border_color, 0.5),
+                 0 0 2px transparentize(white, 0.4);
+  }
+
+  &:disabled {
+    color: $insensitive_fg_color;
+    border-color: $borders_color;
+    background-color: $insensitive_bg_color;
+    text-shadow: none;
+  }
+
+  &:backdrop {
+    color: $backdrop_fg_color;
+    border-color: $backdrop_borders_color;
+    background-color: $backdrop_dark_fill;
+    text-shadow: none;
+    transition: $backdrop_transition;
+
+    &:checked {
+      @if $variant == 'light' { color: $backdrop_bg_color; }
+      border-color: if($variant=='light', $switch_bg_color, $switch_border_color);
+      background-color: $switch_bg_color;
+    }
+
+    &:disabled {
+      color: $backdrop_insensitive_color;
+      border-color: $backdrop_borders_color;
+      background-color: $insensitive_bg_color;
+    }
+  }
+
+  slider {
+    margin: -1px;
+    min-width: 24px;
+    min-height: 24px;
+    border: 1px solid;
+    border-radius: 50%;
+    transition: $button_transition;
+    -gtk-outline-radius: 20px;
+
+    @if $variant == 'light' {
+      @include button(normal-alt, $edge: $shadow_color);
+    } 
+    @else {
+      @include button(normal-alt, $c: lighten($bg_color,6%), $edge: $shadow_color);
+    }
+  }
+  
+  image { color: transparent; } /* only show i / o for the accessible theme */
+
+  &:hover slider {
+    @if $variant == 'light' {
+      @include button(hover-alt, $edge: $shadow_color);
+    }
+    @else {
+      @include button(hover-alt, $c: lighten($bg_color,6%), $edge: $shadow_color);
+    }
+  }
+
+  &:checked slider { border: 1px solid $switch_border_color; }
+
+  &:disabled slider { @include button(insensitive); }
+
+  &:backdrop {
+    slider {
+      transition: $backdrop_transition;
+
+      @include button(backdrop);
+    }
+
+    &:checked slider { border-color: if($variant == 'light', $switch_bg_color, $switch_border_color); }
+
+    &:disabled slider { @include button(backdrop-insensitive); }
+  }
+}
+
+entry selection { background-color: $text_selected_bg_color; color: $text_selected_fg_color; }
+
+textview.view {
+  text {
+    selection { &:focus, & { background-color: $text_selected_bg_color; color: $text_selected_fg_color; }}
+  }
+}

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -174,6 +174,9 @@ menubar,
 // fix for gtk 3.28 switches to not show the on/off label
 switch { font-size: 0 }
 
+// Since "we" missed to intoduce a switch color for Adwaita, we now need to restyle the switches in tweaks
+// This really needs an upstream change
+
 /**********
  * Switch *
  **********/
@@ -267,10 +270,7 @@ switch { font-size: 0 }
   }
 }
 
-entry selection { background-color: $text_selected_bg_color; color: $text_selected_fg_color; }
-
-textview.view {
-  text {
-    selection { &:focus, & { background-color: $text_selected_bg_color; color: $text_selected_fg_color; }}
-  }
+// Dark blue text selection
+entry selection, text selection, label selection, textview.view text selection {
+  &:focus, & { background-color: $text_selected_bg_color; color: $text_selected_fg_color; }
 }

--- a/gtk/src/default/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/default/gtk-3.20/_ubuntu-colors.scss
@@ -11,11 +11,12 @@ $silk: #CCC;
 $ash: #878787;
 
 // Utility
-$red: #ED3146;
+$red: #c7162b;
 $orange: #E95420;
-$yellow: #F89B0F;
-$green: #3EB34F;
+$yellow: #f99b11;
+$green: #0e8420;
 $blue: #19B6EE;
+$linkblue: #007aa6;
 $darkblue: #335280;
 $purple: #762572;
 

--- a/gtk/src/default/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/default/gtk-3.20/_ubuntu-colors.scss
@@ -16,6 +16,7 @@ $orange: #E95420;
 $yellow: #F89B0F;
 $green: #3EB34F;
 $blue: #19B6EE;
+$darkblue: #335280;
 $purple: #762572;
 
 // Terminal colors

--- a/gtk/src/default/gtk-3.20/assets/bullet-symbolic.svg
+++ b/gtk/src/default/gtk-3.20/assets/bullet-symbolic.svg
@@ -17,7 +17,7 @@
    height="14"
    id="svg7384"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
    width="14">
   <metadata
      id="metadata90">
@@ -37,7 +37,7 @@
      bordercolor="#666666"
      borderopacity="1"
      inkscape:current-layer="layer9"
-     inkscape:cx="9.6493349"
+     inkscape:cx="3.2191062"
      inkscape:cy="5.5864571"
      gridtolerance="10"
      inkscape:guide-bbox="true"
@@ -59,10 +59,10 @@
      inkscape:snap-nodes="false"
      inkscape:snap-others="false"
      inkscape:snap-to-guides="true"
-     inkscape:window-height="1016"
+     inkscape:window-height="917"
      inkscape:window-maximized="1"
-     inkscape:window-width="1920"
-     inkscape:window-x="0"
+     inkscape:window-width="1783"
+     inkscape:window-x="70"
      inkscape:window-y="27"
      inkscape:zoom="22.005438"
      inkscape:showpageshadow="false">
@@ -74,8 +74,8 @@
        originx="-139.99995"
        originy="120"
        snapvisiblegridlinesonly="true"
-       spacingx="1px"
-       spacingy="1px"
+       spacingx="1"
+       spacingy="1"
        type="xygrid"
        visible="true" />
   </sodipodi:namedview>
@@ -101,10 +101,10 @@
      transform="translate(-381.00015,-339)">
     <path
        inkscape:connector-curvature="0"
-       d="m 388.00015,343.01754 c -1.64587,0 -2.98246,1.33658 -2.98246,2.98246 0,1.64587 1.33659,2.98246 2.98246,2.98246 1.64587,0 2.98246,-1.33659 2.98246,-2.98246 0,-1.64588 -1.33659,-2.98246 -2.98246,-2.98246 z"
+       d="m 388.00015,343.5 c -1.37962,0 -2.5,1.12037 -2.5,2.5 0,1.37962 1.12038,2.5 2.5,2.5 1.37962,0 2.5,-1.12038 2.5,-2.5 0,-1.37963 -1.12038,-2.5 -2.5,-2.5 z"
        id="path9555"
        sodipodi:nodetypes="csssc"
-       style="color:#bebebe;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:'Andale Mono';text-indent:0pt;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.78125;marker:none" />
+       style="color:#bebebe;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:'Andale Mono';text-indent:0pt;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.4931047;marker:none" />
   </g>
   <g
      inkscape:groupmode="layer"

--- a/gtk/src/default/gtk-3.20/assets/check-symbolic.svg
+++ b/gtk/src/default/gtk-3.20/assets/check-symbolic.svg
@@ -17,7 +17,7 @@
    height="14"
    id="svg7384"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
    width="14">
   <metadata
      id="metadata90">
@@ -37,8 +37,8 @@
      bordercolor="#666666"
      borderopacity="1"
      inkscape:current-layer="layer9"
-     inkscape:cx="-15.966869"
-     inkscape:cy="8.8415069"
+     inkscape:cx="1.3837293"
+     inkscape:cy="4.949571"
      gridtolerance="10"
      inkscape:guide-bbox="true"
      guidetolerance="10"
@@ -50,7 +50,7 @@
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
      showborder="true"
-     showgrid="false"
+     showgrid="true"
      showguides="true"
      inkscape:snap-bbox="true"
      inkscape:snap-bbox-midpoints="false"
@@ -61,10 +61,10 @@
      inkscape:snap-to-guides="true"
      inkscape:window-height="1016"
      inkscape:window-maximized="1"
-     inkscape:window-width="1920"
-     inkscape:window-x="0"
+     inkscape:window-width="1850"
+     inkscape:window-x="70"
      inkscape:window-y="27"
-     inkscape:zoom="15.238496"
+     inkscape:zoom="43.100975"
      inkscape:showpageshadow="false">
     <inkscape:grid
        dotted="false"
@@ -99,11 +99,11 @@
      inkscape:label="status"
      style="display:inline;opacity:1"
      transform="translate(-401.00015,-339)">
-    <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:3;marker:none;enable-background:accumulate"
-       d="m 415.00015,339.98047 -6.5,6.39453 -2.9375,-2.9375 -2.125,2.125 5.0625,5.0625 6.5,-6.60547 0,-4.03906 z"
-       id="path8913-6-7-1-5-1"
-       inkscape:connector-curvature="0" />
+    <polygon
+       transform="matrix(1.2547306,0,0,1.2547306,398.97548,336.63753)"
+       id="path6712"
+       points="11.050299,4.1734886 11.050299,4.1734486 10.984399,4.2311486 6.2496486,8.3783686 3.4740786,5.9974286 2.6350186,6.9463086 6.2503386,10.750019 11.750009,4.9627786 "
+       style="fill:#ffffff;fill-rule:evenodd;stroke:none;stroke-width:1" />
   </g>
   <g
      inkscape:groupmode="layer"


### PR DESCRIPTION
As one of the outcomes of the design fest :gb: this pull request wants to merge the following into master:

*The official canonical vanilla colours*
- ```#f7f7f7``` as the new background colour for the light theme(s)
- ```#0e8420``` as the new green, now only used for positive/suggested things
- ```#f99b11``` as the new yellow, only used as a warning colour
- ```#335280``` as an additional blue second accent colour used as an replacement for both, the old green and the bright blue
- ```#007aa6``` as an additional new blue only used as the link colour
- ```#c7162b``` as the new red only used for destructive/negative elements

*Colour and contrast improvements*
- lighten the background colour of the dark themes slightly but darken the border colours of both the light and the dark themes-
- adjust colours for the dark theme so both bright and dark colours can be easily spotted in the dark themes but never are jarring or hurting the eye
- brighten the background colour of all buttons slightly, no matter where, to make it easier to spot them which also improves the usability downsides of inverting the headerbar colour in "a light" theme
- flatten all buttons surfaces by getting rid of the highlight shadows at the top and adding stronger shadows at the bottom (basically how they looked in Yaru 1.0)

*Vanilla assets*
- new checkmark for the checkboxes
- new bullet for the radio buttons

*Other changes*
- using the old blue ```#19B6EE``` for the focus rings except those for buttons

ToDo:
- [ ] sync the shell completely with these changes, this includes to draw new assets for the switches and the checkboxes!
- [ ] get the vanilla spinner into Yaru
- [ ] get the background colour ```#f7f7f7``` into the palette file and improve the naming of the blue colour variables

(The fixes for requests by Mpt should be applied in pull requests after)