### PR TITLE
headerbar: lighter backdrop button border

### DIFF
--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -59,7 +59,7 @@ headerbar,
     }
 
     &:backdrop {
-      $_btn_backdrop_border: darken($headerbar_bg_color, 8%);
+      $_btn_backdrop_border: $headerbar_bg_color;
       &,
       &.flat {
           @include button(backdrop, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);


### PR DESCRIPTION
Use a lighter dark color for headerbar button border in backdrop (only for default theme)

see https://github.com/ubuntu/yaru/pull/1759#issuecomment-576021449