### PR TITLE
Green color improvements

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -17,7 +17,7 @@ $top_hilight: $borders_edge;
 
 $warning_color: $yellow;
 $error_color: $red;
-$success_color: if($variant == 'light', $green, darken($green, 10%));
+$success_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%));
 $destructive_color: if($variant == 'light', $red, darken($red, 10%));
 
 $osd_fg_color: #eeeeec;
@@ -58,8 +58,8 @@ $dash-alpha-value: 0.6;
 $dash-opaque-alpha-value: 0.0;
 
 //special cased widget colors
-$suggested_bg_color: if($variant=='light', $green, darken($green, 5%));
-$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
+$suggested_bg_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%));
+$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 5%), darken($suggested_bg_color, 10%));
 $progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -114,10 +114,10 @@
 
   .notification-badge {
     color: rgba(255, 255, 255, 1);
-    background-color: $green;
+    background-color: $success_color;
     padding: 0.2em 0.5em;
     border-radius: 1em;
-    border: 1px solid darken($green,10%);
+    border: 1px solid darken($success_color,10%);
     box-shadow: -1px 1px 5px 0px transparentize(black, 0.5);
     font-weight: bold;
     text-align: center;

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -30,7 +30,7 @@ $scrollbar_slider_active_color: if($variant=='light', darken($selected_bg_color,
 
 $warning_color: $yellow;
 $error_color: $red;
-$success_color: if($variant == 'light', $green, darken($green, 10%));
+$success_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%));
 $destructive_color: if($variant == 'light', $red, darken($red, 10%));
 
 $osd_fg_color: #eeeeec;
@@ -70,8 +70,8 @@ $backdrop_scrollbar_slider_color: mix($backdrop_fg_color, $backdrop_bg_color, 40
 $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdrop_bg_color, $backdrop_base_color, 20%));
 
 //special cased widget colors
-$suggested_bg_color: if($variant=='light', $green, darken($green, 5%));
-$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 15%), darken($suggested_bg_color, 30%));
+$suggested_bg_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%));
+$suggested_border_color: if($variant=='light', darken($suggested_bg_color, 5%), darken($suggested_bg_color, 10%));
 $progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -120,6 +120,9 @@ headerbar,
         &:active,
         &:checked {
           @include button(active, $b_color, white);
+          @if $ambiance==true {
+            border-color: darken($suggested_bg_color, 15%);
+          }
         }
 
         &:backdrop,
@@ -353,7 +356,7 @@ headerbar,
         &:active {
           @include button(active);
 
-          border-color: $suggested_border_color;
+          border-color: darken($suggested_border_color, 10%);
         }
 
         &:disabled {


### PR DESCRIPTION
- vanilla green looks great but it is a little bit too dark for gtk and gnome shell
- Lighten up all greens by 5% (shell and gtk)

(Left old, right upper side new [5% lighter])
![grafik](https://user-images.githubusercontent.com/15329494/72496908-50e2a000-382b-11ea-9ebe-fc81b22f7817.png)


- adapt the green border for mixed theme pressed buttons in the headerbar to look in the other themes: same color as the bg
(Pressed button: )
![Bildschirmfoto-20200116063621-384x131](https://user-images.githubusercontent.com/15329494/72496813-05c88d00-382b-11ea-96ca-ae4416948b8f.png)

