### PR TITLE
gtk: grey selected filemenu item

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -128,6 +128,7 @@ menubar,
   > menuitem {
     &:hover {
       color: $fg_color;
+      background-color: $popover_hover_color;
     }
   }
 }


### PR DESCRIPTION
Use popover hover color for menuitems inside the menu bar

see #1703 

![image](https://user-images.githubusercontent.com/2883614/72354689-76b25c80-36e6-11ea-9640-2a219451f4db.png)
![image](https://user-images.githubusercontent.com/2883614/72354720-86ca3c00-36e6-11ea-92b4-24b38faedf04.png)
 