### PR TITLE
common: fix backdrop link color

### DIFF
--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -1182,28 +1182,29 @@ list row button.image-button:not(.flat) {
   &:visited {
     color: $link_visited_color;
 
-    *:selected & { color: mix($selected_fg_color, $selected_bg_color, 60%); }
+    *:selected & { color: mix($selected_fg_color, $link_visited_color, 60%); }
   }
 
   &:hover {
-    color: lighten($link_color,10%);
+    $_fg: lighten($link_color, 10%);
+    color: $_fg;
 
-    *:selected & { color: mix($selected_fg_color, $selected_bg_color, 90%); }
+    *:selected & { color: mix($selected_fg_color, $_fg, 90%); }
   }
 
   &:active {
     color: $link_color;
 
-    *:selected & { color: mix($selected_fg_color, $selected_bg_color, 80%); }
+    *:selected & { color: mix($selected_fg_color, $link_color, 80%); }
   }
 
   &:disabled, &:disabled:backdrop { color: transparentize(desaturate($link_color,100%), 0.2); }
 
-  &:backdrop { &:backdrop:hover, &:backdrop:hover:selected, & { color: $selected_bg_color; }}
+  &:backdrop { &:backdrop:hover, &:backdrop:hover:selected, & { color: transparentize($link_color, 0.1); }}
 
   @at-root %link_selected,
   &:selected,
-  *:selected & { color: mix($selected_fg_color, $selected_bg_color, 80%); }
+  *:selected & { color: mix($selected_fg_color, $link_color, 80%); }
 }
 
 button:link,


### PR DESCRIPTION
Currently, backdrop link color is orange, instead that some blue.
This has been alredy fixed upstream

https://gitlab.gnome.org/GNOME/gtk/merge_requests/1201

but it does not seem available yet, so this change manually cherry-picks it in Yaru.