### PR TITLE
Crisp dark switch border

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -65,7 +65,7 @@ $progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 4%)
 $checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
 $checkradio_fg_color: #ffffff;
 $switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
-$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken(lighten($aubergine, 4%), 30%));
+$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken($borders_color, 5%));
 $focus_border_color: $focus_ring;
 $text_selected_bg_color: $orange;
 $text_selected_fg_color: #ffffff;

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -77,7 +77,7 @@ $progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 4%)
 $checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
 $checkradio_fg_color: #ffffff;
 $switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
-$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken(lighten($aubergine, 4%), 30%));
+$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken($borders_color, 5%));
 $focus_border_color: $focus_ring;
 $text_selected_bg_color: $orange;
 $text_selected_fg_color: #ffffff;


### PR DESCRIPTION
- by using a darkened $borders_color instead of the purple base

![image](https://user-images.githubusercontent.com/15329494/72345542-ef57ef80-36cb-11ea-86b1-8f46588a9b97.png)

Closes #1732 