### PR TITLE
Reorganize colors and includes

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -60,12 +60,10 @@ $dash-opaque-alpha-value: 0.0;
 //special cased widget colors
 $suggested_bg_color: if($variant=='light', $green, darken($green, 5%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
-$progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
-$progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
-$checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
+$progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
+$progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
+$checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $checkradio_fg_color: #ffffff;
-$switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
-$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken(lighten($aubergine, 4%), 30%));
-$focus_border_color: $focus_ring;
-$text_selected_bg_color: $orange;
-$text_selected_fg_color: #ffffff;
+$switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
+$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken($borders_color, 5%));
+$focus_border_color: lighten($aubergine, 14%);

--- a/gnome-shell/src/gnome-shell-sass/_ubuntu-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_ubuntu-colors.scss
@@ -10,15 +10,26 @@ $porcelain: #F7F7F7;
 $silk: #CCC;
 $ash: #878787;
 
-// Utility
-$red: #c7162b;
-$orange: #E95420;
-$yellow: #f99b11;
-$green: #0e8420;
-$blue: #19B6EE;
-$darkblue: #335280;
-$linkblue: #007aa6;
+// Purples
+$aubergine: #924D8B;
 $purple: #762572;
+$light_aubergine: #77216F;
+$mid_aubergine: #5E2750;
+$dark_aubergine: #2C001E;
 
-$aubergine: if($variant == 'light', #924D8B, darken(#924D8B, 4%));
-$focus_ring: lighten($aubergine, 18%);
+// Reds
+$red: #c7162b;
+
+// Oranges
+$orange: #E95420;
+
+// Yellows
+$yellow: #f99b11;
+
+// Greens
+$green: #0e8420;
+
+// Blues
+$blue: #19B6EE;
+$linkblue: #007aa6;
+$darkblue: #335280;

--- a/gtk/src/default/gtk-3.0/_colors.scss
+++ b/gtk/src/default/gtk-3.0/_colors.scss
@@ -78,6 +78,18 @@ $backdrop_scrollbar_slider_color: transparentize($backdrop_fg_color, 0.4);
 $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdrop_bg_color, $backdrop_base_color, 20%));
 
 // Headerbar widgets colors
+$headerbar_bg_color: #323030;
+$menubar_bg_color: $headerbar_bg_color;
+$headerbar_fg_color: $porcelain;
+$headerbar_border_color: lighten($headerbar_bg_color, 8%);
+$headerbar_text_color: $silk;
+$headerbar_insensitive_color: mix($headerbar_fg_color, $headerbar_bg_color, 50%);
+//
+$backdrop_headerbar_bg_color: $headerbar_bg_color;
+$backdrop_headerbar_fg_color: mix($headerbar_fg_color, $headerbar_bg_color, 70%);
+$backdrop_headerbar_text_color: mix($headerbar_text_color, $backdrop_headerbar_bg_color, 70%);
+$backdrop_headerbar_insensitive_color: mix($headerbar_fg_color, $backdrop_headerbar_bg_color, 70%);
+$backdrop_menubar_bg_color: lighten($menubar_bg_color, 5%);
 $hb_pathbar_bg: lighten($headerbar_bg_color, 5%);
 $hb_pathbar_bg_backdrop: mix(lighten($headerbar_bg_color, 5%), $headerbar_bg_color, 50%);
 $hb_pathbar_border_backdrop: darken($hb_pathbar_bg_backdrop, 2%);

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -131,17 +131,21 @@ $ambiance: null !default;
 /************
  * Terminal *
  ************/
+
+$_terminal_bg_color: #300A24;
+$_terminal_fg_color: white;
+
 terminal-window {
 
     // use unity 8 colors
     // only colors, let everything else be inherited
     .terminal-screen {
         // inherits from .background
-        background-color: $terminal_bg_color;
-        color: $terminal_fg_color;
+        background-color: $_terminal_bg_color;
+        color: $_terminal_fg_color;
 
         &:backdrop {
-            background-color: lighten($terminal_bg_color, 2%);
+            background-color: lighten($_terminal_bg_color, 2%);
             color: $backdrop_selected_fg_color;
         }
     }

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -72,12 +72,20 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 //special cased widget colors
 $suggested_bg_color: if($variant=='light', $green, darken($green, 5%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
-$progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
-$progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
-$checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
+$progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
+$progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
+$checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $checkradio_fg_color: #ffffff;
-$switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 4%));
-$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken(lighten($aubergine, 4%), 30%));
-$focus_border_color: $focus_ring;
-$text_selected_bg_color: $orange;
-$text_selected_fg_color: #ffffff;
+$switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
+$switch_border_color: if($variant=='light', darken($aubergine, 15%), darken($borders_color, 5%));
+$focus_border_color: lighten($aubergine, 14%);
+// Headerbar bg colors for the "mixed" theme
+$headerbar_bg_color: #323030;
+$headerbar_fg_color: $porcelain;
+$headerbar_border_color: lighten($headerbar_bg_color, 8%);
+$headerbar_text_color: $silk;
+$headerbar_insensitive_color: mix($headerbar_fg_color, $headerbar_bg_color, 50%);
+$backdrop_headerbar_bg_color: $headerbar_bg_color;
+$backdrop_headerbar_fg_color: mix($headerbar_fg_color, $headerbar_bg_color, 70%);
+$backdrop_headerbar_text_color: mix($headerbar_text_color, $backdrop_headerbar_bg_color, 70%);
+$backdrop_headerbar_insensitive_color: mix($headerbar_fg_color, $backdrop_headerbar_bg_color, 70%);

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -198,7 +198,7 @@
     // border-bottom-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
     $button_fill: if($variant == 'light', linear-gradient(to top, lighten($c, 2%) 2px, lighten($c, 2%)), linear-gradient(to top, lighten($c, 2%) 2px, lighten($c, 2%))) !global;
     background-image: $button_fill;
-    // @include _button_text_shadow($tc, $c);
+    @include _button_text_shadow($tc, $c);
     @include _shadows(0 1px transparentize(black, 0.9));
   }
 

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -1,6 +1,4 @@
-@import 'tweaks';
 
-$small_radius: 4px;
 $_headerbar_button_bg: lighten($headerbar_bg_color, 6%);
 $_dark_border_color: rgb(20, 19, 19);
 

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -32,20 +32,6 @@ spinner {
   }
 }
 
-// TODO: REMOVE the diff when we fixed this upstream (upstream has blue suggested border color)
-switch {
-  row:selected:not(:disabled) & {
-    @if $variant == 'light' {
-      box-shadow: none;
-      border-color: $selected_borders_color;
-
-      &:backdrop { border-color: $selected_borders_color; }
-
-      slider { &:checked { border-color: $switch_border_color; } }
-    }
-  }
-}
-
 // titlebutton
 button.titlebutton:not(.appmenu) {
 
@@ -171,11 +157,9 @@ menubar,
   border { border: none; }
 }
 
-// fix for gtk 3.28 switches to not show the on/off label
-switch { font-size: 0 }
-
-// Since "we" missed to intoduce a switch color for Adwaita, we now need to restyle the switches in tweaks
-// This really needs an upstream change
+// Since "we" missed to intoduce a switch color for Adwaita, we now need to re-insert the switches in tweaks
+// So it uses thew new switch color variables
+// This really needs an upstream change to remove this code
 
 /**********
  * Switch *
@@ -189,6 +173,7 @@ switch { font-size: 0 }
   color: $fg_color;
   background-color: $dark_fill;
   text-shadow: 0 1px transparentize(black, 0.9);
+  font-size: 0; // fix for gtk 3.28 switches to not show the on/off label
 
   &:checked {
     color: $selected_fg_color;
@@ -268,11 +253,17 @@ switch { font-size: 0 }
 
     &:disabled slider { @include button(backdrop-insensitive); }
   }
-}
 
-// Text selection - staying orange for 20.04 but with the variables we could easily change it here if we want to
-entry selection, text selection, label selection, textview.view text selection {
-  &:focus, & { background-color: $text_selected_bg_color; color: $text_selected_fg_color; }
+  row:selected:not(:disabled) & {
+    @if $variant == 'light' {
+      box-shadow: none;
+      border-color: $selected_borders_color;
+
+      &:backdrop { border-color: $selected_borders_color; }
+
+      slider { &:checked { border-color: $switch_border_color; } }
+    }
+  }
 }
 
 // Blue focus "ring" - upstream is also interested in this, so better get this into upstream at some time

--- a/gtk/src/default/gtk-3.20/_ubuntu-colors.scss
+++ b/gtk/src/default/gtk-3.20/_ubuntu-colors.scss
@@ -10,39 +10,26 @@ $porcelain: #F7F7F7;
 $silk: #CCC;
 $ash: #878787;
 
+// Purples
+$aubergine: #924D8B;
+$purple: #762572;
 $light_aubergine: #77216F;
 $mid_aubergine: #5E2750;
 $dark_aubergine: #2C001E;
 
-// Utility
+// Reds
 $red: #c7162b;
+
+// Oranges
 $orange: #E95420;
+
+// Yellows
 $yellow: #f99b11;
+
+// Greens
 $green: #0e8420;
+
+// Blues
 $blue: #19B6EE;
 $linkblue: #007aa6;
 $darkblue: #335280;
-$purple: #762572;
-
-$aubergine: if($variant == 'light', #924D8B, darken(#924D8B, 4%));
-$focus_ring: lighten($aubergine, 18%);
-
-// Terminal colors
-$terminal_bg_color: #300A24;
-$terminal_base_color: lighten($terminal_bg_color, 5%);
-$terminal_fg_color: white;
-$terminal_borders_color: darken($terminal_bg_color, 10%);
-
-// Widget Colors
-$headerbar_bg_color: #323030;
-$menubar_bg_color: $headerbar_bg_color;
-$headerbar_fg_color: $porcelain;
-$headerbar_border_color: lighten($headerbar_bg_color, 8%);
-$headerbar_text_color: $silk;
-$headerbar_insensitive_color: mix($headerbar_fg_color, $headerbar_bg_color, 50%);
-//
-$backdrop_headerbar_bg_color: $headerbar_bg_color;
-$backdrop_headerbar_fg_color: mix($headerbar_fg_color, $headerbar_bg_color, 70%);
-$backdrop_headerbar_text_color: mix($headerbar_text_color, $backdrop_headerbar_bg_color, 70%);
-$backdrop_headerbar_insensitive_color: mix($headerbar_fg_color, $backdrop_headerbar_bg_color, 70%);
-$backdrop_menubar_bg_color: lighten($menubar_bg_color, 5%);

--- a/gtk/src/default/gtk-3.20/gtk.scss
+++ b/gtk/src/default/gtk-3.20/gtk.scss
@@ -5,5 +5,6 @@ $ambiance: true;
 @import 'drawing';
 @import 'common';
 @import 'apps';
+@import "tweaks";
 @import 'headerbar';
 @import 'colors-public';


### PR DESCRIPTION
- Restructure the _ubuntu-colors.scss to only include our palette (though yet incomplete) and move widget colors to _colors.scss
- Move the two last used terminal colors to _apps.scss and include an underscore to make them not global
- move the @include _tweaks.scss out of _headerbar.scss and include them in gtk.scss to only have the build decide how to create the variants
- don't do if($variant...) checks in the palette file
- don't change any color values in this PR beside $switch_border_color

Closes https://github.com/ubuntu/yaru/issues/1732

No changes to any design or colors (except switch border color)... proof:
![grafik](https://user-images.githubusercontent.com/15329494/72373173-074d6480-3708-11ea-9ff8-dd3a140e0f0e.png)
![grafik](https://user-images.githubusercontent.com/15329494/72373200-1502ea00-3708-11ea-81e4-495382c706ab.png)
![grafik](https://user-images.githubusercontent.com/15329494/72373428-8fcc0500-3708-11ea-92b6-0177bd5b54f6.png)


![grafik](https://user-images.githubusercontent.com/15329494/72373223-23510600-3708-11ea-9021-dec1db6c088e.png)
![grafik](https://user-images.githubusercontent.com/15329494/72373241-2cda6e00-3708-11ea-83b3-835ab551976a.png)

![grafik](https://user-images.githubusercontent.com/15329494/72373275-3d8ae400-3708-11ea-811c-32e30898982a.png)
![grafik](https://user-images.githubusercontent.com/15329494/72373295-467bb580-3708-11ea-876f-2905b02ba02c.png)
