### PR TITLE
shell: tile-preview has straight corners in Yaru

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_tiled-previews.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_tiled-previews.scss
@@ -1,6 +1,6 @@
 
 /* Tiled window previews */
-$tile_corner_radius: $base_border_radius + 1px;
+$tile_corner_radius: 0;
 .tile-preview {
   background-color: transparentize($ash, 0.8);
   border: 1px solid transparentize($silk, 0.2);


### PR DESCRIPTION
Currently, tile-preview has rounded corner as in upstream, but in Ubuntu
the dock is not rounded, then the tile-preview corners shall be
straight.

Closes: #2021 