### PR TITLE
Legacy icon for object locked / unlocked

### DIFF
--- a/icons/Suru/16x16/legacy/object-locked.svg
+++ b/icons/Suru/16x16/legacy/object-locked.svg
@@ -1,30 +1,32 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
    version="1.1"
-   viewBox="0 0 16 16"
-   id="svg7"
+   id="svg4"
    sodipodi:docname="object-locked.svg"
    inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
   <metadata
-     id="metadata11">
+     id="metadata10">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs8" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -34,282 +36,62 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1016"
-     id="namedview9"
-     showgrid="false"
-     inkscape:zoom="14.75"
-     inkscape:cx="15.900999"
-     inkscape:cy="8"
-     inkscape:window-x="0"
+     inkscape:window-width="1608"
+     inkscape:window-height="986"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="256"
+     inkscape:cx="8.0427905"
+     inkscape:cy="11.003475"
+     inkscape:window-x="72"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg7" />
-  <defs
-     id="defs3">
-    <style
-       id="current-color-scheme"
-       type="text/css">
-   .ColorScheme-Text { color:#808080; }
-  </style>
-    <radialGradient
-       cx="64.575233"
-       cy="48.605404"
-       r="31.000002"
-       fx="64.575233"
-       fy="48.605404"
-       id="radialGradient3259"
-       xlink:href="#linearGradient3242-7-3-8-0-4-58-06"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.38528829,-0.41958841,0,32.389496,-16.793007)" />
-    <linearGradient
-       id="linearGradient3242-7-3-8-0-4-58-06">
-      <stop
-         id="stop3244-5-8-5-6-4-3-8"
-         style="stop-color:#cdf87e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246-9-5-1-5-3-0-7"
-         style="stop-color:#a2e34f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248-7-2-0-7-5-35-9"
-         style="stop-color:#68b723;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250-8-2-8-5-6-40-4"
-         style="stop-color:#1d7e0d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6201">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop6203" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1"
-         id="stop6205" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient6201"
-       id="linearGradient1116"
-       x1="58.695213"
-       y1="-43.66399"
-       x2="62.695213"
-       y2="-43.66399"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(12.804933,56.413844)" />
-    <linearGradient
-       gradientTransform="translate(17.018502,17.593776)"
-       xlink:href="#linearGradient6201"
-       id="linearGradient3541"
-       x1="65.5"
-       y1="12.75"
-       x2="73.25"
-       y2="12.75"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       gradientTransform="translate(-0.76703108,7.1909164)"
-       xlink:href="#linearGradient6201"
-       id="linearGradient3551"
-       x1="75.75"
-       y1="12.75"
-       x2="83.5"
-       y2="12.75"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath994-59">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         id="path996-84"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <linearGradient
-       id="linearGradient4884"
-       x1="31.341"
-       x2="31.341"
-       y1="235.03"
-       y2="224.68"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop4024-2-8"
-         style="stop-color:#555753"
-         offset="0" />
-      <stop
-         id="stop4026-8-3"
-         style="stop-color:#babdb6"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3655"
-       x1="33"
-       x2="33"
-       y1="234"
-       y2="220"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop2605"
-         style="stop-color:#bb2b12"
-         offset="0" />
-      <stop
-         id="stop2607"
-         style="stop-color:#cd7233"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3663"
-       x1="30"
-       x2="30"
-       y1="221"
-       y2="234"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop2612"
-         style="stop-color:#f0c178"
-         offset="0" />
-      <stop
-         id="stop2614"
-         style="stop-color:#e18941"
-         offset=".5" />
-      <stop
-         id="stop2616"
-         style="stop-color:#ec4f18"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="38.940514"
-       y1="15.991243"
-       x2="20.576487"
-       y2="15.991243"
-       id="linearGradient3842"
-       xlink:href="#linearGradient4087-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.39447799,-0.42344634,0,16.496307,18.346218)" />
-    <linearGradient
-       id="linearGradient4087-5">
-      <stop
-         id="stop4089-8"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4091-2"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.51153916" />
-      <stop
-         id="stop4093-6"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.58522105" />
-      <stop
-         id="stop4095-0"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3846">
-      <stop
-         id="stop3848"
-         style="stop-color:#fff3cb;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3850"
-         style="stop-color:#fdde76;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3852"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3854"
-         style="stop-color:#e48b20;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.731871"
-       y1="4.4175272"
-       x2="23.731871"
-       y2="33.875889"
-       id="linearGradient3877"
-       xlink:href="#linearGradient3846"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.47095072,0,0,0.43873263,21.62465,-3.8158265)" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       id="linearGradient5606"
-       osb:paint="solid">
-      <stop
-         id="stop5608"
-         offset="0"
-         style="stop-color:#000000" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4526"
-       osb:paint="solid">
-      <stop
-         id="stop4528"
-         offset="0"
-         style="stop-color:#ffffff" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600-4"
-       osb:paint="gradient">
-      <stop
-         id="stop3602-7"
-         offset="0"
-         style="stop-color:#f4f4f4" />
-      <stop
-         id="stop3604-6"
-         offset="1"
-         style="stop-color:#dbdbdb" />
-    </linearGradient>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983-36">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985-7"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-    <clipPath
-       id="clipPath983-3"
-       clipPathUnits="userSpaceOnUse">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         id="path985-5"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-    </clipPath>
-    <clipPath
-       id="clipPath4653"
-       clipPathUnits="userSpaceOnUse">
-      <path
-         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
-         d="m 412.21109,-140.08377 c 90.81111,0 103.78933,12.94582 103.78933,103.671926 v 72.656487 c 0,90.725907 -12.97822,103.671927 -103.78933,103.671927 h -92.42191 c -90.81071,0 -103.78912,-12.94602 -103.78912,-103.671927 v -72.656487 c 0,-90.726106 12.97841,-103.671926 103.78932,-103.671926 z"
-         id="path4655"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sssssssss" />
-    </clipPath>
-  </defs>
-  <path
-     class="ColorScheme-Text"
-     d="M 7.9999996,0 C 5.6803922,0 3.7999999,1.7908496 3.7999999,4.0000001 V 8 H 1 v 8 H 15 V 8 H 12.200001 V 4.0000001 C 12.200001,1.7908496 10.319608,0 7.9999996,0 Z m 0,1.3333333 c 1.5463964,0 2.7999994,1.1939072 2.7999994,2.6666668 V 8 H 5.1999997 V 4.0000001 c 0,-1.4727596 1.2536027,-2.6666668 2.7999999,-2.6666668 z"
-     id="path5"
-     style="color:#808080;fill:#e72662;fill-opacity:1;stroke-width:1.36626017"
-     inkscape:connector-curvature="0" />
+     inkscape:current-layer="layer2"
+     inkscape:snap-global="false"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid17" />
+  </sodipodi:namedview>
+  <rect
+     id="rect6415"
+     style="color:#000000;display:inline;fill:none;stroke-width:1.49999845;stroke-dasharray:1.49999841, 1.49999841;stroke-dashoffset:0.60000002;enable-background:new"
+     height="15.999983"
+     width="15.999983"
+     y="1.033169e-05"
+     x="1.3898995e-05"
+     inkscape:export-filename="/home/stuart/yaru/icons/Suru/16x16/actions/window-close.png"
+     inkscape:export-xdpi="96"
+     inkscape:export-ydpi="96" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3689-6"
+       style="color:#000000;display:inline;opacity:1;fill:#c7162b;fill-opacity:1;stroke-width:1.49999845;stroke-dashoffset:0.80000001;enable-background:new"
+       d="m 8.0433398,0.04505873 c -4.4093907,0 -7.99999071,3.59058997 -7.99999071,7.99999007 0,4.4093902 3.59060001,7.9999902 7.99999071,7.9999902 4.4094002,0 7.9999902,-3.5906 7.9999902,-7.9999902 0,-4.4094001 -3.59059,-7.99999007 -7.9999902,-7.99999007 z"
+       inkscape:export-filename="/home/stuart/yaru/icons/Suru/16x16/actions/window-close.png"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.60408223;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74509804"
+       class="ColorScheme-Text"
+       d="m 7.9958666,3.0036263 c -1.661179,0 -3.0014252,1.30639 -2.9985176,2.9134823 l 0.00377,2.0837966 c 2.0687923,-0.00879 3.2056019,0.01834 5.991472,0.00556 l 0.0018,-2.0893578 C 10.995791,4.3106599 9.6570444,3.0036266 7.9958666,3.0036263 Z m 0,1.4343299 c 0.8305899,0 1.4992584,0.639711 1.4992584,1.4343295 l -0.0018,2.1230576 -2.9929559,0.00556 -0.00378,-2.1286193 c -0.0014,-0.79462 0.6686811,-1.4343322 1.4992708,-1.4343322 z"
+       id="path5-3"
+       sodipodi:nodetypes="ssccsscsccssc" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.02706063;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect826"
+       width="8.006587"
+       height="5"
+       x="3.9973192"
+       y="8"
+       rx="0"
+       ry="0" />
+  </g>
 </svg>

--- a/icons/Suru/16x16/legacy/object-unlocked.svg
+++ b/icons/Suru/16x16/legacy/object-unlocked.svg
@@ -7,22 +7,26 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
    version="1.1"
-   viewBox="0 0 16 16"
-   id="svg7"
+   id="svg4"
    sodipodi:docname="object-unlocked.svg"
    inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
   <metadata
-     id="metadata11">
+     id="metadata10">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs8" />
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -32,38 +36,100 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1016"
-     id="namedview9"
-     showgrid="false"
-     inkscape:zoom="52.4375"
-     inkscape:cx="8.3333335"
-     inkscape:cy="8"
-     inkscape:window-x="0"
+     inkscape:window-width="1608"
+     inkscape:window-height="986"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="16"
+     inkscape:cx="25.624397"
+     inkscape:cy="7.4456424"
+     inkscape:window-x="72"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg7" />
-  <defs
-     id="defs3">
-    <style
-       id="current-color-scheme"
-       type="text/css">
-   .ColorScheme-Text { color:#808080; }
-  </style>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath983">
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path985"
-         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    </clipPath>
-  </defs>
-  <path
-     style="color:#808080;fill:#45a925;fill-opacity:1;stroke-width:1.36626029"
-     d="M 7.9999995,0 C 5.7260595,0 3.8842336,1.7239258 3.8121993,3.8729166 h 1.400841 C 5.28409,2.4604153 6.4992764,1.3333333 7.9999995,1.3333333 9.5463975,1.3333333 10.799578,2.5272405 10.799578,4 V 8 H 5.200421 V 7.99375 H 3.799579 V 8 H 1 v 8 H 15 V 8 H 12.200421 V 4 c 0,-2.2091505 -1.880814,-4 -4.2004215,-4 z"
-     id="path5-3"
-     inkscape:connector-curvature="0" />
+     inkscape:current-layer="g1536"
+     inkscape:snap-global="false"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid17" />
+  </sodipodi:namedview>
+  <rect
+     id="rect6415"
+     style="color:#000000;display:inline;fill:none;stroke-width:1.49999845;stroke-dasharray:1.49999841, 1.49999841;stroke-dashoffset:0.60000002;enable-background:new"
+     height="15.999983"
+     width="15.999983"
+     y="1.033169e-05"
+     x="1.3898995e-05"
+     inkscape:export-filename="/home/stuart/yaru/icons/Suru/16x16/actions/window-close.png"
+     inkscape:export-xdpi="96"
+     inkscape:export-ydpi="96" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <path
+       inkscape:connector-curvature="0"
+       id="path3689-6"
+       style="color:#000000;display:inline;opacity:1;fill:#c7162b;fill-opacity:1;stroke-width:1.49999845;stroke-dashoffset:0.80000001;enable-background:new"
+       d="m 8.0433398,0.04505873 c -4.4093907,0 -7.99999071,3.59058997 -7.99999071,7.99999007 0,4.4093902 3.59060001,7.9999902 7.99999071,7.9999902 4.4094002,0 7.9999902,-3.5906 7.9999902,-7.9999902 0,-4.4094001 -3.59059,-7.99999007 -7.9999902,-7.99999007 z"
+       inkscape:export-filename="/home/stuart/yaru/icons/Suru/16x16/actions/window-close.png"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74509804"
+       class="ColorScheme-Text"
+       d="m 7.9958658,3.0505013 c -1.6499524,0 -2.9811417,1.297562 -2.9782536,2.8937941 L 5.021357,8.01401 c 2.054812,-0.00873 3.1839387,0.018216 5.950982,0.00552 l 0.0018,-2.0752386 C 10.975486,4.3487023 9.6458178,3.0505013 7.9958658,3.0505013 Z m 0,1.4246371 c 0.824977,0 1.489127,0.635388 1.489127,1.424637 l -0.00178,2.1087104 -2.9727301,0.00552 -0.00375,-2.1142346 c -0.0014,-0.7892477 0.6641507,-1.424637 1.4891267,-1.424637 z"
+       id="path5-3"
+       sodipodi:nodetypes="ssccsscsccssc" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.01737952;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect826"
+       width="7.9558058"
+       height="4.9375"
+       x="4.0129442"
+       y="8"
+       rx="0"
+       ry="0" />
+  </g>
+  <g
+     style="display:inline"
+     inkscape:label="Layer 2 copy"
+     id="g1536"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:export-ydpi="96"
+       inkscape:export-xdpi="96"
+       inkscape:export-filename="/home/stuart/yaru/icons/Suru/16x16/actions/window-close.png"
+       d="m 8.0433398,0.04505873 c -4.4093907,0 -7.99999071,3.59058997 -7.99999071,7.99999007 0,4.4093902 3.59060001,7.9999902 7.99999071,7.9999902 4.4094002,0 7.9999902,-3.5906 7.9999902,-7.9999902 0,-4.4094001 -3.59059,-7.99999007 -7.9999902,-7.99999007 z"
+       style="color:#000000;display:inline;opacity:1;fill:#0e8420;fill-opacity:1;stroke-width:1.49999845;stroke-dashoffset:0.80000001;enable-background:new"
+       id="path1530"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ssccsscsccssc"
+       id="path1532"
+       d="m 7.9802408,2.5661263 c -1.6499524,0 -2.9805768,1.2975611 -2.9782536,2.8937941 l 0.00374,2.5697146 c 2.054812,-0.00873 3.1839387,0.018216 5.9509818,0.00552 l 0.0018,-2.5752386 C 10.959624,3.8643271 9.6301928,2.5661263 7.9802408,2.5661263 Z m 0,1.4246371 c 0.824977,0 1.489127,0.635388 1.489127,1.424637 l -0.00178,2.6087104 -2.9727301,0.00552 -0.00375,-2.6142346 c -0.00113,-0.7892481 0.6641507,-1.424637 1.4891267,-1.424637 z"
+       class="ColorScheme-Text"
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.74509804"
+       inkscape:connector-curvature="0" />
+    <rect
+       ry="0"
+       rx="0"
+       y="8"
+       x="3.9973192"
+       height="5.0039062"
+       width="8.0026808"
+       id="rect1534"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.02721107;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#0e8420;fill-opacity:1;stroke:none;stroke-width:0.7499615;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect1538"
+       width="2.078125"
+       height="2"
+       x="9.390625"
+       y="6" />
+  </g>
 </svg>


### PR DESCRIPTION
Trying to fix the issue where the lock icon for layers in Inkscape isn't visible because of the red / green clashing with the orange selection.

Before:
![image](https://user-images.githubusercontent.com/3986894/76910412-35892500-68ae-11ea-8473-ab7da847a250.png)
 
After:
![image](https://user-images.githubusercontent.com/3986894/76910522-8436bf00-68ae-11ea-94a4-88eb8b26eb65.png)
