### PR TITLE
Gtk3: headerbar button fixes

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -74,13 +74,15 @@ headerbar *, button * {
 // Leave border-color of headerbar buttons evenly colored
 // But darken the border-color a little bit to keep legibility
 // This is consistent with the "default theme"
-headerbar, .titlebar {
+headerbar {
+  &, &.titlebar, window.csd > &, paned.titlebar & {
   stackswitcher button:checked,
     button.toggle:checked {
       border-color: darken($borders_color, 6%);
       border-top-color: darken($borders_color, 6%);
     }
   }
+}
 
 // blue spinner
 spinner {


### PR DESCRIPTION
Include more headerbars (hopefully all) for styling their button borders equally when active. See https://github.com/ubuntu/yaru/pull/1898

For example Gedit and Rhythmbox were missing.