### PR TITLE
Reduce differences between default and dark variant headerbar buttons

### DIFF
--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -920,14 +920,14 @@ button {
 
     $_border_bg: linear-gradient(to top, $alt-borders-color 25%, $borders-color 50%);
 
-    &:not(.flat):not(:checked):not(:active):not(:disabled):not(:backdrop) {
+    &:not(.flat):not(.osd):not(:checked):not(:active):not(:disabled):not(:backdrop) {
       @include button(normal);
 
       background-image: $button_fill, $_border_bg;
       border-color: transparent;
     }
 
-    &:hover:not(:checked):not(:active):not(:disabled):not(:backdrop) {
+    &:hover:not(.osd):not(:checked):not(:active):not(:disabled):not(:backdrop) {
       @include button(hover);
 
       background-image: $button_fill, $_border_bg;
@@ -1618,8 +1618,8 @@ headerbar {
   button.toggle:checked {
 
     background: if($variant == 'light', image(darken($bg_color, 17%)), image(darken($bg_color, 9%)));
-    border-color: darken($borders_color, 3%);
-    border-top-color: darken($borders_color, 8%);
+    border-color: darken($borders_color, 6%);
+    // border-top-color: darken($borders_color, 8%);
     &:backdrop {
       @include button(backdrop-active);
     }

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -1,7 +1,8 @@
 // Color variables dependant on $headerbar_bg_color defined in _colors.scss
-$_button_bg_color: lighten($headerbar_bg_color, 6%);
+$_button_bg_color: lighten($headerbar_bg_color, 7.5%);
 $_button_border_color: darken($headerbar_bg_color, 9%);
-$_backdrop_button_border_color: $headerbar_bg_color;
+// deducted from the color used in common which is $backdrop_borders_color: mix($borders_color, $bg_color, 80%);
+$_backdrop_button_border_color: darken($inkstone, 9%);
 
 // overwriting the headerbar styling from common, for the inverted look in the ambiance theme
 headerbar,
@@ -92,7 +93,7 @@ headerbar,
     }
 
     &:disabled {
-      @include button(insensitive, if($variant=='light', darken($headerbar_bg_color, 15%), $headerbar_bg_color), $headerbar_fg_color);
+      @include button(insensitive, if($variant=='light', darken($headerbar_bg_color, 9%), $headerbar_bg_color), $headerbar_fg_color);
       border-color: darken($headerbar_bg_color, 6%);
 
       &:active,


### PR DESCRIPTION
cherry-pick #2072

* headerbar: use the same backdrop border color of dark variant
* headerbar: make button background color the same as dark variant
* common: remove whitespaces
* reduce difference in headerbar insensitive buttons