### PR TITLE
Gtk3: Fix for checks in selected treeviews

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -682,6 +682,15 @@ radio {
     }
   }
 }
+// Fixes selected disabled check/radios leaking selected_bg_color, should move to upstream
+treeview.view check,
+treeview.view radio {
+    &:selected {
+      &:focus, & {
+        &:disabled { color: $insensitive_fg_color; }
+    }
+  }
+}
 
 // Reducing the amount of the palette's background colors to two
 


### PR DESCRIPTION
The selected_bg_color is leaking through a disabled check in a treeview. This tweak fixes this. Should move to upstream as they are affected, too.

Before:
![image](https://user-images.githubusercontent.com/15329494/75097467-5316e780-55ab-11ea-9f20-302f232d5a30.png)


After:
![image](https://user-images.githubusercontent.com/15329494/75097469-590cc880-55ab-11ea-8cae-561fc4e29ae1.png)

Closes #1743 