### PR TITLE
Use Aubergine as second accent color instead of blue

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -9,7 +9,7 @@ $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $selected_fg_color: #ffffff;
 $selected_bg_color: if($variant == 'light', $orange, darken($orange, 4%));
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 18%), darken($bg_color, 10%));
+$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
 $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));

--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -60,12 +60,12 @@ $dash-opaque-alpha-value: 0.0;
 //special cased widget colors
 $suggested_bg_color: if($variant=='light', $green, darken($green, 5%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
-$progress_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
-$progress_border_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
-$checkradio_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
+$progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
+$progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
+$checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
 $checkradio_fg_color: #ffffff;
-$switch_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
-$switch_border_color: if($variant=='light', darken($darkblue, 15%), darken(lighten($darkblue, 4%), 30%));
-$focus_border_color: darken($blue, if($variant=='light', 0%, 15%));
+$switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
+$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken(lighten($aubergine, 4%), 30%));
+$focus_border_color: $focus_ring;
 $text_selected_bg_color: $orange;
 $text_selected_fg_color: #ffffff;

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -667,7 +667,7 @@ StScrollBar {
     -barlevel-height: 0.3em;
     -barlevel-background-color: $inkstone;
     -barlevel-border-color: $borders_color; //trough border color
-    -barlevel-active-background-color: $progress_bg_color;
+    -barlevel-active-background-color: $osd_fg_color;
     -barlevel-active-border-color: $borders_color; //active trough border
     -barlevel-overdrive-color: $destructive_color;
     -barlevel-overdrive-separator-width: 0.2em;

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -665,8 +665,10 @@ StScrollBar {
   .level {
     height: 0.6em;
     -barlevel-height: 0.3em;
-    -barlevel-background-color: transparent;
+    -barlevel-background-color: $inkstone;
+    -barlevel-border-color: $borders_color; //trough border color
     -barlevel-active-background-color: $progress_bg_color;
+    -barlevel-active-border-color: $borders_color; //active trough border
     -barlevel-overdrive-color: $destructive_color;
     -barlevel-overdrive-separator-width: 0.2em;
   }

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -138,10 +138,10 @@ StScrollBar {
 .slider {
   height: 1em;
   -barlevel-height: 0.2em;
-  -barlevel-background-color: transparentize($fg_color, 0.9);; //background of the trough
+  -barlevel-background-color: mix($borders_color, $bg_color, 50%);
   -barlevel-border-color: $borders_color; //trough border color
   -barlevel-active-background-color: $progress_bg_color; //active trough fill
-  -barlevel-active-border-color: $progress_bg_color; //active trough border
+  -barlevel-active-border-color: if($variant == 'light', $progress_bg_color, $borders_color); //active trough border
   -barlevel-overdrive-color: $destructive_color;
   -barlevel-overdrive-border-color: darken($destructive_color,10%);
   -barlevel-overdrive-separator-width: 0.2em;
@@ -149,7 +149,7 @@ StScrollBar {
   -slider-handle-radius: 8px;
   -slider-handle-border-width: 1px;
   -slider-handle-border-color: $borders_color;
-  color: if($variant == 'light', lighten($bg_color, 10%), darken($bg_color,4%));
+  color: lighten($bg_color, 4%);
   &:hover { color: $_hover_bg_color; }
   &:active { color: $_active_bg_color; }
 }
@@ -161,7 +161,7 @@ StScrollBar {
   StBin {
     width: 24px;
     height: 22px;
-    background-image: if($variant=='light', url("checkbox-off.svg"), 
+    background-image: if($variant=='light', url("checkbox-off.svg"),
                                             url("checkbox-off-dark.svg"));
   }
   &:focus StBin { background-image: if($variant=='light', url("checkbox-off-focused.svg"),

--- a/gnome-shell/src/gnome-shell-sass/_ubuntu-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_ubuntu-colors.scss
@@ -19,3 +19,6 @@ $blue: #19B6EE;
 $darkblue: #335280;
 $linkblue: #007aa6;
 $purple: #762572;
+
+$aubergine: if($variant == 'light', #924D8B, darken(#924D8B, 4%));
+$focus_ring: lighten($aubergine, 18%);

--- a/gnome-shell/src/toggle-off-dark.svg
+++ b/gnome-shell/src/toggle-off-dark.svg
@@ -1,1 +1,94 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="46" height="22"><defs><linearGradient id="a"><stop offset="0" stop-color="#39393a"/><stop offset="1" stop-color="#302f30"/></linearGradient><linearGradient xlink:href="#a" id="b" x1="53" y1="294.429" x2="53" y2="309.804" gradientUnits="userSpaceOnUse" gradientTransform="translate(-42.76)"/></defs><g transform="translate(0 -291.18)" stroke-width="1.085"><rect style="marker:none" width="44.446" height="20.911" x=".625" y="291.715" rx="10.455" ry="10.073" fill="#323233" stroke="#272728"/><rect ry="10.455" rx="10.455" y="291.715" x=".543" height="20.911" width="21.143" style="marker:none" fill="url(#b)" stroke="#151515"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="46"
+   height="22"
+   version="1.1"
+   id="svg16"
+   sodipodi:docname="toggle-off-dark.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata20">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1056"
+     inkscape:window-height="888"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="8.7391304"
+     inkscape:cx="23"
+     inkscape:cy="10.828358"
+     inkscape:window-x="670"
+     inkscape:window-y="78"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g14" />
+  <defs
+     id="defs8">
+    <linearGradient
+       id="a">
+      <stop
+         offset="0"
+         stop-color="#39393a"
+         id="stop2" />
+      <stop
+         offset="1"
+         stop-color="#302f30"
+         id="stop4" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#a"
+       id="b"
+       x1="53"
+       y1="294.429"
+       x2="53"
+       y2="309.804"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-42.76)" />
+  </defs>
+  <g
+     transform="translate(0,-291.18)"
+     id="g14"
+     style="stroke-width:1.08500004">
+    <rect
+       style="fill:#363636;stroke:#222222;marker:none;fill-opacity:1;stroke-opacity:1"
+       width="44.445999"
+       height="20.910999"
+       x="0.625"
+       y="291.715"
+       rx="10.455"
+       ry="10.073"
+       id="rect10" />
+    <rect
+       ry="10.455"
+       rx="10.455"
+       y="291.715"
+       x="0.54299998"
+       height="20.910999"
+       width="21.143"
+       style="fill:#595959;stroke:#222222;marker:none;fill-opacity:1;stroke-opacity:1"
+       id="rect12" />
+  </g>
+</svg>

--- a/gnome-shell/src/toggle-off-intl.svg
+++ b/gnome-shell/src/toggle-off-intl.svg
@@ -7,7 +7,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="46"
@@ -15,33 +14,10 @@
    viewBox="0 0 46 22"
    version="1.1"
    id="svg2751"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
    sodipodi:docname="toggle-off-intl.svg">
   <defs
-     id="defs2745">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient3329">
-      <stop
-         style="stop-color:#39393a;stop-opacity:1;"
-         offset="0"
-         id="stop3325" />
-      <stop
-         style="stop-color:#302f30;stop-opacity:1"
-         offset="1"
-         id="stop3327" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3329"
-       id="linearGradient3331"
-       x1="53"
-       y1="294.42917"
-       x2="53"
-       y2="309.80417"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-42.760724)" />
-  </defs>
+     id="defs2745" />
   <sodipodi:namedview
      id="base"
      pagecolor="#535353"
@@ -49,9 +25,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="-19.436775"
-     inkscape:cy="-13.499723"
+     inkscape:zoom="11.313708"
+     inkscape:cx="17.24893"
+     inkscape:cy="13.70951"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -59,7 +35,12 @@
      inkscape:pagecheckerboard="true"
      borderlayer="true"
      inkscape:showpageshadow="false"
-     showborder="false">
+     showborder="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1014"
+     inkscape:window-x="0"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
        id="grid3298" />
@@ -72,7 +53,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -82,7 +63,7 @@
      id="layer1"
      transform="translate(0,-291.17916)">
     <rect
-       style="opacity:1;vector-effect:none;fill:#323233;fill-opacity:1;stroke:#272728;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       style="opacity:1;vector-effect:none;fill:#363636;fill-opacity:1;stroke:#222222;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
        id="rect3296"
        width="44.446434"
        height="20.910645"
@@ -98,6 +79,6 @@
        height="20.910645"
        width="21.142862"
        id="rect3300"
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient3331);fill-opacity:1;stroke:#151515;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+       style="opacity:1;vector-effect:none;fill:#595959;fill-opacity:1;stroke:#222222;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
   </g>
 </svg>

--- a/gnome-shell/src/toggle-off.svg
+++ b/gnome-shell/src/toggle-off.svg
@@ -35,15 +35,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1111"
-     inkscape:window-height="712"
+     inkscape:window-width="1352"
+     inkscape:window-height="809"
      id="namedview22"
      showgrid="false"
      inkscape:zoom="7.5652174"
-     inkscape:cx="18.571839"
+     inkscape:cx="-7.0057472"
      inkscape:cy="10.074713"
-     inkscape:window-x="180"
-     inkscape:window-y="189"
+     inkscape:window-x="131"
+     inkscape:window-y="155"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg20" />
   <rect
@@ -54,10 +54,10 @@
      x="0.625"
      height="20.910999"
      width="44.445999"
-     style="fill:#dcdfe3;stroke:#c2c8ce;stroke-linecap:round;stroke-linejoin:round;marker:none;fill-opacity:1;stroke-opacity:1" />
+     style="fill:#dddddd;stroke:#c2c2c2;stroke-linecap:round;stroke-linejoin:round;marker:none;fill-opacity:1;stroke-opacity:1" />
   <rect
      id="rect4"
-     style="fill:#fbfbfc;stroke:#b3bbc3;stroke-linecap:round;stroke-linejoin:round;marker:none;fill-opacity:1;stroke-opacity:1"
+     style="fill:#ffffff;stroke:#c2c2c2;stroke-linecap:round;stroke-linejoin:round;marker:none;fill-opacity:1;stroke-opacity:1"
      width="21.143"
      height="20.910999"
      x="0.54299998"

--- a/gnome-shell/src/toggle-on-dark.svg
+++ b/gnome-shell/src/toggle-on-dark.svg
@@ -73,9 +73,9 @@
      stroke="#030e1b"
      stroke-width="1.085"
      id="g14"
-     style="stroke:#21a434;stroke-opacity:1">
+     style="stroke:#7C436F;stroke-opacity:1">
     <rect
-       style="marker:none;stroke:#001703;stroke-opacity:1;fill:#21a434;fill-opacity:1"
+       style="marker:none;stroke:#001703;stroke-opacity:1;fill:#7C436F;fill-opacity:1"
        width="44.446"
        height="20.911"
        x=".625"

--- a/gnome-shell/src/toggle-on-dark.svg
+++ b/gnome-shell/src/toggle-on-dark.svg
@@ -39,10 +39,10 @@
      id="namedview18"
      showgrid="false"
      inkscape:zoom="7.5652174"
-     inkscape:cx="14.738506"
+     inkscape:cx="10.045977"
      inkscape:cy="11"
      inkscape:window-x="78"
-     inkscape:window-y="27"
+     inkscape:window-y="29"
      inkscape:window-maximized="0"
      inkscape:current-layer="g14" />
   <defs
@@ -69,30 +69,26 @@
        gradientTransform="translate(-19)" />
   </defs>
   <g
-     transform="translate(0 -291.18)"
-     stroke="#030e1b"
-     stroke-width="1.085"
+     transform="translate(0,-291.18)"
      id="g14"
-     style="stroke:#7C436F;stroke-opacity:1">
+     style="stroke:#7c436f;stroke-width:1.08500004;stroke-opacity:1">
     <rect
-       style="marker:none;stroke:#001703;stroke-opacity:1;fill:#7C436F;fill-opacity:1"
-       width="44.446"
-       height="20.911"
-       x=".625"
+       style="fill:#7c436f;fill-opacity:1;stroke:#222222;stroke-opacity:1;marker:none"
+       width="44.445999"
+       height="20.910999"
+       x="0.625"
        y="291.715"
        rx="10.455"
        ry="10.073"
-       fill="#15539e"
        id="rect10" />
     <rect
        ry="10.455"
        rx="10.455"
        y="291.715"
-       x="24.304"
-       height="20.911"
+       x="24.304001"
+       height="20.910999"
        width="21.143"
-       style="marker:none;stroke:#001703;stroke-opacity:1"
-       fill="url(#b)"
+       style="fill:#595959;stroke:#222222;stroke-opacity:1;marker:none;fill-opacity:1"
        id="rect12" />
   </g>
 </svg>

--- a/gnome-shell/src/toggle-on-hc.svg
+++ b/gnome-shell/src/toggle-on-hc.svg
@@ -92,7 +92,7 @@
          id="toggle-on"
          inkscape:label="#g8481">
         <rect
-           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3eb34f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#924D8B;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            id="rect8475"
            width="34.850178"
            height="4.0216675"
@@ -102,7 +102,7 @@
            ry="2.0108337" />
         <circle
            transform="scale(-1,1)"
-           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#3eb34f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#924D8B;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            id="circle8463"
            cx="-591.0213"
            cy="1072.9402"

--- a/gnome-shell/src/toggle-on-intl.svg
+++ b/gnome-shell/src/toggle-on-intl.svg
@@ -7,7 +7,6 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="46"
@@ -18,30 +17,7 @@
    inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
    sodipodi:docname="toggle-on-intl.svg">
   <defs
-     id="defs2745">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient3329">
-      <stop
-         style="stop-color:#39393a;stop-opacity:1;"
-         offset="0"
-         id="stop3325" />
-      <stop
-         style="stop-color:#302f30;stop-opacity:1"
-         offset="1"
-         id="stop3327" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3329"
-       id="linearGradient3331"
-       x1="53"
-       y1="294.42917"
-       x2="53"
-       y2="309.80417"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-19)" />
-  </defs>
+     id="defs2745" />
   <sodipodi:namedview
      id="base"
      pagecolor="#535353"
@@ -50,8 +26,8 @@
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
      inkscape:zoom="8"
-     inkscape:cx="61.154086"
-     inkscape:cy="-14.474547"
+     inkscape:cx="37.029086"
+     inkscape:cy="0.025453"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -60,11 +36,11 @@
      borderlayer="true"
      inkscape:showpageshadow="false"
      showborder="false"
-     inkscape:window-width="1842"
-     inkscape:window-height="908"
-     inkscape:window-x="78"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1">
+     inkscape:window-width="1219"
+     inkscape:window-height="738"
+     inkscape:window-x="141"
+     inkscape:window-y="194"
+     inkscape:window-maximized="0">
     <inkscape:grid
        type="xygrid"
        id="grid3298" />
@@ -87,7 +63,7 @@
      id="layer1"
      transform="translate(0,-291.17916)">
     <rect
-       style="opacity:1;vector-effect:none;fill:#924D8B;fill-opacity:1;stroke:#001703;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       style="opacity:1;vector-effect:none;fill:#924d8b;fill-opacity:1;stroke:#222222;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
        id="rect3296"
        width="44.446434"
        height="20.910645"
@@ -103,6 +79,6 @@
        height="20.910645"
        width="21.142862"
        id="rect3300"
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient3331);fill-opacity:1;stroke:#001703;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+       style="opacity:1;vector-effect:none;fill:#595959;fill-opacity:1;stroke:#222222;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
   </g>
 </svg>

--- a/gnome-shell/src/toggle-on-intl.svg
+++ b/gnome-shell/src/toggle-on-intl.svg
@@ -87,7 +87,7 @@
      id="layer1"
      transform="translate(0,-291.17916)">
     <rect
-       style="opacity:1;vector-effect:none;fill:#21a434;fill-opacity:1;stroke:#001703;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       style="opacity:1;vector-effect:none;fill:#924D8B;fill-opacity:1;stroke:#001703;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
        id="rect3296"
        width="44.446434"
        height="20.910645"

--- a/gnome-shell/src/toggle-on.svg
+++ b/gnome-shell/src/toggle-on.svg
@@ -50,9 +50,9 @@
      transform="translate(0 -291.18)"
      stroke="#2b73cc"
      id="g6"
-     style="stroke:#21a434;stroke-opacity:1">
+     style="stroke:#924D8B;stroke-opacity:1">
     <rect
-       style="marker:none;font-variant-east_asian:normal;stroke:#009f16;stroke-opacity:1;fill:#3eb34f;fill-opacity:1"
+       style="marker:none;font-variant-east_asian:normal;stroke:#924D8B;stroke-opacity:1;fill:#924D8B;fill-opacity:1"
        width="44.446"
        height="20.911"
        x=".625"
@@ -68,7 +68,7 @@
        x="24.304"
        height="20.911"
        width="21.143"
-       style="marker:none;font-variant-east_asian:normal;stroke:#009f16;stroke-opacity:1"
+       style="marker:none;font-variant-east_asian:normal;stroke:#924D8B;stroke-opacity:1"
        fill="#f8f7f7"
        stroke-linecap="round"
        stroke-linejoin="round"

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -72,12 +72,12 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 //special cased widget colors
 $suggested_bg_color: if($variant=='light', $green, darken($green, 5%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
-$progress_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
-$progress_border_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
-$checkradio_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
+$progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
+$progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
+$checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
 $checkradio_fg_color: #ffffff;
-$switch_bg_color: if($variant=='light', $darkblue, lighten($darkblue, 4%));
-$switch_border_color: if($variant=='light', darken($darkblue, 15%), darken(lighten($darkblue, 4%), 30%));
-$focus_border_color: darken($blue, if($variant=='light', 0%, 15%));
+$switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
+$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken(lighten($aubergine, 4%), 30%));
+$focus_border_color: $focus_ring;
 $text_selected_bg_color: $orange;
 $text_selected_fg_color: #ffffff;

--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -2815,12 +2815,12 @@ switch {
 
     @if $variant == 'light' {
       @include button(normal-alt, $edge: $shadow_color);
-    } 
+    }
     @else {
       @include button(normal-alt, $c: lighten($bg_color,6%), $edge: $shadow_color);
     }
   }
-  
+
   image { color: transparent; } /* only show i / o for the accessible theme */
 
   &:hover slider {

--- a/gtk/src/default/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/default/gtk-3.20/_ubuntu-colors.scss
@@ -10,6 +10,10 @@ $porcelain: #F7F7F7;
 $silk: #CCC;
 $ash: #878787;
 
+$light_aubergine: #77216F;
+$mid_aubergine: #5E2750;
+$dark_aubergine: #2C001E;
+
 // Utility
 $red: #c7162b;
 $orange: #E95420;
@@ -19,6 +23,9 @@ $blue: #19B6EE;
 $linkblue: #007aa6;
 $darkblue: #335280;
 $purple: #762572;
+
+$aubergine: if($variant == 'light', #924D8B, darken(#924D8B, 4%));
+$focus_ring: lighten($aubergine, 18%);
 
 // Terminal colors
 $terminal_bg_color: #300A24;


### PR DESCRIPTION
As per PR title, this change is a try for replacing the blue with aubergine. The color relationships between the widget that used blue are kept the same, that is:

- checkradio, switch and progress bar share the same dark tone (aubergine in this case)
- focus ring is a lighter variant than the color for the widgets above
- **link color is still blue**, since aubergine is usually used for "visited link" and might be misunderstood  

TODO:
- [x] fix #1723
- check what gtk2 is using (probably only orange, but let's double check) -> see #1730 
- [x] shell dark: slider handle is too dark
- gtk dark: slider-has-mark... is too dark (review the assets) -> see #1728
- [from @madsrh] consider #6e3c61 as base aubergine (for checkboxes, sliders, switches) -> see #1731 
- [x] fix scrollbar through color on osd

EDIT: to avoid blocking development too much, I opened bug/discussion tickets for the remaining open points, so that we can merge this PR if you also think it's ready. 