### PR TITLE
Fix circular button padding

### DIFF
--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -19,7 +19,7 @@ $_btn_pad: if($_sizevariant=='default', 4px 9px, 2px 6px);
 $_hb_btn_pad: if($_sizevariant=='default', 6px, 5px);
 $_img_btn_pad: if($_sizevariant=='default', 5px, 2px);
 $_sel_menu_pad: if($_sizevariant=='default', 6px 10px, 4px 10px);
-$_circ_btn_pad: if($_sizevariant=='default', 4px, 2px);
+$_circ_btn_pad: if($_sizevariant=='default', 4px, 2px 6px);
 $_switch_margin: if($_sizevariant=='default', 10px, 7px);
 
 * {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -694,3 +694,7 @@ radio {
     }
   }
 }
+
+// Fix for slimed down circular buttons, could need a change upstream since this happens for
+// Some of the circular buttons too there
+* { & button.circular { min-width: 0; } }


### PR DESCRIPTION
- change the global variable
- add a line in tweaks for axing the min-width
- "low hanging fruit" for upstream contribution as this also happens to upstream default sizes

![image](https://user-images.githubusercontent.com/15329494/73137015-4d81bc80-4054-11ea-8896-0918fd921e69.png)

![image](https://user-images.githubusercontent.com/15329494/73137025-5d010580-4054-11ea-8e15-f4a687b1b870.png)


Closes #1806 