### PR TITLE
switch: stronger disabled state in default and light variants

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -227,33 +227,30 @@ switch {
 
   &:checked {
     background-color: $switch_bg_color;
+    &, & slider { border-color: $switch_border_color; }
 
-    &, slider {
-      border-color: $switch_border_color;
-    }
-    &:disabled slider { @include button(insensitive); }
     &:disabled {
       color: $insensitive_fg_color;
       border-color: $borders_color;
       background-color: $insensitive_bg_color;
       text-shadow: none;
 
-      &:disabled {
-        color: $backdrop_insensitive_color;
-        border-color: $backdrop_borders_color;
-        background-color: $insensitive_bg_color;
-      }
-
+      & slider { @include button(insensitive); }
     }
   }
 
   &:backdrop {
     &:checked {
-      @if $variant == 'light' { color: $backdrop_bg_color; }
-      &, slider { border-color: if($variant=='light', $switch_bg_color, $switch_border_color); }
       background-color: $switch_bg_color;
+      &, & slider { border-color: if($variant=='light', $switch_bg_color, $switch_border_color); }
 
-      &:disabled slider { @include button(backdrop-insensitive); }
+      @if $variant == 'light' { color: $backdrop_bg_color; }
+
+      &:disabled {
+        color: $backdrop_insensitive_color;
+        border-color: $backdrop_borders_color;
+        background-color: $insensitive_bg_color;
+      }
     }
   }
 
@@ -269,11 +266,12 @@ switch {
   }
 
   slider {
-
     @if $variant == 'dark' {
       @include button(normal-alt, $c: $bg_color, $edge: $shadow_color);
     }
   }
+
+  &:disabled:backdrop slider { @include button(backdrop-insensitive); }
 }
 
 // 2 pixel transparentized focus rings
@@ -346,9 +344,9 @@ notebook > header {
           &, &:dir(ltr), &:dir(rtl) {
             &, &:backdrop {
               &, &:checked {
-                &, &:hover, &:active {                
+                &, &:hover, &:active {
                   background-color: transparent;
-                  border-color: transparent;                
+                  border-color: transparent;
                 }
               }
               &:hover:not(:checked):not(:backdrop) { color: $insensitive_fg_color; }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -226,16 +226,34 @@ switch {
   font-size: 0; // fix for gtk 3.28 switches to not show the on/off label
 
   &:checked {
-    &, slider { border-color: $switch_border_color; }
     background-color: $switch_bg_color;
+
+    &, slider {
+      border-color: $switch_border_color;
+    }
+    &:disabled slider { @include button(insensitive); }
+    &:disabled {
+      color: $insensitive_fg_color;
+      border-color: $borders_color;
+      background-color: $insensitive_bg_color;
+      text-shadow: none;
+
+      &:disabled {
+        color: $backdrop_insensitive_color;
+        border-color: $backdrop_borders_color;
+        background-color: $insensitive_bg_color;
+      }
+
+    }
   }
 
   &:backdrop {
-
     &:checked {
       @if $variant == 'light' { color: $backdrop_bg_color; }
       &, slider { border-color: if($variant=='light', $switch_bg_color, $switch_border_color); }
       background-color: $switch_bg_color;
+
+      &:disabled slider { @include button(backdrop-insensitive); }
     }
   }
 


### PR DESCRIPTION
In default and light variant, the disabled checked switch is the same as non-disabled one. In the dark variant, the only difference is the handle.

This is due to the need to move our switch style to tweaks to reduce upstream diff in common, so the fix consists in porting some missing styling from common to tweaks.

Closes: #2016

![switch-disabled-after](https://user-images.githubusercontent.com/2883614/75659565-7821ef00-5c6a-11ea-9a9d-2bf544d3faf3.gif)
