### PR TITLE
Issue2034/shell slider borders

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -10,6 +10,7 @@ $selected_fg_color: #ffffff;
 $selected_bg_color: if($variant == 'light', $orange, darken($orange, 4%));
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
 $borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
+$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));

--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -14,6 +14,7 @@ $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentiz
 $link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
 $top_hilight: $borders_edge;
+$dark_fill: mix($borders_color, $bg_color, 50%);
 
 $warning_color: $yellow;
 $error_color: $red;
@@ -62,7 +63,7 @@ $dash-opaque-alpha-value: 0.0;
 $suggested_bg_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 5%), darken($suggested_bg_color, 10%));
 $progress_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
-$progress_border_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
+$progress_border_color: if($variant== 'light', darken($progress_bg_color, 5%), darken($progress_bg_color, 20%));
 $checkradio_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));
 $checkradio_fg_color: #ffffff;
 $switch_bg_color: if($variant=='light', $aubergine, darken($aubergine, 8%));

--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -9,7 +9,7 @@ $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $selected_fg_color: #ffffff;
 $selected_bg_color: if($variant == 'light', $orange, darken($orange, 4%));
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 12%));
+$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));

--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -20,7 +20,7 @@ $slider_size: 15px;
   // slider hander
   -slider-handle-radius: $slider_size * 0.5; // half the size of the size
   -slider-handle-border-width: 1px;
-  -slider-handle-border-color: if($variant == 'light', $borders_color, $fg_color);
+  -slider-handle-border-color: darken($alt_borders_color, 3%); //if($variant == 'light', $borders_color, $fg_color);
 
   color: if($variant == 'light', lighten($bg_color, 10%), $fg_color);
   &:hover { color: $hover_bg_color; }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -6,15 +6,16 @@ $slider_size: 15px;
   height: $slider_size;
   // slider trough
   -barlevel-height: 3px; // has to be an odd number
-  -barlevel-background-color: $inkstone; //background of the trough
+  -barlevel-background-color: if($variant=='light', $dark_fill, $inkstone); //background of the trough
   -barlevel-border-width: 1px;
   -barlevel-border-color: $borders_color; // trough border color
   // fill style
   -barlevel-active-background-color: $progress_bg_color; //active trough fill
-  -barlevel-active-border-color: if($variant == 'light', darken($progress_bg_color, 4%), lighten($progress_bg_color, 2%)); //active trough border
+
+  -barlevel-active-border-color: $progress_border_color; //active trough border
   // overfill style (red in this case)
   -barlevel-overdrive-color: $destructive_color;
-  -barlevel-overdrive-border-color: if($variant == 'light', darken($destructive_color, 4%), lighten($destructive_color, 2%)); //trough border when red;
+  -barlevel-overdrive-border-color: if($variant == 'light', darken($destructive_color, 4%), darken($destructive_color, 20%)); //trough border when red;
   -barlevel-overdrive-separator-width:1px;
   // slider hander
   -slider-handle-radius: $slider_size * 0.5; // half the size of the size

--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -6,8 +6,8 @@ $slider_size: 15px;
   height: $slider_size;
   // slider trough
   -barlevel-height: 3px; // has to be an odd number
-  -barlevel-background-color: $borders_color; //background of the trough
-  -barlevel-border-width: 1px; 
+  -barlevel-background-color: $inkstone; //background of the trough
+  -barlevel-border-width: 1px;
   -barlevel-border-color: $borders_color; // trough border color
   // fill style
   -barlevel-active-background-color: $progress_bg_color; //active trough fill


### PR DESCRIPTION
shell/slider: revert upstream change to yaru style

- changed border color to pre-rebase since current one is too strong against panel background
- use new progress_border_color from gtk and adapt the overdriver border color to it.
- on the slider, don't use the same color for background and border

Closes: #2034

![image](https://user-images.githubusercontent.com/2883614/76033808-7774ab80-5f3d-11ea-86b3-5594f639ab24.png)
![image](https://user-images.githubusercontent.com/2883614/76033869-983d0100-5f3d-11ea-9400-7616d634a46c.png)

Note: this might be a little tricky to test on dark shell because the new meson build does not symlink anymore Yaru-dark shell. I've already asked @3v1n0 if there is a reason not to symlink, and if not, the fix should be easy. Anyway if you don't see any difference in the dark shell, try to double check the symlink and do it manually eventually.

