### PR TITLE
Special case switch focus

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -330,12 +330,11 @@ button {
   -gtk-outline-radius: $button-radius;
 }
 
-switch slider {
-  outline-color: $focus_border_color;
-  outline-style: solid;
-  outline-offset: -2px;
-  outline-width: 2px;
-  -gtk-outline-radius: 100%;
+switch {
+  &, &:hover { slider { outline-color: transparent; } }
+  &:focus {
+    box-shadow: 0 0 0 3px if($variant=='light', lighten(opacify($focus_border_color, 1), 20%), $focus_border_color);
+  }
 }
 
 checkbutton,


### PR DESCRIPTION
- gtk defaults the outline to be on the switch sliders
- the new focus ring style plus the new switch bg color creates a blurry "experience"
- setting the outline on the slider to transparent
- adding a 3px spread box-shadow, opacified and lightened in the light themes(s)

Closes #1822 