### PR TITLE
tweaks: notebook tab hover text color

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -311,7 +311,7 @@ notebook {
           border: 1px solid transparent;
           border-radius: 4px 4px 0 0;
 
-          &:hover {
+          &:hover:not(:backdrop) {
             background-color: transparentize($base_color, 0.5);
             box-shadow: none;
             border-color: $borders_color;
@@ -340,7 +340,7 @@ notebook {
           border: 1px solid transparent;
           border-radius: 0 0 4px 4px;
 
-          &:hover {
+          &:hover:not(:backdrop) {
             background-color: transparentize($base_color, 0.5);
             box-shadow: none;
             border-color: $borders_color;
@@ -369,7 +369,7 @@ notebook {
           border: 1px solid transparent;
           border-radius: 4px 0 0 4px;
 
-          &:hover {
+          &:hover:not(:backdrop) {
             background-color: transparentize($base_color, 0.5);
             box-shadow: none;
             border-color: $borders_color;
@@ -398,7 +398,7 @@ notebook {
           border: 1px solid transparent;
           border-radius: 0 4px 4px 0;
 
-          &:hover {
+          &:hover:not(:backdrop) {
             background-color: transparentize($base_color, 0.5);
             box-shadow: none;
             border-color: $borders_color;

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -312,6 +312,7 @@ notebook {
           border-radius: 4px 4px 0 0;
 
           &:hover {
+            background-color: transparentize($base_color, 0.5);
             box-shadow: none;
             border-color: $borders_color;
           }
@@ -340,6 +341,7 @@ notebook {
           border-radius: 0 0 4px 4px;
 
           &:hover {
+            background-color: transparentize($base_color, 0.5);
             box-shadow: none;
             border-color: $borders_color;
           }
@@ -368,6 +370,7 @@ notebook {
           border-radius: 4px 0 0 4px;
 
           &:hover {
+            background-color: transparentize($base_color, 0.5);
             box-shadow: none;
             border-color: $borders_color;
           }
@@ -396,6 +399,7 @@ notebook {
           border-radius: 0 4px 4px 0;
 
           &:hover {
+            background-color: transparentize($base_color, 0.5);
             box-shadow: none;
             border-color: $borders_color;
           }
@@ -494,7 +498,7 @@ notebook {
       border-color: transparent; //
 
       &:hover {
-        color: mix($insensitive_fg_color, $fg_color, 50%);
+        color: $fg_color;
 
         &.reorderable-page {
           border-color: transparentize($borders_color, 0.7);


### PR DESCRIPTION
On hover, notebook tab's text is grey and so it might be mistaken for
disabled.

This change sets for tab's text on hover the same color that unchecked
tab's text have.
Moreover it sets a slightly brighter background color, still less than
checked tabs, to provide more feedback to the user.

closes #1762

![image](https://user-images.githubusercontent.com/2883614/72684935-173cbe00-3ae5-11ea-8283-73071f78371a.png)
![image](https://user-images.githubusercontent.com/2883614/72684942-27549d80-3ae5-11ea-8d5b-36eb5a1a565e.png)
