### PR TITLE
Remove orange on icons

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -26,7 +26,7 @@ $ambiance: null !default;
     @at-root %dim_icons_in_backdrop,
     & *scrolledwindow:backdrop { opacity: 0.9; }
 
-    paned box.floating-bar {  
+    paned box.floating-bar {
       background-color: $bg_color;
       border-style: solid;
       border-color: if($variant=='light', lighten($borders_color, 8.3%), darken($borders_color, 1%));
@@ -81,9 +81,9 @@ $ambiance: null !default;
 
     .nautilus-canvas-item {
       -gtk-outline-radius: $button_radius;
-      outline-offset: -2px;
+      outline-offset: -1px;
       &:selected {
-        outline-color: white;
+        outline-color: if($variant=='light', white, $base_color);
       }
     }
 
@@ -124,6 +124,23 @@ $ambiance: null !default;
         border-radius: 0px 0px 0px 0px;
     }
   }
+
+  scrolledwindow widget.view:selected {
+        color: $text_color; // label color when right clicking
+        border: none;
+
+        // reduces orangeness of selected folder icons
+        background-color: rgba(255, 255, 255, 0.1);  // folder icon is tinted based on this
+                                                     // near transparent white results in no tint
+                                                     // completely transparent tints the icon black
+           &:backdrop {
+             background-color: $orange;
+             color: $selected_fg_color;
+           }
+    }
+
+    scrolledwindow widget.view:active { background-color: $ash; } // icon color when right clicking and in backdrop
+
 
 /************
  * Terminal *


### PR DESCRIPTION
**THIS** PR should be better and fix the orange spill that @friendlyapple mentioned.

![image](https://user-images.githubusercontent.com/3986894/73554018-3fb0aa80-444b-11ea-853a-c27c26120625.png)
