### PR TITLE
nautilus: complete do not color folder on selection

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -73,20 +73,6 @@ $ambiance: null !default;
       &:backdrop { background-image: image(transparentize($borders_color, 0.7)); }
     }
 
-    .nautilus-canvas-item.dim-label,
-    .nautilus-list-dim-label {
-        color: if($variant==light, lighten($text_color, 30%), darken($text_color, 25%));
-        &:selected { color: transparentize($selected_fg_color, 0.3); }
-    }
-
-    .nautilus-canvas-item {
-      -gtk-outline-radius: $button_radius;
-      outline-offset: -1px;
-      &:selected {
-        outline-color: if($variant=='light', white, $base_color);
-      }
-    }
-
     // custom code from nautilus Adwaita.css for entries and the pathbar
     entry.search > * {
       margin: 5px;
@@ -124,19 +110,22 @@ $ambiance: null !default;
         border-radius: 0px 0px 0px 0px;
     }
 
-    widget.view {
-      background-color: rgba(255, 255, 255, 0.1); // reduces orangeness of selected folder icons
-      color: $text_color;
-
+    // This is the Icon + Text beneath - it's one widget
+    .nautilus-canvas-item {
+      outline-width: 0;
+      // First, remove the background
+      background-color: rgba(255, 255, 255, 0.1);
+      // Then bring it back for when it receives a direction
+      &:dir(ltr) { 
+        background-color: $selected_bg_color;
+      }
+      
       &:backdrop {
-        background-color: if($variant=='light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 5%));
+        background-color: transparentize($fg_color, 0.8);
         color: $backdrop_text_color;
       }
     }
-
- scrolledwindow widget.view:active { background-color: none; } // icon color when right clicking and in backdrop
 }
-
 
 /************
  * Terminal *


### PR DESCRIPTION
- only style .nautilus-canvas-item, not all widget.view
- remove the outline ring, not needed because the focus is already orange and it corrupts the label
- remove the background then bring it back for dir(ltr)

![Peek 2020-02-15 00-35](https://user-images.githubusercontent.com/15329494/74576445-133c7880-4f8b-11ea-950a-88639d50c333.gif)

@clobrano @madsrh 
I hope you like the backdrop color
I also removed the outline ring because I don't think that it's nessecary because I think there is no room for the focus ring in this tiny label - WDYT?

Closes: #43
Closes: #1914