### PR TITLE
Gtk3: Make all :not:(.empty) level bars green

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -422,3 +422,15 @@ button.color { min-height: $_headerbar_height / 2; }
 @if $variant=='dark' {
   notebook entry { background-color: darken($base_color, 2%); }
 }
+
+// Make all :not:(.empty) level bars green - should be moved to upstream
+levelbar {
+  block {
+    &.high,
+    &:not(.empty) {
+      border-color: if($variant == 'light', darken($success_color, 20%), $success_color);
+      background-color: $success_color;
+      &:backdrop { border-color: $success_color; }
+    }
+  }
+}


### PR DESCRIPTION
Closes #2014 

Before:
![image](https://user-images.githubusercontent.com/15329494/75633679-53486000-5c07-11ea-9e00-74fe4be974ec.png)

After:
![image](https://user-images.githubusercontent.com/15329494/75633671-3e6bcc80-5c07-11ea-8680-7587080ab9e2.png)

