### PR TITLE
Remove orange tint on icons

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -124,19 +124,17 @@ $ambiance: null !default;
         border-radius: 0px 0px 0px 0px;
     }
 
- widget.view {
-          background-color: rgba(255, 255, 255, 0.1); // reduces orangeness of selected folder icons
-          color: $text_color;
+    widget.view {
+      background-color: rgba(255, 255, 255, 0.1); // reduces orangeness of selected folder icons
+      color: $text_color;
 
-          &:backdrop {
-                       background-color: $selected_bg_color;
-                       color: $backdrop_text_color;
-                     }
-          &:selected { color: $selected_fg_color; }
-        }
+      &:backdrop {
+        background-color: if($variant=='light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 5%));
+        color: $backdrop_text_color;
+      }
+    }
 
  scrolledwindow widget.view:active { background-color: none; } // icon color when right clicking and in backdrop
-
 }
 
 

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -26,7 +26,7 @@ $ambiance: null !default;
     @at-root %dim_icons_in_backdrop,
     & *scrolledwindow:backdrop { opacity: 0.9; }
 
-    paned box.floating-bar {  
+    paned box.floating-bar {
       background-color: $bg_color;
       border-style: solid;
       border-color: if($variant=='light', lighten($borders_color, 8.3%), darken($borders_color, 1%));
@@ -81,9 +81,9 @@ $ambiance: null !default;
 
     .nautilus-canvas-item {
       -gtk-outline-radius: $button_radius;
-      outline-offset: -2px;
+      outline-offset: -1px;
       &:selected {
-        outline-color: white;
+        outline-color: if($variant=='light', white, $base_color);
       }
     }
 
@@ -123,7 +123,22 @@ $ambiance: null !default;
         border-width: 0px 1px 0px 1px;
         border-radius: 0px 0px 0px 0px;
     }
-  }
+
+ widget.view {
+          background-color: rgba(255, 255, 255, 0.1); // reduces orangeness of selected folder icons
+          color: $text_color;
+
+          &:backdrop {
+                       background-color: $selected_bg_color;
+                       color: $backdrop_text_color;
+                     }
+          &:selected { color: $selected_fg_color; }
+        }
+
+ scrolledwindow widget.view:active { background-color: none; } // icon color when right clicking and in backdrop
+
+}
+
 
 /************
  * Terminal *


### PR DESCRIPTION
A third (#1831 and https://github.com/ubuntu/yaru/pull/48) attempt at removing the orange tint on the icons in Nautilus.

This is VERY close, but I need the wizard skills of @Feichtmeier or @clobrano to fix the label color when right clicking :disappointed: 
I don't know why, but the label is gray in the dark theme but "invisible" in the light theme.

![files](https://user-images.githubusercontent.com/3986894/74325568-b13b0380-4d3d-11ea-9819-99c3a6e41c6d.gif)

![filesdark 01-47](https://user-images.githubusercontent.com/3986894/74325612-c57f0080-4d3d-11ea-8cbd-9e3fc810978f.gif)






