### PR TITLE
ShellTheme: reduce diff in drawing and app-grid

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -155,7 +155,7 @@
   // hover button
   @else if $t==hover {
     color: $tc;
-    background-color: lighten($c, if($variant == 'light', 8%, 5%)) !important;
+    background-color: lighten($c, if($variant == 'light', 8%, 5%));
     border-color: if($variant == 'light', draw_border_color(lighten($c, 7%)), draw_border_color($c));
     @include draw_shadows(0 1px opacify($shadow_color, 0.05));
     text-shadow: 0 1px $text_shadow_color;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
@@ -159,7 +159,6 @@ $app_grid_fg_color: #fff;
   &, &:hover, &:checked {
     @include button(undecorated);
     color: darken($osd_fg_color, 25%);
-    background-color: transparent !important;
   }
 
   &:hover {


### PR DESCRIPTION
- removed !important assigment from _drawing, so it does not overwrite app grid buttons, reduces diff with upstream and makes more sense