### PR TITLE
Apps: remove the box-shadow hack for counter-label

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -229,7 +229,6 @@ terminal-window {
     border-width: 0px;
     padding-left: 2px;
     padding-right: 2px;
-    box-shadow: inset 0 0 10px 10px $success_color;
   }
 
   /*********


### PR DESCRIPTION
It's no longer needed since gnome-software now uses success_color for this: https://github.com/ubuntu/yaru/issues/1725