### PR TITLE
tweaks: outline for tabs

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -148,8 +148,9 @@ $ambiance: null !default;
       // First, remove the background
       background-color: rgba(255, 255, 255, 0.1);
       // Then bring it back for when it receives a direction
-      &:dir(ltr) {
-        background-color: $selected_bg_color;
+      &:selected:not(:backdrop) {
+        &:dir(ltr) { background-color: $selected_bg_color; }
+        &:not(:dir(ltr)) { background-color: rgba(175, 175, 175, 0.5); }
       }
 
       &:backdrop {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -327,7 +327,8 @@ notebook > header {
       &, &.right, &.left, &.top, &.bottom {
         background-color: transparent;
         tab {
-          outline-color: transparent;
+          outline-width: 1px;
+          outline-offset: -1px;
           &, &:dir(ltr), &:dir(rtl) {
             &, &:backdrop {
               &, &:checked {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -328,7 +328,7 @@ notebook > header {
         background-color: transparent;
         tab {
           outline-width: 1px;
-          outline-offset: -1px;
+          outline-offset: -2px;
           &, &:dir(ltr), &:dir(rtl) {
             &, &:backdrop {
               &, &:checked {


### PR DESCRIPTION
In order to show when the tab has "just got" the focus with keyboard the
outline is still necessary.

Add a thinner style for tab's outline, since the normal 2px outline
seems too heavy for this widget.

Fixes: #2114