### PR TITLE
Adding symlink drive-removable-media-usb --> media-removable

### DIFF
--- a/icons/Suru/16x16/devices/media-removable.png
+++ b/icons/Suru/16x16/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/Suru/16x16@2x/devices/media-removable.png
+++ b/icons/Suru/16x16@2x/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/Suru/24x24/devices/media-removable.png
+++ b/icons/Suru/24x24/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/Suru/24x24@2x/devices/media-removable.png
+++ b/icons/Suru/24x24@2x/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/Suru/256x256/devices/media-removable.png
+++ b/icons/Suru/256x256/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/Suru/256x256@2x/devices/media-removable.png
+++ b/icons/Suru/256x256@2x/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/Suru/32x32/devices/media-removable.png
+++ b/icons/Suru/32x32/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/Suru/32x32@2x/devices/media-removable.png
+++ b/icons/Suru/32x32@2x/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/Suru/48x48/devices/media-removable.png
+++ b/icons/Suru/48x48/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/Suru/48x48@2x/devices/media-removable.png
+++ b/icons/Suru/48x48@2x/devices/media-removable.png
@@ -1,0 +1,1 @@
+drive-removable-media-usb.png

--- a/icons/src/symlinks/fullcolor/devices.list
+++ b/icons/src/symlinks/fullcolor/devices.list
@@ -8,4 +8,4 @@ media-optical.png media-optical-cd.png
 media-optical.png media-optical-cd-audio.png
 media-optical.png media-optical-bd.png
 media-optical.png media-optical-dvd.png
-
+drive-removable-media-usb.png media-removable.png


### PR DESCRIPTION
We can work out how to do this better (if it's within the gift of the theme, rather than an upstream quirk) but in the meantime I thought it would be good to add this symlink, to prevent a symbol appearing in a full colour context.  @Jupiter007-43, grateful if you could test!

Closes #1859