### PR TITLE
shell/gtk: use silver color for mouse selection

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -1247,8 +1247,9 @@ StScrollBar {
 
 // Rubberband for select-area screenshots
 .select-area-rubberband {
-  background-color: transparentize($selected_bg_color,0.7);
-  border: 1px solid $selected_bg_color;
+  background-color: transparentize($ash, 0.8);
+  border: 1px solid transparentize($silk, 0.2);
+
 }
 
 // Pointer location

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -812,7 +812,7 @@ StScrollBar {
 /* Tiled window previews */
 .tile-preview {
   background-color: transparentize($ash, 0.8);
-  border: 1px solid $silk;
+  border: 1px solid transparentize($silk, 0.2);
 }
 
   .tile-preview-left.on-primary {

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -811,8 +811,8 @@ StScrollBar {
 
 /* Tiled window previews */
 .tile-preview {
-  background-color: transparentize($ash,0.87);
-  border: 1px solid darken($silk, 10%);
+  background-color: transparentize($ash, 0.8);
+  border: 1px solid $silk;
 }
 
   .tile-preview-left.on-primary {

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -811,8 +811,8 @@ StScrollBar {
 
 /* Tiled window previews */
 .tile-preview {
-  background-color: transparentize($selected_bg_color,0.5);
-  border: 1px solid $selected_bg_color;
+  background-color: transparentize($porcelain, 0.8);
+  border: 1px solid $porcelain;
 }
 
   .tile-preview-left.on-primary {

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -794,14 +794,14 @@ StScrollBar {
 
   StEntry { @extend %bubble-entry; }
   .button {
-    &, &:hover, &:focus, &:active, &:disabled { 
+    &, &:hover, &:focus, &:active, &:disabled {
       box-shadow: none;
       border-color: $_bubble_borders_color;
     }
     background-color: $bg_color;
     color: $fg_color;
     &:hover { background-color: $_hover_bg_color; }
-    &:active { 
+    &:active {
       background-color: $selected_bg_color;
       color: $selected_fg_color;
     }
@@ -811,8 +811,8 @@ StScrollBar {
 
 /* Tiled window previews */
 .tile-preview {
-  background-color: transparentize($porcelain, 0.8);
-  border: 1px solid $porcelain;
+  background-color: transparentize($ash, 0.8);
+  border: 1px solid $silk;
 }
 
   .tile-preview-left.on-primary {

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -180,7 +180,7 @@ StScrollBar {
   background-size: contain;
   background-image: if($variant == 'light', url("toggle-off.svg"),
 					    url("toggle-off-dark.svg"));
-  &:checked { 
+  &:checked {
     background-image: if($variant == 'light', url("toggle-on.svg"),
 					    url("toggle-on-dark.svg"));
   }
@@ -489,7 +489,7 @@ StScrollBar {
     border: 1px solid $_bubble_borders_color;
     border-radius: 12px;
     &:hover,&:focus { background-color: $_hover_bg_color; }
-    &:active { 
+    &:active {
       background-color: $selected_bg_color;
       color: $selected_fg_color;
     }
@@ -569,7 +569,7 @@ StScrollBar {
       background-color: $_hover_bg_color;
       color: $fg_color;
     }
-    &:active { 
+    &:active {
       background-color: $_active_bg_color;
       color: $fg_color;
      }
@@ -811,8 +811,8 @@ StScrollBar {
 
 /* Tiled window previews */
 .tile-preview {
-  background-color: transparentize($ash, 0.8);
-  border: 1px solid $silk;
+  background-color: transparentize($ash,0.87);
+  border: 1px solid darken($silk, 10%);
 }
 
   .tile-preview-left.on-primary {
@@ -1153,7 +1153,7 @@ StScrollBar {
           }
 
           .message-title {
-            color: $fg_color;            
+            color: $fg_color;
           }
 
           .message-content {
@@ -1225,7 +1225,7 @@ StScrollBar {
       background-color: $_hover_bg_color;
       color: $fg_color;
     }
-    &:active { 
+    &:active {
       background-color: $_active_bg_color;
       color: $fg_color;
       //border-color: $selected_borders_color;
@@ -1676,7 +1676,7 @@ StScrollBar {
 
     StEntry { @extend %bubble-entry; }
 
-    .notification-icon { padding: 5px; }  
+    .notification-icon { padding: 5px; }
     .notification-content { padding: 5px; spacing: 5px; }
     .secondary-icon { icon-size: 1.09em; }
     .notification-actions {
@@ -2111,7 +2111,7 @@ $_screenshield_shadow: 0px 0px 6px rgba(0, 0, 0, 0.726);
   font-feature-settings: "tnum";
 }
 
-.screen-shield-clock-date { 
+.screen-shield-clock-date {
   font-size: 28pt;
   font-weight: normal;
 }

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -14,7 +14,7 @@ $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%),
 $borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
 $alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
-$link_color: if($variant == 'light', $linkblue, $blue); 
+$link_color: if($variant == 'light', $linkblue, $blue);
 $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);

--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -145,8 +145,8 @@ iconview { @extend .view; }
 
 .rubberband,
 rubberband {
-  border: 1px solid darken($selected_bg_color, 10%);
-  background-color: transparentize(darken($selected_bg_color, 10%), 0.8);
+  background-color: transparentize($light_aubergine,0.87);
+  border: 1px solid darken($silk, 10%);
 }
 
 flowbox {
@@ -168,7 +168,7 @@ flowbox {
   background-color: if($variant=='light', transparent, black);
   border-radius: 0;
   padding: 0;
-  
+
   &:backdrop { background-color: if($variant=='light', transparent, darken($backdrop_base_color,5%)); }
   &:active, &:selected { background-color: if($variant=='light', transparent, $selected_bg_color); }
   &:disabled { background-color: if($variant=='light', transparent, $insensitive_bg_color); }
@@ -1639,10 +1639,10 @@ headerbar {
       background-color: $suggested_bg_color;
       background-image: none;
       box-shadow: inset 0 1px mix($top_hilight, $suggested_bg_color, 60%);
-      
-      label { 
+
+      label {
         text-shadow: none;
-        color: $selected_fg_color; 
+        color: $selected_fg_color;
       }
     }
 
@@ -1780,9 +1780,9 @@ headerbar {
       padding: 0;
     }
   }
-  
 
-  
+
+
   separator.titlebutton { opacity: 0; } /* hide the close button separator */
 
   .solid-csd & {
@@ -2881,12 +2881,12 @@ switch {
 
     @if $variant == 'light' {
       @include button(normal-alt, $edge: $shadow_color);
-    } 
+    }
     @else {
       @include button(normal-alt, $c: lighten($bg_color,6%), $edge: $shadow_color);
     }
   }
-  
+
   image { color: transparent; } /* only show i / o for the accessible theme */
 
   &:hover slider {
@@ -3033,7 +3033,7 @@ radio {
   }
 
   &:backdrop { transition: $backdrop_transition; }
-  
+
   @if $variant == 'light' {
     // the borders of the light variant versions of checks and radios are too similar in luminosity to the selected background
     // color, hence we need special casing.
@@ -4119,7 +4119,7 @@ separator.sidebar {
 $_placesidebar_icons_opacity: 0.7;
 
 row image.sidebar-icon { opacity: $_placesidebar_icons_opacity; } // dim the sidebar icons
-                                                                  // see bug #786613 for details 
+                                                                  // see bug #786613 for details
                                                                   // on this oddity
 
 placessidebar {
@@ -4297,7 +4297,7 @@ infobar {
   border-style: none;
 
   &.action:hover > revealer > box {
-      background-color: if($variant == 'light', desaturate(lighten(invert($selected_bg_color), 47%), 30%), 
+      background-color: if($variant == 'light', desaturate(lighten(invert($selected_bg_color), 47%), 30%),
                         desaturate(darken(invert($selected_bg_color),42%), 70%));
       border-bottom: 1px solid lighten($borders_color, 5%);
   }
@@ -4308,7 +4308,7 @@ infobar {
   &.error {
     &:backdrop > revealer > box, & > revealer > box {
       label, & { color: $fg_color; }
-      background-color: if($variant == 'light', desaturate(lighten(invert($selected_bg_color), 45%), 30%), 
+      background-color: if($variant == 'light', desaturate(lighten(invert($selected_bg_color), 45%), 30%),
                         desaturate(darken(invert($selected_bg_color),40%), 70%));
       border-bottom: 1px solid lighten($borders_color, 5%);
     }
@@ -4794,7 +4794,7 @@ stackswitcher button.text-button.circular { // FIXME aggregate with buttons
  * Emoji *
  ********/
 
-popover.emoji-picker { 
+popover.emoji-picker {
   padding-left: 0;
   padding-right: 0;
 

--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -145,7 +145,7 @@ iconview { @extend .view; }
 
 .rubberband,
 rubberband {
-  background-color: transparentize($light_aubergine,0.87);
+  background-color: transparentize($ash,0.87);
   border: 1px solid darken($silk, 10%);
 }
 

--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -145,8 +145,8 @@ iconview { @extend .view; }
 
 .rubberband,
 rubberband {
-  background-color: transparentize($ash,0.87);
-  border: 1px solid darken($silk, 10%);
+  border: 1px solid darken($selected_bg_color, 10%);
+  background-color: transparentize(darken($selected_bg_color, 10%), 0.8);
 }
 
 flowbox {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -692,11 +692,11 @@ radio {
 treeview:hover { background: $popover_hover_color; }
 
 // Fix for slimed down circular buttons, could need a change upstream since this happens for
-// Some of the circular buttons too there
+// Some of the circular buttons there too
 * { & button.circular { min-width: 0; } }
 
 scale {
-  slider { 
+  slider {
     .osd & {
       @include button(osd);
       background-image: image(darken($osd_fg_color, 2%));
@@ -712,6 +712,12 @@ scale {
   }
 }
 
+// Rubberband selection shall match with shell's tile-preview
+.rubberband,
+rubberband {
+  background-color: transparentize($ash, 0.8);
+  border: 1px solid if($variant == 'light', $silk, darken($silk, 10%));
+}
 // Fix for color chose buttons, should be moved to upstream as it is variable
 // If the min-height is not set, it stretches compact headerbars
 button.color { min-height: $_headerbar_height / 2; }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -716,7 +716,7 @@ scale {
 .rubberband,
 rubberband {
   background-color: transparentize($ash, 0.8);
-  border: 1px solid if($variant == 'light', $silk, darken($silk, 10%));
+  border: 1px solid if($variant == 'light', transparentize($silk, 0.2), transparentize(darken($silk, 10%), 0.4));
 }
 // Fix for color chose buttons, should be moved to upstream as it is variable
 // If the min-height is not set, it stretches compact headerbars


### PR DESCRIPTION
Replace current orange with a silver-ish color for mouse selection

- gtk rubberband (e.g. Nautilus folder selection with mouse)
- shell rubberband (e.g. Desktop Icon selection and area screenshot)
- shell tile-window-preview (e.g. snapping windows on left/right side of the screen)


Co-authored-by: MadsRH <madsrh@gmail.com>

Closes: #1727