### PR TITLE
Light and dark theme headerbar button border improvements

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -71,6 +71,17 @@ headerbar *, button * {
   -gtk-icon-shadow: none;
 }
 
+// Leave border-color of headerbar buttons evenly colored
+// But darken the border-color a little bit to keep legibility
+// This is consistent with the "default theme"
+headerbar, .titlebar {
+  stackswitcher button:checked,
+    button.toggle:checked {
+      border-color: darken($borders_color, 6%);
+      border-top-color: darken($borders_color, 6%);
+    }
+  }
+
 // blue spinner
 spinner {
   &:not(:backdrop) {


### PR DESCRIPTION
- unify the color of the :checked button borders in the headerbar, because uneven border colors make the button look more pressed than necessary without improving the legibility
- this is also more consistent with the default theme :checked headerbar buttons

Before:
![image](https://user-images.githubusercontent.com/15329494/74269122-4c65b600-4d09-11ea-97e5-f869bf3b85de.png)
![image](https://user-images.githubusercontent.com/15329494/74269148-54255a80-4d09-11ea-99a1-dc07d52bc1e9.png)

After:
![image](https://user-images.githubusercontent.com/15329494/74269057-30621480-4d09-11ea-9413-88acfe29a479.png)
![image](https://user-images.githubusercontent.com/15329494/74269088-3ce66d00-4d09-11ea-8250-a5d188a35180.png)

Default theme:
![image](https://user-images.githubusercontent.com/15329494/74269220-71f2bf80-4d09-11ea-9092-740f5efd981e.png)


@madsrh @clobrano @ubuntujaggers ?
