### PR TITLE
Fix headerbar distorted transition

### DIFF
--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -495,13 +495,13 @@
 // $hc: top highlight color
 // $ov: a background layer for background shorthand (hence no commas!)
 //
-  $gradient: linear-gradient(to top, darken($c, 2%), lighten($c, 1%));
+  $gradient: linear-gradient(to top, darken($c, 0%), lighten($c, 0%));
 
-  @if $variant == 'dark' { $gradient: linear-gradient(to top, lighten($c, 4%), lighten($c, 6%)); }
+  @if $variant == 'dark' { $gradient: linear-gradient(to top, lighten($c, 3%), lighten($c, 3%)); }
 
   @if $ov != none { background: $c $ov, $gradient; }
   @else { background: $c $gradient; }
-  background: image(if($variant=='dark', lighten($c, 3%), $c));
+
   box-shadow: inset 0 1px $hc; // top highlight
 }
 


### PR DESCRIPTION
Current master:

![image](https://user-images.githubusercontent.com/15329494/74090428-85a0ea80-4aab-11ea-9a9b-c70cab1f7a09.png)

![Peek 2020-02-09 14-52](https://user-images.githubusercontent.com/15329494/74103370-dc5e0100-4b4b-11ea-82a0-ca98adb385a5.gif)

Fixed: 

![Peek 2020-02-09 14-56](https://user-images.githubusercontent.com/15329494/74103449-555d5880-4b4c-11ea-9331-b4eedaaf4c91.gif)

(same with default and dark)