### PR TITLE
Make ubiquity progressbars look like real circles

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -519,6 +519,7 @@ terminal-window {
     #dot_grid progressbar	{
       border-radius: 100%;
       padding: 1px;
+      padding-top: 2px;
       background-color: white;
       border: 1px solid $progress_bg_color;
 
@@ -531,6 +532,8 @@ terminal-window {
       .full progress {
         border-radius: 100%;
         padding: 1px;
+        padding-top: 2px;
+        margin-bottom: 2px;
       }
     }
   }


### PR DESCRIPTION
Make the circles real circles and not stretched circles :) 
As pointed out by @friendlyapple 

Before:
![Screenshot from 2020-01-22 14-04-16](https://user-images.githubusercontent.com/15329494/72900607-1d6aae80-3d20-11ea-8498-2fef4b3b1a19.png)


After:
![image](https://user-images.githubusercontent.com/15329494/75035308-13ff6e00-54a7-11ea-8f18-9e92bc1d517e.png)
