### PR TITLE
Dark gtk3 theme: darken $borders_color by 2%

### DIFF
--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -11,7 +11,7 @@ $selected_fg_color: #ffffff;
 $selected_bg_color: if($variant == 'light', $orange, darken($orange, 4%));
 
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
+$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 11%));
 $alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', $linkblue, $blue);


### PR DESCRIPTION
I have the impression that we need to increase the contrast of borders in the dark theme a bit more, especially while looking on Adwaita-dark for a while, they do better there:

Adwaita-dark:
![image](https://user-images.githubusercontent.com/15329494/75828761-e1aa1680-5dac-11ea-881b-7d1dd56f1c79.png)


Before:
![Bildschirmfoto vom 2020-03-04 00-29-36](https://user-images.githubusercontent.com/15329494/75829778-5e3df480-5daf-11ea-9b8b-4ec0955e3268.png)

![Bildschirmfoto von 2020-03-04 00-29-59](https://user-images.githubusercontent.com/15329494/75829766-58481380-5daf-11ea-898d-398ed07106fe.png)
![Bildschirmfoto von 2020-03-04 00-29-45](https://user-images.githubusercontent.com/15329494/75829767-58e0aa00-5daf-11ea-80b6-6afb2a0ba66e.png)


After:
![Bildschirmfoto vom 2020-03-04 00-24-56](https://user-images.githubusercontent.com/15329494/75829634-07381f80-5daf-11ea-9587-7fadba88b3d5.png)
![Bildschirmfoto von 2020-03-04 00-31-18](https://user-images.githubusercontent.com/15329494/75829835-82013a80-5daf-11ea-8b7b-1678e0a8bd5a.png)
![Bildschirmfoto von 2020-03-04 00-28-26](https://user-images.githubusercontent.com/15329494/75829676-1e770d00-5daf-11ea-8765-42ae5e8e7960.png)

Please see if you agree @clobrano @madsrh @ubuntujaggers 