### PR TITLE
Fix for color chose buttons

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -716,3 +716,7 @@ scale {
     }
   }
 }
+
+// Fix for color chose buttons, should be moved to upstream as it is variable
+// If the min-height is not set, it stretches compact headerbars
+button.color { min-height: $_headerbar_height / 2; }


### PR DESCRIPTION
- Set the min-height of color buttons to the half of the headerbar, works for the default sizing of upstream and the compact sizing we use
- If the min-height is not set, it stretches compact headerbars
- should be moved to upstream as it is variable

![Peek 2020-02-11 11-17](https://user-images.githubusercontent.com/15329494/74228091-0fc19c80-4cc0-11ea-8090-fb2226dda91d.gif)

Closes: #1878 