### PR TITLE
common: reduce entry side padding

### DIFF
--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -276,8 +276,8 @@ spinner {
 entry {
   %entry_basic, & {
     min-height: $_entry_height;
-    padding-left: 8px;
-    padding-right: 8px;
+    padding-left: 6px;
+    padding-right: 6px;
     border: 1px solid;
     border-radius: $button_radius;
     transition: all 200ms $ease-out-quad;


### PR DESCRIPTION
8px of side padding on entries can be mistaken by an empty space. Reduce
the side padding by half (4px).

![image](https://user-images.githubusercontent.com/2883614/72521541-e85fe700-385b-11ea-91cd-e09020f4a9f6.png)


closes #1705