### PR TITLE
Adding Snap Store category symbols for Reference and Education

### DIFF
--- a/icons/Suru/scalable/categories/accessories-dictionary-symbolic.svg
+++ b/icons/Suru/scalable/categories/accessories-dictionary-symbolic.svg
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-713.0002,-117)'/>
+  <g id='layer2' style='display:inline' transform='translate(-472,-484)'/>
+  <g id='layer4' style='display:inline' transform='translate(-472,-484)'/>
+  <g id='g1812' style='display:inline' transform='translate(-472,-484)'/>
+  <g id='g6217' style='display:inline' transform='translate(-472,-484)'/>
+  <g id='layer3' style='display:inline' transform='translate(-472,-484)'>
+    <path d='m 472,485 v 13 h 6 c 0.97522,8e-5 1.60156,0.80078 1.60156,0.80078 l 0.39063,0.51758 0.40039,-0.50977 c 0,0 0.65126,-0.79321 1.61133,-0.80859 H 488 v -13 h -2 v 1 h 1 v 11 h -5.00391 -0.004 c -1.02478,0.0148 -1.62385,0.47752 -1.98828,0.82422 C 479.64034,497.4702 479,497 478,497 h -5 v -11 h 5 c 0.98317,9e-5 1.59961,0.79883 1.59961,0.79883 l 0.40039,0.53515 0.40039,-0.53515 c 0,0 0.61643,-0.79883 1.59961,-0.79883 v 7 l 3,-1 v -7 h -3 c -1.03628,0 -1.63476,0.46542 -2,0.82031 C 479.63465,485.4654 479.03597,485 478,485 Z m 3,3 v 1 h 3 v -1 z m 0,2 v 1 h 3 v -1 z m 0,2 v 1 h 3 v -1 z m 0,2 v 1 h 3 v -1 z' id='rect4177-6' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
+    
+  </g>
+  <g id='g1833' style='display:inline' transform='translate(-472,-484)'/>
+  <g id='layer1' style='display:inline' transform='translate(-472,-484)'/>
+</svg>

--- a/icons/Suru/scalable/categories/document-page-setup-symbolic.svg
+++ b/icons/Suru/scalable/categories/document-page-setup-symbolic.svg
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-733.0002,-117)'/>
+  <g id='layer2' style='display:inline' transform='translate(-492,-484)'/>
+  <g id='layer4' style='display:inline' transform='translate(-492,-484)'/>
+  <g id='g1812' style='display:inline' transform='translate(-492,-484)'/>
+  <g id='g6217' style='display:inline' transform='translate(-492,-484)'/>
+  <g id='layer3' style='display:inline' transform='translate(-492,-484)'>
+    <path d='m 493,484 v 1 h 9 v 4 h 4 v 4.7495 l 1,0.625 V 489 488.25 L 502.75,484 H 502 Z' id='path3062' style='color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;enable-background:accumulate'/>
+    <path d='m 492,487 v 10 h 16 z m 1.0332,1.8418 c 3.79931,2.37969 7.60343,4.7517 11.4043,7.1289 -3.80303,0.005 -7.60713,0.003 -11.41016,0.004 0,-2.1429 -0.002,-4.2868 0.002,-6.42969 h 0.002 c 10e-4,-0.23467 10e-4,-0.46846 0.002,-0.70312 z' id='rect3006' style='display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1'/>
+    <path d='m 494.04688,490.67578 c -3.9e-4,0.12542 2.4e-4,0.25153 0,0.37695 l -0.002,-0.002 c -0.002,1.30226 0,2.60594 0,3.9082 2.28667,-4.7e-4 4.57271,5e-5 6.85938,-0.002 -2.28486,-1.42876 -4.57033,-2.85606 -6.85742,-4.28125 z m 1.01367,1.82617 c 0.76868,0.47958 1.53799,0.95985 2.30664,1.43946 h -2.30664 v -1.1211 z' id='path3034' style='display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1'/>
+    <rect height='1' id='rect3125' style='display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1' width='14' x='493' y='499'/>
+    <rect height='2' id='rect3127' style='display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1' width='1' x='493' y='498'/>
+    <rect height='2' id='rect3127-0' style='display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1' width='1' x='506.05362' y='498'/>
+    <path d='m 493,484 h 1 v 2.6 l -1,-0.6 z' id='rect3127-6' style='display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1'/>
+    
+  </g>
+  <g id='g1833' style='display:inline' transform='translate(-492,-484)'/>
+  <g id='layer1' style='display:inline' transform='translate(-492,-484)'/>
+</svg>

--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -32,9 +32,9 @@
      inkscape:window-height="704"
      id="namedview88"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="676.74764"
-     inkscape:cy="126.43548"
+     inkscape:zoom="11.313708"
+     inkscape:cx="494.14112"
+     inkscape:cy="111.59029"
      inkscape:window-x="72"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -7588,6 +7588,81 @@
            id="path5872"
            inkscape:connector-curvature="0" />
       </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g5676-3"
+       transform="translate(280,284)"
+       inkscape:label="accessories-dictionary">
+      <path
+         sodipodi:nodetypes="cccccccccccccccccccccccccccscsccccccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect4177-6"
+         d="m 192,201 v 13 h 6 c 0.97522,8e-5 1.60156,0.80078 1.60156,0.80078 l 0.39063,0.51758 0.40039,-0.50977 c 0,0 0.65126,-0.79321 1.61133,-0.80859 H 208 v -13 h -2 v 1 h 1 v 11 h -5.00391 -0.004 c -1.02478,0.0148 -1.62385,0.47752 -1.98828,0.82422 C 199.64034,213.4702 199,213 198,213 h -5 v -11 h 5 c 0.98317,9e-5 1.59961,0.79883 1.59961,0.79883 l 0.40039,0.53515 0.40039,-0.53515 c 0,0 0.61643,-0.79883 1.59961,-0.79883 v 7 l 3,-1 v -7 h -3 c -1.03628,0 -1.63476,0.46542 -2,0.82031 C 199.63465,201.4654 199.03597,201 198,201 Z m 3,3 v 1 h 3 v -1 z m 0,2 v 1 h 3 v -1 z m 0,2 v 1 h 3 v -1 z m 0,2 v 1 h 3 v -1 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <rect
+         transform="rotate(90)"
+         y="-208"
+         x="200"
+         height="16"
+         width="16"
+         id="rect5655-7"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate" />
+    </g>
+    <g
+       id="g3189"
+       inkscape:label="document-page-setup">
+      <path
+         sodipodi:nodetypes="cccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path3062"
+         d="m 493,484 v 1 h 9 v 4 h 4 v 4.7495 l 1,0.625 V 489 488.25 L 502.75,484 H 502 Z"
+         style="display:inline;color:#000000;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect3006"
+         d="m 492,487 v 10 h 16 z m 1.0332,1.8418 c 3.79931,2.37969 7.60343,4.7517 11.4043,7.1289 -3.80303,0.005 -7.60713,0.003 -11.41016,0.004 0,-2.1429 -0.002,-4.2868 0.002,-6.42969 h 0.002 c 10e-4,-0.23467 10e-4,-0.46846 0.002,-0.70312 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3034"
+         d="m 494.04688,490.67578 c -3.9e-4,0.12542 2.4e-4,0.25153 0,0.37695 l -0.002,-0.002 c -0.002,1.30226 0,2.60594 0,3.9082 2.28667,-4.7e-4 4.57271,5e-5 6.85938,-0.002 -2.28486,-1.42876 -4.57033,-2.85606 -6.85742,-4.28125 z m 1.01367,1.82617 c 0.76868,0.47958 1.53799,0.95985 2.30664,1.43946 h -2.30664 v -1.1211 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="499"
+         x="493"
+         height="1"
+         width="14"
+         id="rect3125"
+         style="display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="498"
+         x="493"
+         height="2"
+         width="1"
+         id="rect3127"
+         style="display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="498"
+         x="506.05362"
+         height="2"
+         width="1"
+         id="rect3127-0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect3127-6"
+         d="m 493,484 h 1 v 2.6 l -1,-0.6 z"
+         style="display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="rotate(90)"
+         y="-508"
+         x="484"
+         height="16"
+         width="16"
+         id="rect5655-7-9"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate" />
     </g>
   </g>
   <g


### PR DESCRIPTION
Excuse the typo in the branch name!!

Snap Store is looking for the following two icons for two of the missing categories (just need a name for the fitness icon now):

**accessories-dictionary-symbolic** (for "Books & Reference")

![image](https://user-images.githubusercontent.com/38893390/75706618-60238d00-5cb5-11ea-9d02-e2687b66e21d.png)

For this one I simply copied an appropriate symbol that already exists.

**document-page-setup-symbolic** (for "Education" - note that this won't work until upstream fix the fact that the app looks for document-page-setup, rather than document-page-setup-symbolic - that's why a colour icon is seen currently):

![image](https://user-images.githubusercontent.com/38893390/75706758-a547bf00-5cb5-11ea-9b51-a4875f105918.png)

For this one I drew a new symbol which works for both education and page setup.  In fact, I followed the metaphor of the colour icon that's currently seen:

![image](https://user-images.githubusercontent.com/38893390/75706854-cd372280-5cb5-11ea-8f27-72c9552abb4c.png)
