### PR TITLE
Gtk theme upstream nautilus sync + fixes

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -92,7 +92,8 @@ $ambiance: null !default;
       @if $ambiance {
         $_bg: if($variant=='light', lighten($headerbar_bg_color, 3%),
                                     lighten($headerbar_bg_color, 1%));
-        border: 1px solid black;
+        border: 1px solid if($ambiance, darken($headerbar_bg_color, 9%), $borders_color);
+        &:backdrop { border-color: if($ambiance, $headerbar_bg_color, $backdrop_borders_color);}
         background-color: $_bg;
       } @else {
         border: 1px solid $borders_color;

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -133,7 +133,7 @@ $ambiance: null !default;
 
 $_disk_space_unknown: $insensitive_bg_color;
 $_disk_space_used: $progress_bg_color;
-$_disk_space_free: $bg_color;
+$_disk_space_free: if($variant=='light', darken($bg_color, 10%), $bg_color);
 
 .disk-space-display {
     border-style: solid;

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -101,7 +101,7 @@ $ambiance: null !default;
     }
 
     .path-bar-box.width-maximized button:first-child {
-        border-radius: $button_radius 0px 0px $button_radius;
+        border-radius: ($button_radius - 1.5) 0px 0px ($button_radius - 1.5);
         border-width: 0px 1px 0px 0px;
     }
 
@@ -125,6 +125,46 @@ $ambiance: null !default;
         color: $backdrop_text_color;
       }
     }
+}
+
+// Nautilus disk space dialogue styling
+// Copied from the nautilus adwaita.css
+// keeping the CSS code style to make upstream updates easier
+
+$_disk_space_unknown: $insensitive_bg_color;
+$_disk_space_used: $progress_bg_color;
+$_disk_space_free: $bg_color;
+
+.disk-space-display {
+    border-style: solid;
+    border-width: 2px;
+}
+
+.disk-space-display.unknown {
+    background-color: $_disk_space_unknown;
+    border-color: transparentize($_disk_space_unknown, 0.7);
+    color: $_disk_space_unknown;
+}
+.disk-space-display.unknown.border {
+    color: transparentize($_disk_space_unknown, 0.7);
+}
+
+.disk-space-display.used {
+    background-color: $_disk_space_used;
+    border-color: transparentize($_disk_space_used, 0.7);
+    color: $_disk_space_used;
+}
+.disk-space-display.used.border {
+    color: transparentize($_disk_space_used, 0.7);
+}
+
+.disk-space-display.free {
+    background-color: $_disk_space_free;
+    border-color: transparentize($_disk_space_free, 0.7);
+    color: $_disk_space_free;
+}
+.disk-space-display.free.border {
+    color: transparentize($_disk_space_free, 0.7);
 }
 
 /************

--- a/gtk/upstream/nautilus/Adwaita.css
+++ b/gtk/upstream/nautilus/Adwaita.css
@@ -63,7 +63,7 @@
 }
 
 .path-bar-box.width-maximized button:first-child {
-    border-radius: 5px 0px 0px 5px;
+    border-radius: 3.5px 0px 0px 3.5px;
     border-width: 0px 1px 0px 0px;
 }
 


### PR DESCRIPTION
- Take the nautilus in app code and convert the styles for yaru
- Slightly adjust the free disk space colors for the light theme(s)
- fix the border color for the default theme ($ambiance)

![image](https://user-images.githubusercontent.com/15329494/74884105-b66a0500-5372-11ea-9dd6-08ce4cf8e101.png)
![image](https://user-images.githubusercontent.com/15329494/74884178-dc8fa500-5372-11ea-9b5f-944767208023.png)

Closes #1807 

Before:
For some reason they use a black border here... :thinking: 
![image](https://user-images.githubusercontent.com/15329494/74884287-1eb8e680-5373-11ea-86f8-9f714ecaade2.png)
After:
![image](https://user-images.githubusercontent.com/15329494/74884132-c386f400-5372-11ea-9327-f697fff9610e.png)





