### PR TITLE
TESTING PR: More contrast for context menus

### DIFF
--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -19,7 +19,7 @@ $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), li
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
-$menu_color: if($variant == 'light', $base_color, lighten($bg_color, 3%));
+$menu_color: if($variant == 'light', $base_color, lighten($bg_color, 2%));
 $popover_bg_color: if($variant == 'light', lighten($bg_color, 1%), $menu_color);
 $popover_hover_color: transparentize($fg_color, 0.85);
 

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -20,7 +20,7 @@ $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
 $menu_color: if($variant == 'light', $base_color, lighten($bg_color, 2%));
-$popover_bg_color: if($variant == 'light', lighten($bg_color, 1%), $menu_color);
+$popover_bg_color: lighten($bg_color, if($variant == 'light', 1%, 0%));
 $popover_hover_color: transparentize($fg_color, 0.85);
 
 $scrollbar_bg_color: if($variant == 'light', mix($bg_color, $fg_color, 80%), mix($base_color, $bg_color, 50%));

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -19,8 +19,8 @@ $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), li
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
-$menu_color: if($variant == 'light', $base_color, mix($bg_color, $base_color, 80%));
-$popover_bg_color: lighten($bg_color, if($variant == 'light', 1%, 0%));
+$menu_color: if($variant == 'light', $base_color, lighten($bg_color, 3%));
+$popover_bg_color: if($variant == 'light', lighten($bg_color, 1%), $menu_color);
 $popover_hover_color: transparentize($fg_color, 0.85);
 
 $scrollbar_bg_color: if($variant == 'light', mix($bg_color, $fg_color, 80%), mix($base_color, $bg_color, 50%));


### PR DESCRIPTION
More contrast for context menus and popovers 🙈 

This might be a bit too much but IMO the backgrounds in master still blend a bit together 🤷‍♂ 

Left is master and right is `lighten(bg_color, 2%)`

![image](https://user-images.githubusercontent.com/3986894/73032789-5306b900-3e40-11ea-8c73-523ffbde91d7.png)



![image](https://user-images.githubusercontent.com/3986894/73032776-48e4ba80-3e40-11ea-94a8-462235ba8116.png)


![image](https://user-images.githubusercontent.com/3986894/73032714-23f04780-3e40-11ea-84dd-a736d97abc34.png)

![image](https://user-images.githubusercontent.com/3986894/73032974-e9d37580-3e40-11ea-82ea-809fe29ff416.png)

