### PR TITLE
Clean up third party app styling

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -462,12 +462,6 @@ terminal-window {
     }
   }
 
-  /****************
-   * GNOME Photos *
-   ****************/
-  //removes the black background for picture tiles
-  .documents-scrolledwin.frame.frame widget flowboxchild.tile { background-color: transparent; }
-
   /***********
    * Firefox *
    ***********/
@@ -500,15 +494,6 @@ terminal-window {
       trough {
         background-color: transparentize($bg_color, 0.8);
       }
-    }
-  }
-
-  /*********************
-   * Chrome / Chromium *
-   *********************/
-   window.background.chromium {
-    @if $variant=='dark' {
-     menu { border: 1px solid lighten($inkstone,1%); }
     }
   }
 


### PR DESCRIPTION
- remove gnome-photos tweak, there is no reason to tweak here in a not pre-installed application plus it actually looks worse without the black background in the grid
![image](https://user-images.githubusercontent.com/15329494/75913371-15d81280-5e53-11ea-8355-17ccd799e6d8.png)

- remove chromium bright border for the dark theme, this is an artifact styling when we had OSD-like context menus in "Yaru 1.0"