### PR TITLE
Gtk dark theme: make headerbar border visible again

### DIFF
--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -12,7 +12,7 @@ $selected_bg_color: if($variant == 'light', $orange, darken($orange, 4%));
 
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
 $borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
-$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 12%));
+$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: $linkblue;
 $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -70,12 +70,6 @@ headerbar *, button * {
   text-shadow: none;
   -gtk-icon-shadow: none;
 }
-// headerbar border-color is a bit too strong in the dark theme
-headerbar {
-  &, &.titlebar:not(headerbar) {
-    border-color: lighten($alt_borders_color, if($variant=='light', 0%, 8%));
-  }
-}
 
 // blue spinner
 spinner {


### PR DESCRIPTION
it was basically invisible before:
![image](https://user-images.githubusercontent.com/15329494/73204301-045a6700-413f-11ea-9721-9bc0b3be6bcf.png)


After:
![image](https://user-images.githubusercontent.com/15329494/73204230-e8ef5c00-413e-11ea-8d54-4c76522b6997.png)
