### PR TITLE
Default theme: switch backdrop improvements

### DIFF
--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -216,7 +216,6 @@ headerbar,
     &:backdrop {
       background-color: lighten($backdrop_headerbar_bg_color, 2%);
       &, &:checked { border-color: darken($_backdrop_button_border_color, 4%); }
-      box-shadow: none;
       &:disabled { 
         background-color: $backdrop_headerbar_bg_color;
         border-color: $_backdrop_button_border_color;
@@ -238,7 +237,9 @@ headerbar,
 
       &:backdrop {
         @include button(backdrop-alt, $_button_bg_color);
-        &:checked, &:disabled, &:checked:disabled { border-color: $_backdrop_button_border_color; }
+        &, &:checked, &:disabled, &:checked:disabled { 
+          border-color: darken($_backdrop_button_border_color, 4%); box-shadow: none;
+        }
       }      
 
       &:checked {


### PR DESCRIPTION
Remove the box-shadow and even out the border of switches inside the headerbar of the datk theme in the backdrop.