### PR TITLE
focus ring: review focus ring for some widgets

### DIFF
--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -78,7 +78,7 @@ $checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $checkradio_fg_color: #ffffff;
 $switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $switch_border_color: if($variant=='light', darken($aubergine, 15%), darken($borders_color, 5%));
-$focus_border_color: lighten($aubergine, 14%);
+$focus_border_color: transparentize(lighten($aubergine, 14%), 0.3);
 // Headerbar bg colors for the "mixed" theme
 $headerbar_bg_color: #323030;
 $headerbar_fg_color: $porcelain;

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -193,7 +193,7 @@
   // normal button
   //
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    outline-color: $focus_border_color;
     border-color: if($c != $bg_color, _border_color($c), $borders_color);
     // border-bottom-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
     $button_fill: if($variant == 'light', linear-gradient(to top, lighten($c, 2%) 2px, lighten($c, 2%)), linear-gradient(to top, lighten($c, 2%) 2px, lighten($c, 2%))) !global;
@@ -207,7 +207,7 @@
   // hovered button
   //
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    outline-color: $focus_border_color;
     border-color: if($c != $bg_color, _border_color($c), $borders_color);
     border-bottom-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
     @if $variant == 'light' {
@@ -229,7 +229,7 @@
   // normal button alternative look
   //
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    outline-color: $focus_border_color;
     border-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
     @include _button_text_shadow($tc, $c);
     @if $variant == 'light' {
@@ -251,7 +251,7 @@
   // hovered button alternative look
   //
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    outline-color: $focus_border_color;
     border-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
     @if $variant == 'light' {
       $button_fill: linear-gradient(to bottom, lighten($c, 9%) 10%, lighten($c, 4%) 90%) !global;
@@ -272,7 +272,7 @@
   // pushed button
   //
     color: $tc;
-    outline-color: transparentize($tc, 0.7);
+    outline-color: $focus_border_color;
     border-color: if($c != $bg_color, _border_color($c), $borders_color);
     $button_fill: if($variant == 'light', image(darken($c, 14%)), image(darken($c, 9%))) !global;
     background-image: $button_fill;

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -267,21 +267,48 @@ menubar,
   }
 }
 
-// Blue focus "ring" - upstream is also interested in this, so better get this into upstream at some time
+// Focus "ring" - upstream is also interested in this, so better get this into upstream at some time
 *:not(button) {
   outline-color: $focus_border_color;
   outline-style: solid;
   outline-offset: -2px;
   outline-width: 2px;
-  -gtk-outline-radius: $button-radius - 2;
+  -gtk-outline-radius: $button-radius;
 }
-// We need to re-evaluate where we want the ring though
-switch slider {
+
+button {
   outline-color: $focus_border_color;
   outline-style: solid;
   outline-offset: -1px;
   outline-width: 2px;
+  -gtk-outline-radius: $button-radius;
+}
+
+switch slider {
+  outline-color: $focus_border_color;
+  outline-style: solid;
+  outline-offset: -2px;
+  outline-width: 2px;
   -gtk-outline-radius: 100%;
+}
+
+checkbutton,
+radiobutton {
+  outline-color: $focus_border_color;
+  outline-offset: 1px;
+  outline-width: 2px;
+}
+
+row {
+  outline-color: $focus_border_color;
+  outline-offset: -2px;
+
+  &:selected {
+    outline-color: $bg_color;
+    outline-style: dashed;
+    outline-width: 1px;
+    -gtk-outline-radius: 1px;
+  }
 }
 
 /*************


### PR DESCRIPTION
The focus ring (outline) of the following widgets have been reviewd
taking care of their peculiarities

- button
    it required a change in drawing, where the outline-color was
    somehow hardcoded
- switch
- check/radio button
- row (selected/unselected)
    it required - in selected state - a different outline. When
    selected, the row's background is a solid orange, where the
    standard aubergine outline is not visible enough. For this
    reason bg_color has been choosen. Moreover, since bg_color
    is the same as the row's backgroud window, a dashed line has
    been preferred, so that it is clear that it is an outline and
    not a border or a smaller row.

![image](https://user-images.githubusercontent.com/2883614/73028590-1fbf2c80-3e36-11ea-81a2-1fde4bb37f02.png)
![image](https://user-images.githubusercontent.com/2883614/73028625-35cced00-3e36-11ea-9f0a-abc209271cc0.png)
![image](https://user-images.githubusercontent.com/2883614/73028658-45e4cc80-3e36-11ea-982e-e4b864387389.png)
![image](https://user-images.githubusercontent.com/2883614/73028742-7298e400-3e36-11ea-9f1d-d8766c1c3b56.png)
![image](https://user-images.githubusercontent.com/2883614/73028800-91977600-3e36-11ea-9553-11e5010972d0.png)
![image](https://user-images.githubusercontent.com/2883614/73028870-b55abc00-3e36-11ea-8134-656d98da2afd.png)
![image](https://user-images.githubusercontent.com/2883614/73028897-c86d8c00-3e36-11ea-925c-b2699d71d4ab.png)
![image](https://user-images.githubusercontent.com/2883614/73028939-df13e300-3e36-11ea-9a1f-c32ba23b32b0.png)

