### PR TITLE
Round the desktop icons

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_widgets.scss
+++ b/gnome-shell/src/gnome-shell-sass/_widgets.scss
@@ -54,3 +54,8 @@
     font-weight: normal;
     text-shadow: none !important;
 }
+
+// gnome-shell-extension-desktop-icons styling
+.file-item {
+    border-radius: $base_border_radius;
+}


### PR DESCRIPTION
This is a regression caused by me in the upstream shell sync

Before:
![Bildschirmfoto-20200220231858-325x280](https://user-images.githubusercontent.com/15329494/74985450-bed84380-5437-11ea-9fa9-0068b063c86f.png)


After:
![Bildschirmfoto-20200220231915-276x284](https://user-images.githubusercontent.com/15329494/74985462-c39cf780-5437-11ea-80c9-662b95eba794.png)
