### PR TITLE
ShellTheme: color app grid rename dialog label

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
@@ -60,7 +60,7 @@ $app_grid_fg_color: #fff;
     & .folder-name-entry { width: 300px }
 
     /* FIXME: this is to keep the label in sync with the entry */
-    & .folder-name-label { padding: 5px 7px }
+    & .folder-name-label { padding: 5px 7px; color: $osd_fg_color; }
 
     & .edit-folder-button {
       @extend %button;


### PR DESCRIPTION
So it stays variant independent, should be moved to upstream since they have forgotten this

Before:
![Screenshot from 2020-03-02 08-37-28](https://user-images.githubusercontent.com/15329494/75659909-badfc900-5c62-11ea-8205-2ebf74be8245.png)

After:
![Screenshot from 2020-03-02 08-40-08](https://user-images.githubusercontent.com/15329494/75659928-c6cb8b00-5c62-11ea-9216-848370a15363.png)
![Screenshot from 2020-03-02 08-43-06](https://user-images.githubusercontent.com/15329494/75659927-c59a5e00-5c62-11ea-8934-3e29d389152a.png)

