### PR TITLE
Fix headerbar button regression caused by #2010

### DIFF
--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -1618,8 +1618,8 @@ headerbar {
   button.toggle:checked {
 
     background: if($variant == 'light', image(darken($bg_color, 17%)), image(darken($bg_color, 9%)));
-    border-color: darken($borders_color, 3%);
-    border-top-color: darken($borders_color, 8%);
+    border-color: darken($borders_color, 6%);
+    // border-top-color: darken($borders_color, 8%);
     &:backdrop {
       @include button(backdrop-active);
     }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -71,19 +71,6 @@ headerbar *, button * {
   -gtk-icon-shadow: none;
 }
 
-// Leave border-color of headerbar buttons evenly colored
-// But darken the border-color a little bit to keep legibility
-// This is consistent with the "default theme"
-headerbar {
-  &, &.titlebar, window.csd > &, paned.titlebar & {
-  stackswitcher button:checked,
-    button.toggle:checked {
-      border-color: darken($borders_color, 6%);
-      border-top-color: darken($borders_color, 6%);
-    }
-  }
-}
-
 // blue spinner
 spinner {
   &:not(:backdrop) {


### PR DESCRIPTION
Remove this from tweaks as it introduced bugs. The only riskfree way of changing the headerbar outside of _common is to fully re-style it, like we did in _headerbar.scss for the default theme. Asking upstream to fix this uneven borders so the diff is gone again.

![Bildschirmfoto von 2020-03-03 20-25-24](https://user-images.githubusercontent.com/15329494/75811672-21610600-5d8d-11ea-885b-2c83fa5a36d1.png)

Closes #2028 