### PR TITLE
Gtk3: darken progressbar border colors

### DIFF
--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -73,7 +73,7 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 $suggested_bg_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 5%), darken($suggested_bg_color, 10%));
 $progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
-$progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
+$progress_border_color: if($variant== 'light', darken($progress_bg_color, 10%), darken($progress_bg_color, 20%));
 $checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $checkradio_fg_color: #ffffff;
 $switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -73,7 +73,7 @@ $backdrop_menu_color: if($variant == 'light', $backdrop_base_color, mix($backdro
 $suggested_bg_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 5%), darken($suggested_bg_color, 10%));
 $progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
-$progress_border_color: if($variant== 'light', darken($progress_bg_color, 10%), darken($progress_bg_color, 20%));
+$progress_border_color: if($variant== 'light', darken($progress_bg_color, 5%), darken($progress_bg_color, 20%));
 $checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $checkradio_fg_color: #ffffff;
 $switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));


### PR DESCRIPTION
when looking at the unfilled progressbars with a border versus the part of the progressbar that is filled, it looks like the progressbar is 1px bigger when filled, which is not exactly clean.
Darkening the progressbars slightly in the dark and light themes fixes this and also increases the contrast to the background, no matter if the progressbar sits on $bg_color or $base_color

![Screenshot from 2020-03-05 09-20-35](https://user-images.githubusercontent.com/15329494/75966983-0b556180-5ec3-11ea-9993-80888d3fa92f.png)
![Screenshot from 2020-03-05 09-20-29](https://user-images.githubusercontent.com/15329494/75966986-0bedf800-5ec3-11ea-8ff9-b38fda72d25a.png)


Closes https://github.com/ubuntu/yaru/issues/2031