### PR TITLE
Default theme: disabled button improvements

### DIFF
--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -135,7 +135,8 @@ headerbar,
           }
 
           &:disabled {
-            @include button(backdrop-insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $backdrop_headerbar_fg_color);
+            @include button(backdrop-insensitive, if($variant=='light', darken($backdrop_headerbar_bg_color, 14%), $headerbar_bg_color), $backdrop_headerbar_fg_color);
+            border-color: darken($backdrop_headerbar_bg_color, 3%);
 
             &:active,
             &:checked {
@@ -157,6 +158,8 @@ headerbar,
 
         &:disabled {
           @include button(insensitive, if($variant== "light", darken($headerbar_bg_color, 15%), $headerbar_bg_color), $headerbar_fg_color);
+          border-color: darken($headerbar_bg_color, 5%);
+          background-image: image(lighten($headerbar_bg_color, 2%));
 
           &:active,
           &:checked {

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -77,7 +77,7 @@ headerbar,
           }
 
           &:disabled {
-            @include button(backdrop-insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $backdrop_headerbar_fg_color);
+            @include button(backdrop-insensitive, darken($backdrop_headerbar_bg_color, 14%), $backdrop_headerbar_fg_color);
 
             border-color: $_btn_backdrop_border;
 


### PR DESCRIPTION
- adapt the backdrop disabled button color to the headerbar
![image](https://user-images.githubusercontent.com/15329494/74103690-8a6aaa80-4b4e-11ea-8bfd-df0c64063484.png)


Closes https://github.com/ubuntu/yaru/issues/1869

- slightly improve background and border of suggested-action disabled buttons in active and backdrop windows:
![image](https://user-images.githubusercontent.com/15329494/74103943-95263f00-4b50-11ea-8ac9-80c0bb424e08.png)
![image](https://user-images.githubusercontent.com/15329494/74103957-a7a07880-4b50-11ea-9307-4d18fafb1dae.png)

Closes https://github.com/ubuntu/yaru/issues/1842