### PR TITLE
shell: improve scrollbar border in dark mode

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -141,9 +141,9 @@ StScrollBar {
   -barlevel-background-color: mix($borders_color, $bg_color, 50%);
   -barlevel-border-color: $borders_color; //trough border color
   -barlevel-active-background-color: $progress_bg_color; //active trough fill
-  -barlevel-active-border-color: if($variant == 'light', $progress_bg_color, $borders_color); //active trough border
+  -barlevel-active-border-color: if($variant == 'light', $progress_bg_color, darken($progress_bg_color, 10%)); //active trough border
   -barlevel-overdrive-color: $destructive_color;
-  -barlevel-overdrive-border-color: darken($destructive_color,10%);
+  -barlevel-overdrive-border-color: darken($destructive_color, 10%);
   -barlevel-overdrive-separator-width: 0.2em;
   -barlevel-border-width: 1px;
   -slider-handle-radius: 8px;


### PR DESCRIPTION
Using deep dark border for scrollbar makes the scrollbar look way
smaller than in light variant and also clashes with the current border
of overdrive.

This change aligns the active scrollbar border to the overdrive one,
using a darker aubergine instead that a dark color. This, of course,
only for the dark variant.

Before
![image](https://user-images.githubusercontent.com/2883614/72801083-1329b100-3c49-11ea-99bd-825615bbfd28.png)
After
![image](https://user-images.githubusercontent.com/2883614/72801014-ebd2e400-3c48-11ea-88b0-2f24282fb7f0.png)

Before with overdrive
![image](https://user-images.githubusercontent.com/2883614/72801144-2dfc2580-3c49-11ea-90e5-256af6a36216.png)
After with overdrive
![image](https://user-images.githubusercontent.com/2883614/72801207-4cfab780-3c49-11ea-8502-370e5cf2a9e0.png)
