### PR TITLE
Add symlink to dark shell theme in /usr/share/themes

### DIFF
--- a/gnome-shell/src/install-shell.sh
+++ b/gnome-shell/src/install-shell.sh
@@ -7,3 +7,4 @@ install_prefix="${MESON_INSTALL_PREFIX}/share"
 
 mkdir -p "${destdir_prefix}/themes/${project_name}"
 ln -sf "${install_prefix}/gnome-shell/theme/${project_name}" "${destdir_prefix}/themes/${project_name}/gnome-shell"
+ln -sf "${install_prefix}/gnome-shell/theme/${project_name}-dark" "${destdir_prefix}/themes/${project_name}-dark/gnome-shell"


### PR DESCRIPTION
Fixes issue #2043 

The dark shell theme was moved from `/usr/share/themes/Yaru-dark/gnome-shell` to
 `/usr/share/gnome-shell/themes/Yaru-dark`.

As with the light shell theme, a symlink should be left in its old location so that it is visible in gnome-tweaks.