### PR TITLE
tweaks: add missing undershoot style

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -612,3 +612,49 @@ notebook {
     &:backdrop { background-color: $backdrop_base_color; }
   }
 }
+
+scrolledwindow {
+  // This is used when content is touch-dragged past boundaries.
+  // draws a box on top of the content, the size changes programmatically.
+  overshoot, undershoot {
+    &.top {
+      @include overshoot(top);
+
+      &:backdrop { @include overshoot(top, backdrop); }
+    }
+
+    &.bottom {
+      @include overshoot(bottom);
+
+      &:backdrop { @include overshoot(bottom, backdrop); }
+    }
+
+    &.left {
+      @include overshoot(left);
+
+      &:backdrop { @include overshoot(left, backdrop); }
+    }
+
+    &.right {
+      @include overshoot(right);
+
+      &:backdrop { @include overshoot(right, backdrop); }
+    }
+  }
+
+
+  junction { // the small square between two scrollbars
+    border-color: transparent;
+    // the border image is used to add the missing dot between the borders, details, details, details...
+    border-image: linear-gradient(to bottom, $borders_color 1px, transparent 1px) 0 0 0 1 / 0 1px stretch;
+    background-color: $scrollbar_bg_color;
+
+    &:dir(rtl) { border-image-slice: 0 1 0 0; }
+
+    &:backdrop {
+      border-image-source: linear-gradient(to bottom, $backdrop_borders_color 1px, transparent 1px);
+      background-color: $backdrop_scrollbar_bg_color;
+      transition: $backdrop_transition;
+    }
+  }
+}


### PR DESCRIPTION
In previous notebook's tab redesign, undershoot style was left in
common.scss, so that - after upstream sync - it is now gone.

Add again the style in tweaks.scss