### PR TITLE
Change shell spinner from blue to #f7f7f7

### DIFF
--- a/gnome-shell/src/process-working-blue.svg
+++ b/gnome-shell/src/process-working-blue.svg
@@ -1905,11 +1905,11 @@
        inkscape:collect="always"
        id="linearGradient5747">
       <stop
-         style="stop-color:#f7f7f7;stop-opacity:1"
+         style="stop-color:#19b6ee;stop-opacity:1"
          offset="0"
          id="stop5743" />
       <stop
-         style="stop-color:#f7f7f7;stop-opacity:0"
+         style="stop-color:#c1ebfa;stop-opacity:0"
          offset="1"
          id="stop5745" />
     </linearGradient>


### PR DESCRIPTION
@3v1n0 is working on getting this gresource in, and the blue spinner looks strange in a monochrome environment like the panel. This changes the spinner from blue to f7f7f7