### PR TITLE
tweaks: use lighter/darker border for checked check- and radio-boxes

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -675,4 +675,21 @@ radio {
       }
     }
   }
+
+  & {
+    // for checked
+    @each $t in (':checked'), (':indeterminate') {
+      &#{$t} {
+        @each $state, $t in ("", "normal"),
+                            (":hover", "hover"),
+                            (":active", "active") {
+          &#{$state} {
+            border-color: if($variant=='light', darken($checkradio_bg_color, 10%), lighten($checkradio_bg_color, 5%));
+          }
+        }
+      }
+    }
+  }
 }
+
+


### PR DESCRIPTION
Use darker border in light variant and lighter border in dark variant to
increase the contrast with the background

Right=current, Left=new
![image](https://user-images.githubusercontent.com/2883614/72971008-1b105f00-3dc9-11ea-8a8a-4e1cd4a6ce7e.png)

![image](https://user-images.githubusercontent.com/2883614/72970978-0b911600-3dc9-11ea-94f7-ae0596754713.png)
