### PR TITLE
Adding eye assets with thinner strokes

### DIFF
--- a/gnome-shell/src/eye-not-looking-symbolic.svg
+++ b/gnome-shell/src/eye-not-looking-symbolic.svg
@@ -1,4 +1,63 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-    <path d="M13.98 1.99a1 1 0 0 0-.687.303l-.984.984A8 8 0 0 0 8 2 8 8 0 0 0 .262 8.01a8 8 0 0 0 2.943 4.37l-.912.913a1 1 0 1 0 1.414 1.414l11-11a1 1 0 0 0-.727-1.717zM8 4a4 4 0 0 1 2.611.974l-1.42 1.42A2 2 0 0 0 8 6a2 2 0 0 0-2 2 2 2 0 0 0 .396 1.19l-1.42 1.42A4 4 0 0 1 4 8a4 4 0 0 1 4-4zm7.03 2.209l-3.344 3.343a4 4 0 0 1-2.127 2.127l-2.28 2.28a8 8 0 0 0 .721.04 8 8 0 0 0 7.738-6.01 8 8 0 0 0-.709-1.78zm-7.53.79a.5.5 0 0 1 .5.5.5.5 0 0 1-.5.5.5.5 0 0 1-.5-.5.5.5 0 0 1 .5-.5z" fill="#2e3436"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg854"
+   sodipodi:docname="eye-not-looking-symbolic.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata860">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs858" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview856"
+     showgrid="false"
+     inkscape:zoom="0.921875"
+     inkscape:cx="8"
+     inkscape:cy="5.2881356"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg854">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1429" />
+  </sodipodi:namedview>
+  <path
+     style="opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+     d="M 8 2 C 4.35206 2.005 1.1692489 4.4765057 0.26171875 8.0097656 C 0.81274044 10.13281 2.1879067 11.865184 3.9882812 12.912109 L 4.7421875 12.158203 C 3.133681 11.30366 1.872854 9.8054082 1.3398438 8.0605469 C 1.42489 7.5416349 1.6855474 7.0358306 1.9375 6.5664062 C 3.1259528 4.4414828 5.4832085 3.0351849 7.921875 3.0292969 C 9.5058026 3.011323 11.110792 3.5540844 12.341797 4.5585938 L 13.074219 3.8261719 C 11.679909 2.6792457 9.9047031 2.0012289 8 2 z M 8.1953125 4.0039062 C 8.0619 3.9978763 7.9282691 3.9985294 7.7949219 4.0058594 C 5.5899747 4.1194573 3.8940508 5.9980856 4.0058594 8.203125 C 4.0701728 9.4634189 4.7227541 10.542872 5.671875 11.228516 L 6.3789062 10.521484 A 3 3 0 0 1 5.0039062 8.1523438 A 3 3 0 0 1 7.8476562 5.0039062 A 3 3 0 0 1 10.519531 6.3789062 L 11.238281 5.6621094 C 10.547891 4.7068565 9.4506246 4.0654769 8.1953125 4.0039062 z M 14.082031 4.8183594 L 13.357422 5.5429688 C 13.954682 6.2581828 14.396639 7.1015445 14.677734 7.9902344 C 14.197359 9.6081914 13.111069 11.036613 11.671875 11.919922 C 10.502453 12.656274 9.1085071 13.009174 7.7519531 12.964844 C 7.2254432 12.957808 6.6914122 12.870181 6.1757812 12.726562 L 5.3535156 13.546875 C 6.1867974 13.839826 7.0784141 13.999405 8 14 C 11.64794 13.995 14.830751 11.523494 15.738281 7.9902344 C 15.426728 6.7898428 14.847741 5.7171107 14.082031 4.8183594 z M 7.9941406 6 A 2 2 0 0 0 7.8984375 6.0019531 A 2 2 0 0 0 6.0019531 8.1015625 A 2 2 0 0 0 7.1113281 9.7890625 L 8.90625 7.9941406 A 1 1 0 0 1 8.0019531 7.0507812 A 1 1 0 0 1 8.5839844 6.0898438 A 2 2 0 0 0 7.9941406 6 z M 11.876953 7.0234375 L 10.996094 7.9042969 A 3 3 0 0 1 8.1523438 10.996094 A 3 3 0 0 1 7.9042969 10.996094 L 7.0371094 11.863281 C 7.4111794 11.956681 7.7981046 12.014667 8.203125 11.994141 C 10.408849 11.881582 12.105931 10.002638 11.994141 7.796875 L 11.994141 7.7949219 C 11.980592 7.5298397 11.939388 7.2723016 11.876953 7.0234375 z "
+     id="path2314" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 13,2 1,14 H 3 L 15,2 Z"
+     id="path1431-3"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
 </svg>
-

--- a/gnome-shell/src/eye-open-negative-filled-symbolic.svg
+++ b/gnome-shell/src/eye-open-negative-filled-symbolic.svg
@@ -1,27 +1,93 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:osb="http://www.openswatchbook.org/uri/2009/osb" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="16" viewBox="0 0 16 16" version="1.1" id="svg7384" height="16">
-  <metadata id="metadata90">
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg7384"
+   height="16"
+   sodipodi:docname="eye-open-negative-filled-symbolic.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview25"
+     showgrid="true"
+     inkscape:zoom="1"
+     inkscape:cx="8.0883883"
+     inkscape:cy="8"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1375" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>Gnome Symbolic Icon Theme</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <title id="title9167">Gnome Symbolic Icon Theme</title>
-  <defs id="defs7386">
-    <linearGradient osb:paint="solid" id="linearGradient7212">
-      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop7214"/>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient7212">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop7214" />
     </linearGradient>
   </defs>
-  <g transform="translate(-341.0002,-13.000323)" style="display:inline" id="layer9"/>
-  <g transform="translate(-100,-380.00032)" id="layer1"/>
-  <g transform="translate(-100,-380.00032)" style="display:inline" id="layer10">
-    <path d="m 108,382 a 8,8 0 0 0 -7.73828,6.00977 A 8,8 0 0 0 108,394 8,8 0 0 0 115.73828,387.99023 8,8 0 0 0 108,382 Z m 0,2 a 4,4 0 0 1 4,4 4,4 0 0 1 -4,4 4,4 0 0 1 -4,-4 4,4 0 0 1 4,-4 z" id="path2314" style="opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"/>
-    <path id="path2318" d="m 110,388.00003 a 2,2 0 0 1 -2,2 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 2,2 0 0 1 2,2 z" style="vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
-  </g>
-  <g transform="translate(-100,-380.00032)" id="g6387"/>
-  <g transform="translate(-100,-380.00032)" id="layer11"/>
+  <g
+     transform="translate(-341.0002,-13.000323)"
+     style="display:inline"
+     id="layer9" />
+  <g
+     transform="translate(-100,-380.00032)"
+     id="layer1" />
+  <path
+     style="opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+     d="M 8 2 C 4.35206 2.005 1.1692488 4.4765056 0.26171875 8.0097656 C 1.1767387 11.535266 4.35769 13.99765 8 14 C 11.64794 13.995 14.830751 11.523494 15.738281 7.9902344 C 14.823261 4.4647344 11.64231 2.00235 8 2 z M 7.921875 3.0292969 C 9.6621482 3.0095487 11.433086 3.6614403 12.699219 4.8652344 C 13.638809 5.694353 14.301632 6.801178 14.677734 7.9902344 C 14.197359 9.6081911 13.111069 11.036613 11.671875 11.919922 C 10.502453 12.656274 9.108507 13.009174 7.7519531 12.964844 C 6.7164631 12.951006 5.6471995 12.631211 4.7597656 12.169922 C 3.1423512 11.31709 1.8749119 9.8121443 1.3398438 8.0605469 C 1.4248901 7.5416345 1.6855474 7.0358307 1.9375 6.5664062 C 3.1259527 4.4414828 5.4832085 3.0351849 7.921875 3.0292969 z "
+     id="path2314" />
+  <g
+     transform="translate(-100,-380.00032)"
+     id="g6387" />
+  <g
+     transform="translate(-100,-380.00032)"
+     id="layer11" />
+  <path
+     style="opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 8.1953125,4.0039062 C 8.0619,3.9978729 7.9282691,3.9985248 7.7949219,4.0058594 5.5899747,4.1194573 3.8940508,5.9980863 4.0058594,8.203125 c 0.1125592,2.205724 1.9915023,3.902806 4.1972656,3.791016 2.205724,-0.112559 3.902806,-1.991503 3.791016,-4.197266 V 7.794925 C 11.889274,5.7432156 10.247227,4.1045487 8.1953125,4.0039062 Z m -0.3476563,1 a 3,3 0 0 1 3.1484378,2.8417969 v 0.00195 A 3,3 0 0 1 8.1523438,10.996091 3,3 0 0 1 5.0039062,8.1523409 3,3 0 0 1 7.8476562,5.0039031 Z"
+     id="path1379"
+     inkscape:connector-curvature="0" />
+  <path
+     style="opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 7.8984375 6.0019531 A 2 2 0 0 0 6.0019531 8.1015625 A 2 2 0 0 0 8.1015625 9.9980469 A 2 2 0 0 0 9.9980469 7.8984375 A 2 2 0 0 0 9.9101562 7.4121094 A 1 1 0 0 1 9.0507812 7.9980469 A 1 1 0 0 1 8.0019531 7.0507812 A 1 1 0 0 1 8.5839844 6.0898438 A 2 2 0 0 0 7.8984375 6.0019531 z "
+     id="path1391" />
 </svg>
-


### PR DESCRIPTION
Not sure how to test these because my password field on the lock screen doesn't have the eye symbol:

![image](https://user-images.githubusercontent.com/38893390/76550884-bef1bf00-648a-11ea-973e-2ad38f7d1026.png)

Closes #2026