### PR TITLE
Adding yaru icons for speaker testing

### DIFF
--- a/icons/Suru/48x48/devices/audio-speaker-center-back-testing.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-center-back-testing.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-center-back-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568544"
+     inkscape:cx="16.968311"
+     inkscape:cy="25.936799"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 1.0583333,290.91458 2.9098875,2.77813 v 2.08676 c 0,0 0.7096125,0.69136 2.3828375,0.69136 1.6732249,0 2.3796624,-0.69136 2.3796624,-0.69136 v -2.08676 l 2.9098873,-2.77813 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 3.9094833,288.91116 0.5611812,0.56118 0.2809875,-0.28099 a 2.3804562,2.3804562 0 0 1 3.3670875,0 l 0.2801937,0.28099 0.5611813,-0.56118 -0.2801938,-0.28099 a 3.175,3.175 0 0 0 -4.4894499,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 2.2259396,287.22761 0.5611812,0.56118 0.2801938,-0.28098 a 4.7617062,4.7617062 0 0 1 6.7349686,0 l 0.2801938,0.28098 0.561181,-0.56118 -0.280194,-0.28099 a 5.5562499,5.5562499 0 0 0 -7.8573307,0 z" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-center-back.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-center-back.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-center-back.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="17.341071"
+     inkscape:cy="25.936799"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(0,-0.79374999,0.79374999,0,-5.2915333e-4,297.26458)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8,1.334 4.5,5 H 1.871 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 H 4.5 L 8,14.666 Z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334" />
+      <path
+         d="m 10.524,4.926 -0.707,0.707 0.354,0.354 a 2.999,2.999 0 0 1 0,4.242 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 4,4 0 0 0 0,-5.656 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 12.645,2.805 -0.707,0.707 0.354,0.353 a 5.999,5.999 0 0 1 0,8.485 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 7,7 0 0 0 0,-9.899 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-center-testing.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-center-testing.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-center-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-47.3592"
+     inkscape:cy="25.936799"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 1.0583333,290.9286 2.9098875,-2.77813 v -2.08676 c 0,0 0.7096125,-0.69136 2.3828375,-0.69136 1.6732249,0 2.3796624,0.69136 2.3796624,0.69136 v 2.08676 l 2.9098873,2.77813 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 3.9094833,292.93202 0.5611812,-0.56118 0.2809875,0.28099 a 2.3804562,2.3804562 0 0 0 3.3670875,0 l 0.2801937,-0.28099 0.5611813,0.56118 -0.2801938,0.28099 a 3.175,3.175 0 0 1 -4.4894499,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 2.2259396,294.61557 0.5611812,-0.56118 0.2801938,0.28098 a 4.7617062,4.7617062 0 0 0 6.7349686,0 l 0.2801938,-0.28098 0.561181,0.56118 -0.280194,0.28099 a 5.5562499,5.5562499 0 0 1 -7.8573307,0 z" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-center.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-center.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-center.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="17.341071"
+     inkscape:cy="25.936799"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(0,0.79374999,0.79374999,0,-5.2915333e-4,284.5786)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8,1.334 4.5,5 H 1.871 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 H 4.5 L 8,14.666 Z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334" />
+      <path
+         d="m 10.524,4.926 -0.707,0.707 0.354,0.354 a 2.999,2.999 0 0 1 0,4.242 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 4,4 0 0 0 0,-5.656 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 12.645,2.805 -0.707,0.707 0.354,0.353 a 5.999,5.999 0 0 1 0,8.485 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 7,7 0 0 0 0,-9.899 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-left-back-testing.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-left-back-testing.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-back-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="-37.573672"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 2.40083,287.23092 v 3.96875 l -1.45282791,1.50484 c 0,0 0.0129091,0.99064 1.19605781,2.17378 1.1831488,1.18315 2.1715382,1.19382 2.1715382,1.19382 l 1.5248175,-1.43285 h 3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404131,287.76009 2e-7,0.79363 h 0.3973761 c 1.3150293,-2.4e-4 2.2492587,1.19869 2.2490186,2.51372 l -5.61e-4,0.39682 h 0.7936299 l 5.612e-4,-0.39682 c -2.648e-4,-1.75313 -1.2895189,-3.30709 -3.0426487,-3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404133,285.37896 v 0.79363 l 0.3968151,-5.6e-4 c 2.6303146,-3.5e-4 4.6311806,2.2651 4.6308296,4.89541 l -5.61e-4,0.39682 h 0.79363 l 5.61e-4,-0.39682 c -1.54e-4,-3.06841 -2.3560445,-5.68889 -5.4244596,-5.68904 z" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-left-back.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-left-back.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-back.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="-25.357202"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 2.40083,287.23092 v 3.96875 l -1.45282791,1.50484 c 0,0 0.0129091,0.99064 1.19605781,2.17378 1.1831488,1.18315 2.1715382,1.19382 2.1715382,1.19382 l 1.5248175,-1.43285 h 3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#808080;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404131,287.76009 2e-7,0.79363 h 0.3973761 c 1.3150293,-2.4e-4 2.2492587,1.19869 2.2490186,2.51372 l -5.61e-4,0.39682 h 0.7936299 l 5.612e-4,-0.39682 c -2.648e-4,-1.75313 -1.2895189,-3.30709 -3.0426487,-3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#808080;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404133,285.37896 v 0.79363 l 0.3968151,-5.6e-4 c 2.6303146,-3.5e-4 4.6311806,2.2651 4.6308296,4.89541 l -5.61e-4,0.39682 h 0.79363 l 5.61e-4,-0.39682 c -1.54e-4,-3.06841 -2.3560445,-5.68889 -5.4244596,-5.68904 z" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-left-side-testing.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-left-side-testing.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-side-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-43.546965"
+     inkscape:cy="21.843892"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="M 6.3499999,295.94167 3.571875,293.03178 H 1.4851062 c 0,0 -0.69135621,-0.70961 -0.69135621,-2.38284 0,-1.67322 0.69135621,-2.37966 0.69135621,-2.37966 H 3.571875 l 2.7781249,-2.90989 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 8.3534249,293.09052 -0.5611812,-0.56118 0.2809874,-0.28099 a 2.3804562,2.3804562 0 0 0 0,-3.36709 l -0.2809874,-0.28019 0.5611812,-0.56118 0.2809875,0.28019 a 3.175,3.175 0 0 1 0,4.48945 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 10.036969,294.77406 -0.5611816,-0.56118 0.2809875,-0.28019 a 4.7617062,4.7617062 0 0 0 0,-6.73497 l -0.2809875,-0.2802 0.5611816,-0.56118 0.280987,0.2802 a 5.5562499,5.5562499 0 0 1 0,7.85733 z" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-left-side.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-left-side.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-side.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="21.153306"
+     inkscape:cy="21.843892"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(0.79374999,0,0,-0.79374999,0,297.00053)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8,1.334 4.5,5 H 1.871 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 H 4.5 L 8,14.666 Z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334" />
+      <path
+         d="m 10.524,4.926 -0.707,0.707 0.354,0.354 a 2.999,2.999 0 0 1 0,4.242 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 4,4 0 0 0 0,-5.656 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 12.645,2.805 -0.707,0.707 0.354,0.353 a 5.999,5.999 0 0 1 0,8.485 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 7,7 0 0 0 0,-9.899 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-left-testing.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-left-testing.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.9999998"
+     inkscape:cx="4.4412587"
+     inkscape:cy="27.018551"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 2.3812508,294.08915 v -3.96875 l -1.45282791,-1.50484 c 0,0 0.0129091,-0.99064 1.19605781,-2.17378 1.1831488,-1.18315 2.1715382,-1.19382 2.1715382,-1.19382 l 1.5248175,1.43285 h 3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8208339,293.55998 2e-7,-0.79363 h 0.3973761 c 1.3150293,2.4e-4 2.2492587,-1.19869 2.2490186,-2.51372 l -5.61e-4,-0.39682 h 0.7936299 l 5.612e-4,0.39682 c -2.648e-4,1.75313 -1.2895189,3.30709 -3.0426487,3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8208341,295.94111 v -0.79363 l 0.3968151,5.6e-4 c 2.6303146,3.5e-4 4.6311808,-2.2651 4.6308298,-4.89541 l -5.61e-4,-0.39682 h 0.79363 l 5.61e-4,0.39682 c -1.54e-4,3.06841 -2.3560447,5.68889 -5.4244598,5.68904 z" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-left.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-left.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="20.616327"
+     inkscape:cy="27.018551"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(0.561266,0.561266,0.561266,-0.561266,-2.9280358,290.37176)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8.0413505,1.4181333 4.5058166,4.9536672 1.871,5 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 l 2.6348166,0.08193 3.5355339,3.535534 z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334"
+         sodipodi:nodetypes="cccscccc" />
+      <path
+         d="m 10.634075,4.9536672 -0.7069996,0.707 0.3539996,0.354 c 1.171699,1.1712708 0.93589,3.0715836 -0.235809,4.2428548 l -0.3539996,0.353 0.7069996,0.707 0.354,-0.353 c 1.561528,-1.5619999 1.797337,-4.0948554 0.235809,-5.6568548 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         d="m 12.755289,2.8324536 -0.707,0.707 0.354,0.353 c 2.343511,2.3428848 2.107808,6.1435034 -0.235702,8.4863884 l -0.354,0.353 0.707,0.707 0.354,-0.353 c 2.73334,-2.733614 2.969042,-7.1667749 0.235702,-9.9003884 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-mono-testing.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-mono-testing.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-mono-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="15.875"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#924d8b;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       d="m 8.2072508,285.69785 -0.2800861,0.74569 a 4.4979166,4.4979166 0 0 1 2.9207513,4.20646 4.4979166,4.4979166 0 0 1 -2.9197178,4.20905 l 0.2775024,0.74 A 5.2916663,5.2916663 0 0 0 11.641666,290.65 5.2916663,5.2916663 0 0 0 8.2072508,285.69785 Z m -3.7129516,0.003 A 5.2916663,5.2916663 0 0 0 1.0583333,290.65 5.2916663,5.2916663 0 0 0 4.492749,295.60215 l 0.2800861,-0.74569 A 4.4979166,4.4979166 0 0 1 1.8520833,290.65 4.4979166,4.4979166 0 0 1 4.7718016,286.44095 Z m 2.876827,2.22519 -0.2790526,0.74414 a 2.1166665,2.1166665 0 0 1 1.3745929,1.97972 2.1166665,2.1166665 0 0 1 -1.3735595,1.98076 l 0.2775024,0.74104 A 2.9104166,2.9104166 0 0 0 9.2604165,290.65 2.9104166,2.9104166 0 0 0 7.3711262,287.92614 Z m -2.0417359,0.002 a 2.9104166,2.9104166 0 0 0 -1.889807,2.7218 2.9104166,2.9104166 0 0 0 1.8892903,2.72386 l 0.2790526,-0.74414 A 2.1166665,2.1166665 0 0 1 4.2333332,290.65 2.1166665,2.1166665 0 0 1 5.6068927,288.66924 Z"
+       id="path12788"
+       inkscape:connector-curvature="0" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path13370"
+       cx="6.3499999"
+       cy="290.64999"
+       r="0.52916664" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-mono.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-mono.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-mono.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="27.126599"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00199997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       d="M 31.019531 5.2832031 L 29.960938 8.1015625 A 17 17 0 0 1 41 24 A 17 17 0 0 1 29.964844 39.908203 L 31.013672 42.705078 A 19.999999 19.999999 0 0 0 44 24 A 19.999999 19.999999 0 0 0 31.019531 5.2832031 z M 16.986328 5.2949219 A 19.999999 19.999999 0 0 0 4 24 A 19.999999 19.999999 0 0 0 16.980469 42.716797 L 18.039062 39.898438 A 17 17 0 0 1 7 24 A 17 17 0 0 1 18.035156 8.0917969 L 16.986328 5.2949219 z M 27.859375 13.705078 L 26.804688 16.517578 A 7.9999994 7.9999994 0 0 1 32 24 A 7.9999994 7.9999994 0 0 1 26.808594 31.486328 L 27.857422 34.287109 A 11 11 0 0 0 35 24 A 11 11 0 0 0 27.859375 13.705078 z M 20.142578 13.712891 A 11 11 0 0 0 13 24 A 11 11 0 0 0 20.140625 34.294922 L 21.195312 31.482422 A 7.9999994 7.9999994 0 0 1 16 24 A 7.9999994 7.9999994 0 0 1 21.191406 16.513672 L 20.142578 13.712891 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,284.3)"
+       id="path12788" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path13370"
+       cx="6.3499999"
+       cy="290.64999"
+       r="0.52916664" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-right-back-testing.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-right-back-testing.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-back-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="10.951531"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 10.31875,287.21041 v 3.96875 l 1.452828,1.50484 c 0,0 -0.01291,0.99064 -1.196058,2.17378 -1.1831483,1.18315 -2.1715377,1.19382 -2.1715377,1.19382 l -1.5248175,-1.43285 h -3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8791673,287.73958 -2e-7,0.79363 H 6.481791 c -1.3150293,-2.4e-4 -2.2492587,1.19869 -2.2490186,2.51372 l 5.61e-4,0.39682 H 3.4397035 l -5.612e-4,-0.39682 c 2.648e-4,-1.75313 1.2895189,-3.30709 3.0426487,-3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8791671,285.35845 v 0.79363 l -0.3968151,-5.6e-4 c -2.6303146,-3.5e-4 -4.6311805,2.2651 -4.6308298,4.89541 l 5.613e-4,0.39682 H 1.0584534 l -5.613e-4,-0.39682 c 1.538e-4,-3.06841 2.3560448,-5.68889 5.4244599,-5.68904 z" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-right-back.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-right-back.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-back.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="27.126599"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(-0.561266,-0.561266,-0.561266,0.561266,15.628478,290.94831)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8.0413505,1.4181333 4.5058166,4.9536672 1.871,5 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 l 2.6348166,0.08193 3.5355339,3.535534 z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334"
+         sodipodi:nodetypes="cccscccc" />
+      <path
+         d="m 10.634075,4.9536672 -0.7069996,0.707 0.3539996,0.354 c 1.171699,1.1712708 0.93589,3.0715836 -0.235809,4.2428548 l -0.3539996,0.353 0.7069996,0.707 0.354,-0.353 c 1.561528,-1.5619999 1.797337,-4.0948554 0.235809,-5.6568548 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         d="m 12.755289,2.8324536 -0.707,0.707 0.354,0.353 c 2.343511,2.3428848 2.107808,6.1435034 -0.235702,8.4863884 l -0.354,0.353 0.707,0.707 0.354,-0.353 c 2.73334,-2.733614 2.969042,-7.1667749 0.235702,-9.9003884 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-right-side-testing.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-right-side-testing.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-side-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="-24.596694"
+     inkscape:cy="21.843892"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 6.3500041,295.94167 2.7781249,-2.90989 h 2.086769 c 0,0 0.691356,-0.70961 0.691356,-2.38284 0,-1.67322 -0.691356,-2.37966 -0.691356,-2.37966 H 9.128129 l -2.7781249,-2.90989 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 4.3465791,293.09052 0.5611812,-0.56118 -0.2809874,-0.28099 a 2.3804562,2.3804562 0 0 1 0,-3.36709 l 0.2809874,-0.28019 -0.5611812,-0.56118 -0.2809875,0.28019 a 3.175,3.175 0 0 0 0,4.48945 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 2.6630354,294.77406 0.5611812,-0.56118 -0.2809875,-0.28019 a 4.7617062,4.7617062 0 0 1 0,-6.73497 l 0.2809875,-0.2802 -0.5611812,-0.56118 -0.2809875,0.2802 a 5.5562499,5.5562499 0 0 0 0,7.85733 z" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-right-side.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-right-side.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-side.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="21.153306"
+     inkscape:cy="21.843892"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(-0.79374999,0,0,-0.79374999,12.700004,297.00053)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8,1.334 4.5,5 H 1.871 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 H 4.5 L 8,14.666 Z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334" />
+      <path
+         d="m 10.524,4.926 -0.707,0.707 0.354,0.354 a 2.999,2.999 0 0 1 0,4.242 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 4,4 0 0 0 0,-5.656 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 12.645,2.805 -0.707,0.707 0.354,0.353 a 5.999,5.999 0 0 1 0,8.485 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 7,7 0 0 0 0,-9.899 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-right-testing.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-right-testing.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.656854"
+     inkscape:cx="10.951531"
+     inkscape:cy="25.702661"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 10.319191,294.08915 v -3.96875 l 1.452828,-1.50484 c 0,0 -0.01291,-0.99064 -1.196058,-2.17378 -1.1831483,-1.18315 -2.1715377,-1.19382 -2.1715377,-1.19382 l -1.5248175,1.43285 h -3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8796083,293.55998 -2e-7,-0.79363 H 6.482232 c -1.3150293,2.4e-4 -2.2492587,-1.19869 -2.2490186,-2.51372 l 5.61e-4,-0.39682 H 3.4401445 l -5.612e-4,0.39682 c 2.648e-4,1.75313 1.2895189,3.30709 3.0426487,3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8796081,295.94111 v -0.79363 l -0.3968151,5.6e-4 c -2.6303146,3.5e-4 -4.6311805,-2.2651 -4.6308298,-4.89541 l 5.613e-4,-0.39682 H 1.0588944 l -5.613e-4,0.39682 c 1.538e-4,3.06841 2.3560448,5.68889 5.4244599,5.68904 z" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-speaker-right.svg
+++ b/icons/Suru/48x48/devices/audio-speaker-right.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="27.126599"
+     inkscape:cy="25.702661"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(-0.561266,0.561266,-0.561266,-0.561266,15.628478,290.37176)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8.0413505,1.4181333 4.5058166,4.9536672 1.871,5 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 l 2.6348166,0.08193 3.5355339,3.535534 z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334"
+         sodipodi:nodetypes="cccscccc" />
+      <path
+         d="m 10.634075,4.9536672 -0.7069996,0.707 0.3539996,0.354 c 1.171699,1.1712708 0.93589,3.0715836 -0.235809,4.2428548 l -0.3539996,0.353 0.7069996,0.707 0.354,-0.353 c 1.561528,-1.5619999 1.797337,-4.0948554 0.235809,-5.6568548 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         d="m 12.755289,2.8324536 -0.707,0.707 0.354,0.353 c 2.343511,2.3428848 2.107808,6.1435034 -0.235702,8.4863884 l -0.354,0.353 0.707,0.707 0.354,-0.353 c 2.73334,-2.733614 2.969042,-7.1667749 0.235702,-9.9003884 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-subwoofer-testing.svg
+++ b/icons/Suru/48x48/devices/audio-subwoofer-testing.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-subwoofer-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="24.044194"
+     inkscape:cy="23.999962"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00199997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       d="M 24 11 A 12.999999 12.999999 0 0 0 19.441406 11.84375 L 19.441406 11.841797 A 12.999999 12.999999 0 0 0 19.404297 11.861328 A 12.999999 12.999999 0 0 0 18.316406 12.332031 A 12.999999 12.999999 0 0 0 18.201172 12.386719 A 12.999999 12.999999 0 0 0 17.171875 12.962891 A 12.999999 12.999999 0 0 0 17.078125 13.019531 A 12.999999 12.999999 0 0 0 16.142578 13.669922 A 12.999999 12.999999 0 0 0 15.980469 13.792969 A 12.999999 12.999999 0 0 0 15.203125 14.458984 A 12.999999 12.999999 0 0 0 14.960938 14.683594 A 12.999999 12.999999 0 0 0 14.308594 15.369141 A 12.999999 12.999999 0 0 0 14.072266 15.636719 A 12.999999 12.999999 0 0 0 13.523438 16.341797 A 12.999999 12.999999 0 0 0 13.257812 16.712891 A 12.999999 12.999999 0 0 0 12.826172 17.398438 A 12.999999 12.999999 0 0 0 12.576172 17.832031 A 12.999999 12.999999 0 0 0 12.246094 18.490234 A 12.999999 12.999999 0 0 0 11.998047 19.048828 A 12.999999 12.999999 0 0 0 11.833984 19.441406 L 11.847656 19.445312 A 12.999999 12.999999 0 0 0 11 24.001953 A 12.999999 12.999999 0 0 0 11.845703 28.560547 L 11.841797 28.560547 A 12.999999 12.999999 0 0 0 11.859375 28.59375 A 12.999999 12.999999 0 0 0 12.308594 29.640625 A 12.999999 12.999999 0 0 0 12.400391 29.828125 A 12.999999 12.999999 0 0 0 12.933594 30.785156 A 12.999999 12.999999 0 0 0 13.033203 30.949219 A 12.999999 12.999999 0 0 0 13.666016 31.853516 A 12.999999 12.999999 0 0 0 13.791016 32.017578 A 12.999999 12.999999 0 0 0 14.455078 32.796875 A 12.999999 12.999999 0 0 0 14.683594 33.041016 A 12.999999 12.999999 0 0 0 15.341797 33.671875 A 12.999999 12.999999 0 0 0 15.650391 33.941406 A 12.999999 12.999999 0 0 0 16.332031 34.472656 A 12.999999 12.999999 0 0 0 16.712891 34.744141 A 12.999999 12.999999 0 0 0 17.375 35.162109 A 12.999999 12.999999 0 0 0 17.84375 35.429688 A 12.999999 12.999999 0 0 0 18.46875 35.744141 A 12.999999 12.999999 0 0 0 19.072266 36.011719 A 12.999999 12.999999 0 0 0 19.439453 36.166016 L 19.443359 36.150391 A 12.999999 12.999999 0 0 0 24 36.998047 A 12.999999 12.999999 0 0 0 28.558594 36.154297 L 28.558594 36.15625 A 12.999999 12.999999 0 0 0 28.595703 36.136719 A 12.999999 12.999999 0 0 0 29.671875 35.669922 A 12.999999 12.999999 0 0 0 29.806641 35.605469 A 12.999999 12.999999 0 0 0 30.802734 35.048828 A 12.999999 12.999999 0 0 0 30.941406 34.966797 A 12.999999 12.999999 0 0 0 31.832031 34.345703 A 12.999999 12.999999 0 0 0 32.037109 34.189453 A 12.999999 12.999999 0 0 0 32.78125 33.554688 A 12.999999 12.999999 0 0 0 33.042969 33.308594 A 12.999999 12.999999 0 0 0 33.677734 32.642578 A 12.999999 12.999999 0 0 0 33.941406 32.34375 A 12.999999 12.999999 0 0 0 34.451172 31.691406 A 12.999999 12.999999 0 0 0 34.757812 31.257812 A 12.999999 12.999999 0 0 0 35.146484 30.640625 A 12.999999 12.999999 0 0 0 35.439453 30.132812 A 12.999999 12.999999 0 0 0 35.730469 29.548828 A 12.999999 12.999999 0 0 0 36.013672 28.916016 A 12.999999 12.999999 0 0 0 36.166016 28.556641 L 36.152344 28.552734 A 12.999999 12.999999 0 0 0 37 23.996094 A 12.999999 12.999999 0 0 0 36.154297 19.4375 L 36.158203 19.4375 A 12.999999 12.999999 0 0 0 36.140625 19.404297 A 12.999999 12.999999 0 0 0 35.669922 18.316406 A 12.999999 12.999999 0 0 0 35.615234 18.201172 A 12.999999 12.999999 0 0 0 35.041016 17.171875 A 12.999999 12.999999 0 0 0 34.982422 17.076172 A 12.999999 12.999999 0 0 0 34.332031 16.142578 A 12.999999 12.999999 0 0 0 34.210938 15.982422 A 12.999999 12.999999 0 0 0 33.521484 15.177734 A 12.999999 12.999999 0 0 0 33.335938 14.978516 A 12.999999 12.999999 0 0 0 32.628906 14.302734 A 12.999999 12.999999 0 0 0 32.367188 14.074219 A 12.999999 12.999999 0 0 0 31.640625 13.505859 A 12.999999 12.999999 0 0 0 31.304688 13.267578 A 12.999999 12.999999 0 0 0 30.597656 12.822266 A 12.999999 12.999999 0 0 0 30.171875 12.578125 A 12.999999 12.999999 0 0 0 29.509766 12.246094 A 12.999999 12.999999 0 0 0 28.9375 11.992188 A 12.999999 12.999999 0 0 0 28.560547 11.832031 L 28.556641 11.847656 A 12.999999 12.999999 0 0 0 24 11 z M 24 14 A 9.9999997 9.9999997 0 0 1 34 24 A 9.9999997 9.9999997 0 0 1 24 34 A 9.9999997 9.9999997 0 0 1 14 24 A 9.9999997 9.9999997 0 0 1 24 14 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,284.3)"
+       id="path13990" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#924d8b;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path13370"
+       cx="6.3499999"
+       cy="290.64999"
+       r="1.0583333" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#808080;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="rect13997"
+       width="9.7895832"
+       height="9.7895832"
+       x="1.4552083"
+       y="285.75522"
+       rx="0.97895831"
+       ry="0.97895831" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004"
+       cx="3.175"
+       cy="287.47501"
+       r="0.5291667" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004-1"
+       cx="9.5249996"
+       cy="287.47501"
+       r="0.52916676" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004-2"
+       cx="3.175"
+       cy="293.82501"
+       r="0.52916676" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004-1-7"
+       cx="9.5249996"
+       cy="293.82501"
+       r="0.52916682" />
+  </g>
+</svg>

--- a/icons/Suru/48x48/devices/audio-subwoofer.svg
+++ b/icons/Suru/48x48/devices/audio-subwoofer.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-subwoofer.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="24"
+     inkscape:cy="23.999962"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00199997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       d="M 24 11 A 12.999999 12.999999 0 0 0 19.441406 11.84375 L 19.441406 11.841797 A 12.999999 12.999999 0 0 0 19.404297 11.861328 A 12.999999 12.999999 0 0 0 18.316406 12.332031 A 12.999999 12.999999 0 0 0 18.201172 12.386719 A 12.999999 12.999999 0 0 0 17.171875 12.962891 A 12.999999 12.999999 0 0 0 17.078125 13.019531 A 12.999999 12.999999 0 0 0 16.142578 13.669922 A 12.999999 12.999999 0 0 0 15.980469 13.792969 A 12.999999 12.999999 0 0 0 15.203125 14.458984 A 12.999999 12.999999 0 0 0 14.960938 14.683594 A 12.999999 12.999999 0 0 0 14.308594 15.369141 A 12.999999 12.999999 0 0 0 14.072266 15.636719 A 12.999999 12.999999 0 0 0 13.523438 16.341797 A 12.999999 12.999999 0 0 0 13.257812 16.712891 A 12.999999 12.999999 0 0 0 12.826172 17.398438 A 12.999999 12.999999 0 0 0 12.576172 17.832031 A 12.999999 12.999999 0 0 0 12.246094 18.490234 A 12.999999 12.999999 0 0 0 11.998047 19.048828 A 12.999999 12.999999 0 0 0 11.833984 19.441406 L 11.847656 19.445312 A 12.999999 12.999999 0 0 0 11 24.001953 A 12.999999 12.999999 0 0 0 11.845703 28.560547 L 11.841797 28.560547 A 12.999999 12.999999 0 0 0 11.859375 28.59375 A 12.999999 12.999999 0 0 0 12.308594 29.640625 A 12.999999 12.999999 0 0 0 12.400391 29.828125 A 12.999999 12.999999 0 0 0 12.933594 30.785156 A 12.999999 12.999999 0 0 0 13.033203 30.949219 A 12.999999 12.999999 0 0 0 13.666016 31.853516 A 12.999999 12.999999 0 0 0 13.791016 32.017578 A 12.999999 12.999999 0 0 0 14.455078 32.796875 A 12.999999 12.999999 0 0 0 14.683594 33.041016 A 12.999999 12.999999 0 0 0 15.341797 33.671875 A 12.999999 12.999999 0 0 0 15.650391 33.941406 A 12.999999 12.999999 0 0 0 16.332031 34.472656 A 12.999999 12.999999 0 0 0 16.712891 34.744141 A 12.999999 12.999999 0 0 0 17.375 35.162109 A 12.999999 12.999999 0 0 0 17.84375 35.429688 A 12.999999 12.999999 0 0 0 18.46875 35.744141 A 12.999999 12.999999 0 0 0 19.072266 36.011719 A 12.999999 12.999999 0 0 0 19.439453 36.166016 L 19.443359 36.150391 A 12.999999 12.999999 0 0 0 24 36.998047 A 12.999999 12.999999 0 0 0 28.558594 36.154297 L 28.558594 36.15625 A 12.999999 12.999999 0 0 0 28.595703 36.136719 A 12.999999 12.999999 0 0 0 29.671875 35.669922 A 12.999999 12.999999 0 0 0 29.806641 35.605469 A 12.999999 12.999999 0 0 0 30.802734 35.048828 A 12.999999 12.999999 0 0 0 30.941406 34.966797 A 12.999999 12.999999 0 0 0 31.832031 34.345703 A 12.999999 12.999999 0 0 0 32.037109 34.189453 A 12.999999 12.999999 0 0 0 32.78125 33.554688 A 12.999999 12.999999 0 0 0 33.042969 33.308594 A 12.999999 12.999999 0 0 0 33.677734 32.642578 A 12.999999 12.999999 0 0 0 33.941406 32.34375 A 12.999999 12.999999 0 0 0 34.451172 31.691406 A 12.999999 12.999999 0 0 0 34.757812 31.257812 A 12.999999 12.999999 0 0 0 35.146484 30.640625 A 12.999999 12.999999 0 0 0 35.439453 30.132812 A 12.999999 12.999999 0 0 0 35.730469 29.548828 A 12.999999 12.999999 0 0 0 36.013672 28.916016 A 12.999999 12.999999 0 0 0 36.166016 28.556641 L 36.152344 28.552734 A 12.999999 12.999999 0 0 0 37 23.996094 A 12.999999 12.999999 0 0 0 36.154297 19.4375 L 36.158203 19.4375 A 12.999999 12.999999 0 0 0 36.140625 19.404297 A 12.999999 12.999999 0 0 0 35.669922 18.316406 A 12.999999 12.999999 0 0 0 35.615234 18.201172 A 12.999999 12.999999 0 0 0 35.041016 17.171875 A 12.999999 12.999999 0 0 0 34.982422 17.076172 A 12.999999 12.999999 0 0 0 34.332031 16.142578 A 12.999999 12.999999 0 0 0 34.210938 15.982422 A 12.999999 12.999999 0 0 0 33.521484 15.177734 A 12.999999 12.999999 0 0 0 33.335938 14.978516 A 12.999999 12.999999 0 0 0 32.628906 14.302734 A 12.999999 12.999999 0 0 0 32.367188 14.074219 A 12.999999 12.999999 0 0 0 31.640625 13.505859 A 12.999999 12.999999 0 0 0 31.304688 13.267578 A 12.999999 12.999999 0 0 0 30.597656 12.822266 A 12.999999 12.999999 0 0 0 30.171875 12.578125 A 12.999999 12.999999 0 0 0 29.509766 12.246094 A 12.999999 12.999999 0 0 0 28.9375 11.992188 A 12.999999 12.999999 0 0 0 28.560547 11.832031 L 28.556641 11.847656 A 12.999999 12.999999 0 0 0 24 11 z M 24 14 A 9.9999997 9.9999997 0 0 1 34 24 A 9.9999997 9.9999997 0 0 1 24 34 A 9.9999997 9.9999997 0 0 1 14 24 A 9.9999997 9.9999997 0 0 1 24 14 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,284.3)"
+       id="path13990" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path13370"
+       cx="6.3499999"
+       cy="290.64999"
+       r="1.0583333" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#808080;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="rect13997"
+       width="9.7895832"
+       height="9.7895832"
+       x="1.4552083"
+       y="285.75522"
+       rx="0.97895831"
+       ry="0.97895831" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004"
+       cx="3.175"
+       cy="287.47501"
+       r="0.5291667" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004-1"
+       cx="9.5249996"
+       cy="287.47501"
+       r="0.52916676" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004-2"
+       cx="3.175"
+       cy="293.82501"
+       r="0.52916676" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004-1-7"
+       cx="9.5249996"
+       cy="293.82501"
+       r="0.52916682" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-center-back-testing.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-center-back-testing.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-center-back-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568544"
+     inkscape:cx="16.968311"
+     inkscape:cy="25.936799"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 1.0583333,290.91458 2.9098875,2.77813 v 2.08676 c 0,0 0.7096125,0.69136 2.3828375,0.69136 1.6732249,0 2.3796624,-0.69136 2.3796624,-0.69136 v -2.08676 l 2.9098873,-2.77813 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 3.9094833,288.91116 0.5611812,0.56118 0.2809875,-0.28099 a 2.3804562,2.3804562 0 0 1 3.3670875,0 l 0.2801937,0.28099 0.5611813,-0.56118 -0.2801938,-0.28099 a 3.175,3.175 0 0 0 -4.4894499,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 2.2259396,287.22761 0.5611812,0.56118 0.2801938,-0.28098 a 4.7617062,4.7617062 0 0 1 6.7349686,0 l 0.2801938,0.28098 0.561181,-0.56118 -0.280194,-0.28099 a 5.5562499,5.5562499 0 0 0 -7.8573307,0 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-center-back.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-center-back.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-center-back.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="17.341071"
+     inkscape:cy="25.936799"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(0,-0.79374999,0.79374999,0,-5.2915333e-4,297.26458)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8,1.334 4.5,5 H 1.871 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 H 4.5 L 8,14.666 Z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334" />
+      <path
+         d="m 10.524,4.926 -0.707,0.707 0.354,0.354 a 2.999,2.999 0 0 1 0,4.242 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 4,4 0 0 0 0,-5.656 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 12.645,2.805 -0.707,0.707 0.354,0.353 a 5.999,5.999 0 0 1 0,8.485 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 7,7 0 0 0 0,-9.899 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-center-testing.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-center-testing.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-center-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-47.3592"
+     inkscape:cy="25.936799"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 1.0583333,290.9286 2.9098875,-2.77813 v -2.08676 c 0,0 0.7096125,-0.69136 2.3828375,-0.69136 1.6732249,0 2.3796624,0.69136 2.3796624,0.69136 v 2.08676 l 2.9098873,2.77813 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 3.9094833,292.93202 0.5611812,-0.56118 0.2809875,0.28099 a 2.3804562,2.3804562 0 0 0 3.3670875,0 l 0.2801937,-0.28099 0.5611813,0.56118 -0.2801938,0.28099 a 3.175,3.175 0 0 1 -4.4894499,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 2.2259396,294.61557 0.5611812,-0.56118 0.2801938,0.28098 a 4.7617062,4.7617062 0 0 0 6.7349686,0 l 0.2801938,-0.28098 0.561181,0.56118 -0.280194,0.28099 a 5.5562499,5.5562499 0 0 1 -7.8573307,0 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-center.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-center.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-center.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="17.341071"
+     inkscape:cy="25.936799"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(0,0.79374999,0.79374999,0,-5.2915333e-4,284.5786)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8,1.334 4.5,5 H 1.871 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 H 4.5 L 8,14.666 Z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334" />
+      <path
+         d="m 10.524,4.926 -0.707,0.707 0.354,0.354 a 2.999,2.999 0 0 1 0,4.242 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 4,4 0 0 0 0,-5.656 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 12.645,2.805 -0.707,0.707 0.354,0.353 a 5.999,5.999 0 0 1 0,8.485 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 7,7 0 0 0 0,-9.899 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-left-back-testing.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-left-back-testing.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-back-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="-37.573672"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 2.40083,287.23092 v 3.96875 l -1.45282791,1.50484 c 0,0 0.0129091,0.99064 1.19605781,2.17378 1.1831488,1.18315 2.1715382,1.19382 2.1715382,1.19382 l 1.5248175,-1.43285 h 3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404131,287.76009 2e-7,0.79363 h 0.3973761 c 1.3150293,-2.4e-4 2.2492587,1.19869 2.2490186,2.51372 l -5.61e-4,0.39682 h 0.7936299 l 5.612e-4,-0.39682 c -2.648e-4,-1.75313 -1.2895189,-3.30709 -3.0426487,-3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404133,285.37896 v 0.79363 l 0.3968151,-5.6e-4 c 2.6303146,-3.5e-4 4.6311806,2.2651 4.6308296,4.89541 l -5.61e-4,0.39682 h 0.79363 l 5.61e-4,-0.39682 c -1.54e-4,-3.06841 -2.3560445,-5.68889 -5.4244596,-5.68904 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-left-back.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-left-back.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-back.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="-25.357202"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 2.40083,287.23092 v 3.96875 l -1.45282791,1.50484 c 0,0 0.0129091,0.99064 1.19605781,2.17378 1.1831488,1.18315 2.1715382,1.19382 2.1715382,1.19382 l 1.5248175,-1.43285 h 3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#808080;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404131,287.76009 2e-7,0.79363 h 0.3973761 c 1.3150293,-2.4e-4 2.2492587,1.19869 2.2490186,2.51372 l -5.61e-4,0.39682 h 0.7936299 l 5.612e-4,-0.39682 c -2.648e-4,-1.75313 -1.2895189,-3.30709 -3.0426487,-3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#808080;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404133,285.37896 v 0.79363 l 0.3968151,-5.6e-4 c 2.6303146,-3.5e-4 4.6311806,2.2651 4.6308296,4.89541 l -5.61e-4,0.39682 h 0.79363 l 5.61e-4,-0.39682 c -1.54e-4,-3.06841 -2.3560445,-5.68889 -5.4244596,-5.68904 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-left-side-testing.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-left-side-testing.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-side-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-43.546965"
+     inkscape:cy="21.843892"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="M 6.3499999,295.94167 3.571875,293.03178 H 1.4851062 c 0,0 -0.69135621,-0.70961 -0.69135621,-2.38284 0,-1.67322 0.69135621,-2.37966 0.69135621,-2.37966 H 3.571875 l 2.7781249,-2.90989 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 8.3534249,293.09052 -0.5611812,-0.56118 0.2809874,-0.28099 a 2.3804562,2.3804562 0 0 0 0,-3.36709 l -0.2809874,-0.28019 0.5611812,-0.56118 0.2809875,0.28019 a 3.175,3.175 0 0 1 0,4.48945 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 10.036969,294.77406 -0.5611816,-0.56118 0.2809875,-0.28019 a 4.7617062,4.7617062 0 0 0 0,-6.73497 l -0.2809875,-0.2802 0.5611816,-0.56118 0.280987,0.2802 a 5.5562499,5.5562499 0 0 1 0,7.85733 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-left-side.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-left-side.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-side.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="21.153306"
+     inkscape:cy="21.843892"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(0.79374999,0,0,-0.79374999,0,297.00053)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8,1.334 4.5,5 H 1.871 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 H 4.5 L 8,14.666 Z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334" />
+      <path
+         d="m 10.524,4.926 -0.707,0.707 0.354,0.354 a 2.999,2.999 0 0 1 0,4.242 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 4,4 0 0 0 0,-5.656 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 12.645,2.805 -0.707,0.707 0.354,0.353 a 5.999,5.999 0 0 1 0,8.485 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 7,7 0 0 0 0,-9.899 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-left-testing.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-left-testing.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.9999998"
+     inkscape:cx="4.4412587"
+     inkscape:cy="27.018551"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 2.3812508,294.08915 v -3.96875 l -1.45282791,-1.50484 c 0,0 0.0129091,-0.99064 1.19605781,-2.17378 1.1831488,-1.18315 2.1715382,-1.19382 2.1715382,-1.19382 l 1.5248175,1.43285 h 3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8208339,293.55998 2e-7,-0.79363 h 0.3973761 c 1.3150293,2.4e-4 2.2492587,-1.19869 2.2490186,-2.51372 l -5.61e-4,-0.39682 h 0.7936299 l 5.612e-4,0.39682 c -2.648e-4,1.75313 -1.2895189,3.30709 -3.0426487,3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8208341,295.94111 v -0.79363 l 0.3968151,5.6e-4 c 2.6303146,3.5e-4 4.6311808,-2.2651 4.6308298,-4.89541 l -5.61e-4,-0.39682 h 0.79363 l 5.61e-4,0.39682 c -1.54e-4,3.06841 -2.3560447,5.68889 -5.4244598,5.68904 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-left.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-left.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-left.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="20.616327"
+     inkscape:cy="27.018551"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(0.561266,0.561266,0.561266,-0.561266,-2.9280358,290.37176)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8.0413505,1.4181333 4.5058166,4.9536672 1.871,5 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 l 2.6348166,0.08193 3.5355339,3.535534 z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334"
+         sodipodi:nodetypes="cccscccc" />
+      <path
+         d="m 10.634075,4.9536672 -0.7069996,0.707 0.3539996,0.354 c 1.171699,1.1712708 0.93589,3.0715836 -0.235809,4.2428548 l -0.3539996,0.353 0.7069996,0.707 0.354,-0.353 c 1.561528,-1.5619999 1.797337,-4.0948554 0.235809,-5.6568548 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         d="m 12.755289,2.8324536 -0.707,0.707 0.354,0.353 c 2.343511,2.3428848 2.107808,6.1435034 -0.235702,8.4863884 l -0.354,0.353 0.707,0.707 0.354,-0.353 c 2.73334,-2.733614 2.969042,-7.1667749 0.235702,-9.9003884 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-mono-testing.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-mono-testing.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-mono-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="15.875"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#924d8b;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       d="m 8.2072508,285.69785 -0.2800861,0.74569 a 4.4979166,4.4979166 0 0 1 2.9207513,4.20646 4.4979166,4.4979166 0 0 1 -2.9197178,4.20905 l 0.2775024,0.74 A 5.2916663,5.2916663 0 0 0 11.641666,290.65 5.2916663,5.2916663 0 0 0 8.2072508,285.69785 Z m -3.7129516,0.003 A 5.2916663,5.2916663 0 0 0 1.0583333,290.65 5.2916663,5.2916663 0 0 0 4.492749,295.60215 l 0.2800861,-0.74569 A 4.4979166,4.4979166 0 0 1 1.8520833,290.65 4.4979166,4.4979166 0 0 1 4.7718016,286.44095 Z m 2.876827,2.22519 -0.2790526,0.74414 a 2.1166665,2.1166665 0 0 1 1.3745929,1.97972 2.1166665,2.1166665 0 0 1 -1.3735595,1.98076 l 0.2775024,0.74104 A 2.9104166,2.9104166 0 0 0 9.2604165,290.65 2.9104166,2.9104166 0 0 0 7.3711262,287.92614 Z m -2.0417359,0.002 a 2.9104166,2.9104166 0 0 0 -1.889807,2.7218 2.9104166,2.9104166 0 0 0 1.8892903,2.72386 l 0.2790526,-0.74414 A 2.1166665,2.1166665 0 0 1 4.2333332,290.65 2.1166665,2.1166665 0 0 1 5.6068927,288.66924 Z"
+       id="path12788"
+       inkscape:connector-curvature="0" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path13370"
+       cx="6.3499999"
+       cy="290.64999"
+       r="0.52916664" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-mono.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-mono.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-mono.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="27.126599"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00199997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       d="M 31.019531 5.2832031 L 29.960938 8.1015625 A 17 17 0 0 1 41 24 A 17 17 0 0 1 29.964844 39.908203 L 31.013672 42.705078 A 19.999999 19.999999 0 0 0 44 24 A 19.999999 19.999999 0 0 0 31.019531 5.2832031 z M 16.986328 5.2949219 A 19.999999 19.999999 0 0 0 4 24 A 19.999999 19.999999 0 0 0 16.980469 42.716797 L 18.039062 39.898438 A 17 17 0 0 1 7 24 A 17 17 0 0 1 18.035156 8.0917969 L 16.986328 5.2949219 z M 27.859375 13.705078 L 26.804688 16.517578 A 7.9999994 7.9999994 0 0 1 32 24 A 7.9999994 7.9999994 0 0 1 26.808594 31.486328 L 27.857422 34.287109 A 11 11 0 0 0 35 24 A 11 11 0 0 0 27.859375 13.705078 z M 20.142578 13.712891 A 11 11 0 0 0 13 24 A 11 11 0 0 0 20.140625 34.294922 L 21.195312 31.482422 A 7.9999994 7.9999994 0 0 1 16 24 A 7.9999994 7.9999994 0 0 1 21.191406 16.513672 L 20.142578 13.712891 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,284.3)"
+       id="path12788" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path13370"
+       cx="6.3499999"
+       cy="290.64999"
+       r="0.52916664" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-right-back-testing.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-right-back-testing.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-back-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="10.951531"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 10.31875,287.21041 v 3.96875 l 1.452828,1.50484 c 0,0 -0.01291,0.99064 -1.196058,2.17378 -1.1831483,1.18315 -2.1715377,1.19382 -2.1715377,1.19382 l -1.5248175,-1.43285 h -3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8791673,287.73958 -2e-7,0.79363 H 6.481791 c -1.3150293,-2.4e-4 -2.2492587,1.19869 -2.2490186,2.51372 l 5.61e-4,0.39682 H 3.4397035 l -5.612e-4,-0.39682 c 2.648e-4,-1.75313 1.2895189,-3.30709 3.0426487,-3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8791671,285.35845 v 0.79363 l -0.3968151,-5.6e-4 c -2.6303146,-3.5e-4 -4.6311805,2.2651 -4.6308298,4.89541 l 5.613e-4,0.39682 H 1.0584534 l -5.613e-4,-0.39682 c 1.538e-4,-3.06841 2.3560448,-5.68889 5.4244599,-5.68904 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-right-back.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-right-back.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-back.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="27.126599"
+     inkscape:cy="24.567554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(-0.561266,-0.561266,-0.561266,0.561266,15.628478,290.94831)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8.0413505,1.4181333 4.5058166,4.9536672 1.871,5 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 l 2.6348166,0.08193 3.5355339,3.535534 z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334"
+         sodipodi:nodetypes="cccscccc" />
+      <path
+         d="m 10.634075,4.9536672 -0.7069996,0.707 0.3539996,0.354 c 1.171699,1.1712708 0.93589,3.0715836 -0.235809,4.2428548 l -0.3539996,0.353 0.7069996,0.707 0.354,-0.353 c 1.561528,-1.5619999 1.797337,-4.0948554 0.235809,-5.6568548 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         d="m 12.755289,2.8324536 -0.707,0.707 0.354,0.353 c 2.343511,2.3428848 2.107808,6.1435034 -0.235702,8.4863884 l -0.354,0.353 0.707,0.707 0.354,-0.353 c 2.73334,-2.733614 2.969042,-7.1667749 0.235702,-9.9003884 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-right-side-testing.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-right-side-testing.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-side-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="-24.596694"
+     inkscape:cy="21.843892"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 6.3500041,295.94167 2.7781249,-2.90989 h 2.086769 c 0,0 0.691356,-0.70961 0.691356,-2.38284 0,-1.67322 -0.691356,-2.37966 -0.691356,-2.37966 H 9.128129 l -2.7781249,-2.90989 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 4.3465791,293.09052 0.5611812,-0.56118 -0.2809874,-0.28099 a 2.3804562,2.3804562 0 0 1 0,-3.36709 l 0.2809874,-0.28019 -0.5611812,-0.56118 -0.2809875,0.28019 a 3.175,3.175 0 0 0 0,4.48945 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 2.6630354,294.77406 0.5611812,-0.56118 -0.2809875,-0.28019 a 4.7617062,4.7617062 0 0 1 0,-6.73497 l 0.2809875,-0.2802 -0.5611812,-0.56118 -0.2809875,0.2802 a 5.5562499,5.5562499 0 0 0 0,7.85733 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-right-side.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-right-side.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-side.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="21.153306"
+     inkscape:cy="21.843892"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(-0.79374999,0,0,-0.79374999,12.700004,297.00053)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8,1.334 4.5,5 H 1.871 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 H 4.5 L 8,14.666 Z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334" />
+      <path
+         d="m 10.524,4.926 -0.707,0.707 0.354,0.354 a 2.999,2.999 0 0 1 0,4.242 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 4,4 0 0 0 0,-5.656 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 12.645,2.805 -0.707,0.707 0.354,0.353 a 5.999,5.999 0 0 1 0,8.485 l -0.354,0.353 0.707,0.707 0.354,-0.353 a 7,7 0 0 0 0,-9.899 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-right-testing.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-right-testing.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right-testing.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.656854"
+     inkscape:cx="10.951531"
+     inkscape:cy="25.702661"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 10.319191,294.08915 v -3.96875 l 1.452828,-1.50484 c 0,0 -0.01291,-0.99064 -1.196058,-2.17378 -1.1831483,-1.18315 -2.1715377,-1.19382 -2.1715377,-1.19382 l -1.5248175,1.43285 h -3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8796083,293.55998 -2e-7,-0.79363 H 6.482232 c -1.3150293,2.4e-4 -2.2492587,-1.19869 -2.2490186,-2.51372 l 5.61e-4,-0.39682 H 3.4401445 l -5.612e-4,0.39682 c 2.648e-4,1.75313 1.2895189,3.30709 3.0426487,3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#924d8b;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8796081,295.94111 v -0.79363 l -0.3968151,5.6e-4 c -2.6303146,3.5e-4 -4.6311805,-2.2651 -4.6308298,-4.89541 l 5.613e-4,-0.39682 H 1.0588944 l -5.613e-4,0.39682 c 1.538e-4,3.06841 2.3560448,5.68889 5.4244599,5.68904 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/devices/audio-speaker-right.svg
+++ b/icons/src/fullcolor/devices/audio-speaker-right.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="audio-speaker-right.svg">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="27.126599"
+     inkscape:cy="25.702661"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <g
+       id="g7106"
+       transform="matrix(-0.561266,0.561266,-0.561266,-0.561266,15.628478,290.37176)"
+       style="fill:#808080;stroke-width:0.33333334">
+      <path
+         d="M 8.0413505,1.4181333 4.5058166,4.9536672 1.871,5 C 1.871,5 1,5.894 1,8.002 1,10.11 1.871,11 1.871,11 l 2.6348166,0.08193 3.5355339,3.535534 z"
+         id="path7100"
+         inkscape:connector-curvature="0"
+         style="stroke-width:0.33333334"
+         sodipodi:nodetypes="cccscccc" />
+      <path
+         d="m 10.634075,4.9536672 -0.7069996,0.707 0.3539996,0.354 c 1.171699,1.1712708 0.93589,3.0715836 -0.235809,4.2428548 l -0.3539996,0.353 0.7069996,0.707 0.354,-0.353 c 1.561528,-1.5619999 1.797337,-4.0948554 0.235809,-5.6568548 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7102"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         d="m 12.755289,2.8324536 -0.707,0.707 0.354,0.353 c 2.343511,2.3428848 2.107808,6.1435034 -0.235702,8.4863884 l -0.354,0.353 0.707,0.707 0.354,-0.353 c 2.73334,-2.733614 2.969042,-7.1667749 0.235702,-9.9003884 z"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;stroke-width:0.33333334"
+         font-weight="400"
+         overflow="visible"
+         id="path7104"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Please test this one because I only have two speakers  :)

These icons are a bit weird.  They're full colour icons in the 48px folder, but they're svgs rather than pngs.  I've put them both in the source folder and in the Yaru folder, but there's no script to export pngs of them :thinking:  They don't work like any other icons.

They look like symbols but aren't, so they don't pick up the text colour, but I've based them on the speaker symbol for consistency.  I've gone for medium grey so they'll hopefully be visible on white and dark backgrounds.  I've used the purple accent colour for the testing accents.  Try them and let me know what you think!

![image](https://user-images.githubusercontent.com/38893390/73091606-a9bcd300-3ed2-11ea-8cbe-f80e2b917754.png)

![image](https://user-images.githubusercontent.com/38893390/73091630-b93c1c00-3ed2-11ea-845d-e2356d0fa6b8.png)

![image](https://user-images.githubusercontent.com/38893390/73091653-c5c07480-3ed2-11ea-8d75-c556cb628a6e.png)

Closes #1471