### PR TITLE
headerbar: custom outline for suggested-action button

### DIFF
--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -60,9 +60,7 @@ headerbar,
     }
 
     &:backdrop {
-
-      &,
-      &.flat {
+      &, &.flat {
           @include button(backdrop, $backdrop_headerbar_bg_color, $backdrop_headerbar_fg_color);
 
           -gtk-icon-effect: none;
@@ -108,6 +106,7 @@ headerbar,
       &.#{$b_type} {
         @include button(normal, $b_color, white);
         border-color: $b_color;
+        outline-color: $coloured_focus_border_color;
         &.flat {
           @include button(undecorated);
           color: $b_color;
@@ -147,7 +146,6 @@ headerbar,
         }
 
         &.flat {
-
           &:backdrop,
           &:disabled,
           &:backdrop:disabled {
@@ -216,7 +214,7 @@ headerbar,
     &:backdrop {
       background-color: lighten($backdrop_headerbar_bg_color, 2%);
       &, &:checked { border-color: darken($_backdrop_button_border_color, 4%); }
-      &:disabled { 
+      &:disabled {
         background-color: $backdrop_headerbar_bg_color;
         border-color: $_backdrop_button_border_color;
       }
@@ -236,14 +234,14 @@ headerbar,
   switch, scale {
     slider {
       @include button(normal-alt, $_button_bg_color);
-  
+
       &:backdrop {
         @include button(backdrop-alt, $_button_bg_color);
-        &, &:checked, &:disabled, &:checked:disabled { 
+        &, &:checked, &:disabled, &:checked:disabled {
           border-color: darken($_backdrop_button_border_color, 4%); box-shadow: none;
         }
-      }      
-  
+      }
+
       &:checked {
         border-color: $_button_border_color;
       }

--- a/gtk/src/default/gtk-3.20/gtk.scss
+++ b/gtk/src/default/gtk-3.20/gtk.scss
@@ -5,6 +5,6 @@ $ambiance: true;
 @import 'drawing';
 @import 'common';
 @import 'apps';
-@import "tweaks";
+@import 'tweaks';
 @import 'headerbar';
 @import 'colors-public';


### PR DESCRIPTION
headerbar.scss is parsed after tweaks.scss, removing the outline definition. The less risky action is to re-set it in headerbar

Closes: #2019