### PR TITLE
Changed symbolic download icon to better match folder download

### DIFF
--- a/icons/Suru/scalable/places/folder-download-symbolic.svg
+++ b/icons/Suru/scalable/places/folder-download-symbolic.svg
@@ -1,3 +1,36 @@
-<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg">
-    <path d="M5 1v4H2.523S4.857 9.965 8 14.33c3.142-4.365 5.475-9.328 5.475-9.328H11V1zm1 1h4v4.002h1.836C11.16 7.352 9.941 9.63 8 12.52 6.06 9.63 4.84 7.35 4.164 6H6zM2 15v1h12v-1z" fill="gray" overflow="visible" style="marker:none" color="#000"/>
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.000006' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
+  <metadata id='metadata20854'>
+    <rdf:RDF>
+      <cc:Work rdf:about=''>
+        <dc:title/>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs id='defs7386'>
+    <linearGradient id='linearGradient5606' osb:paint='solid'>
+      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient4526' osb:paint='solid'>
+      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    </linearGradient>
+    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
+      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
+      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    </linearGradient>
+  </defs>
+  <g id='layer9' label='status' style='display:inline' transform='translate(-592.99987,327.00001)'/>
+  <g id='layer2' style='display:inline' transform='translate(-351.99967,-39.999995)'>
+    
+    <path d='M 354.97715,54.999999 V 56 h 10.04573 v -1.000001 z' id='path4218-9-3' style='color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.91477442;marker:none;enable-background:accumulate'/>
+    <path d='m 358,40.000001 v 6.999998 h -2.21957 c 0,0 1.63829,3.858382 4.22655,7.580991 2.58827,-3.722609 4.25229,-7.580991 4.25229,-7.580991 H 362 V 40.000001 Z M 359,41 h 2 v 7 h 1.5 c -0.45927,0.998294 -1,2.000001 -2.5,4.69405 C 358.5,50.000001 357.95928,48.998294 357.5,48 h 1.5 z' id='path4215-8' style='color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.47635797;marker:none;enable-background:accumulate'/>
+  </g>
+  <g id='layer4' style='display:inline' transform='translate(-351.99967,-39.999995)'/>
+  <g id='g1812' style='display:inline' transform='translate(-351.99967,-39.999995)'/>
+  <g id='g6217' style='display:inline' transform='translate(-351.99967,-39.999995)'/>
+  <g id='layer3' style='display:inline' transform='translate(-351.99967,-39.999995)'/>
+  <g id='g1833' style='display:inline' transform='translate(-351.99967,-39.999995)'/>
+  <g id='layer1' style='display:inline' transform='translate(-351.99967,-39.999995)'/>
 </svg>

--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -28,17 +28,17 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1294"
-     inkscape:window-height="704"
+     inkscape:window-width="1608"
+     inkscape:window-height="986"
      id="namedview88"
-     showgrid="false"
-     inkscape:zoom="11.313708"
-     inkscape:cx="494.14112"
-     inkscape:cy="111.59029"
+     showgrid="true"
+     inkscape:zoom="8"
+     inkscape:cx="347.7849"
+     inkscape:cy="542.19336"
      inkscape:window-x="72"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer3"
+     inkscape:current-layer="g834-0"
      showborder="true"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
@@ -5271,11 +5271,17 @@
          id="rect4782-68"
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:24;marker:none;enable-background:accumulate" />
       <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99980241;marker:none;enable-background:accumulate"
-         d="m 597,33 v 4 h -2.47656 c 0,-3e-6 2.33386,4.96475 5.47656,9.330078 3.14222,-4.365009 5.47461,-9.328125 5.47461,-9.328125 H 603 V 33 Z m 1,1 h 4 v 4.001953 h 1.83594 C 603.15956,39.351939 601.94049,41.629818 600,44.519531 598.05911,41.629358 596.84049,39.350174 596.16406,38 H 598 Z m -4,13 v 1 h 12 v -1 z"
-         transform="matrix(0,5.9999999,6.0023739,0,149.88852,-3206.6357)"
-         id="path4218-9"
-         inkscape:connector-curvature="0" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.48973227;marker:none;enable-background:accumulate"
+         d="m 432.00009,363.22709 h 6.00238 v 60.2744 h -6.00238 z"
+         id="path4218-9-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.85871315;marker:none;enable-background:accumulate"
+         d="m 341.96449,381.36419 h 42.01661 v -13.3174 c 0,0 23.15945,9.8297 45.50394,25.3593 -22.34449,15.5296 -45.50394,25.5137 -45.50394,25.5137 v -13.5556 h -42.01661 z m 6.00237,6 v 12 h 42.01662 v 9 c 5.99213,-2.7556 12.00475,-6 28.17544,-15 -16.17069,-9 -22.18331,-12.2443 -28.17544,-15 v 9 z"
+         id="path4215-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccc" />
     </g>
     <g
        id="g3656"


### PR DESCRIPTION
This fixes (only) the download icon in #2012 - which also is the most eye catching one.

![image](https://user-images.githubusercontent.com/3986894/75728584-8c0c3600-5ce8-11ea-8d52-a1f848772f2a.png)

![image](https://user-images.githubusercontent.com/3986894/75728678-eb6a4600-5ce8-11ea-9254-12d103f5b7d9.png)
