### PR TITLE
shell: re-use silver color for mouse selection

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_misc.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_misc.scss
@@ -1,7 +1,7 @@
 // Rubberband for select-area screenshots
 .select-area-rubberband {
-  background-color: transparentize($selected_bg_color,0.7);
-  border: 1px solid $selected_bg_color;
+  background-color: transparentize($ash, 0.8);
+  border: 1px solid transparentize($silk, 0.2);
 }
 
 // User icon

--- a/gnome-shell/src/gnome-shell-sass/widgets/_tiled-previews.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_tiled-previews.scss
@@ -2,8 +2,8 @@
 /* Tiled window previews */
 $tile_corner_radius: $base_border_radius + 1px;
 .tile-preview {
-  background-color: transparentize($selected_bg_color,0.5);
-  border: 1px solid $selected_bg_color;
+  background-color: transparentize($ash, 0.8);
+  border: 1px solid transparentize($silk, 0.2);
 }
 
 .tile-preview-left.on-primary {


### PR DESCRIPTION
re-apply #1883 to the shell, since it was lost after upstream rebase

Closes: #1727