### PR TITLE
Dark theme: darken entries in notebooks

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -731,3 +731,9 @@ scale {
 // Fix for color chose buttons, should be moved to upstream as it is variable
 // If the min-height is not set, it stretches compact headerbars
 button.color { min-height: $_headerbar_height / 2; }
+
+// Entries drown if drawn on widgets with $base_color
+// Fixing this at least for notebooks, since entries on tabs is a common pattern
+@if $variant=='dark' {
+  notebook entry { background-color: darken($base_color, 2%); }
+}


### PR DESCRIPTION
Since notebooks and entries both use $base_color, entries drown in the dark theme, looking almost disabled. Darkening them for the dark theme only in notebooks helps here. We reduce the change for notebooks only since it is safe to say that the $base_color won't be changed by apps. Everywhere else it is not clear where the entries are drawn.

Closes #1784