### PR TITLE
headerbar: do not use compound selectors

### DIFF
--- a/gtk/src/default/gtk-3.0/_common.scss
+++ b/gtk/src/default/gtk-3.0/_common.scss
@@ -822,6 +822,8 @@ GtkColorButton.button {
   &:backdrop, &:backdrop:hover, &:backdrop:hover:selected {
     color: _backdrop_color($link_color);
   }
+
+  @at-root %link_selected,
   &:selected, *:selected & {
     color: mix($selected_fg_color, $link_color, 80%);
   }
@@ -1196,7 +1198,7 @@ GtkComboBox {
       box-shadow: inset 0 1px mix($top_hilight, $selected_bg_color, 60%);
     }
 
-    .subtitle:link { @extend *:link:selected;  }
+    .subtitle:link { @extend %link_selected; }
 
     .button {
       @include button(normal, $selected_bg_color, $selected_fg_color, $_hc);

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -279,9 +279,7 @@ headerbar,
       }
     }
 
-    .subtitle:link {
-      @extend *:link:selected;
-    }
+    .subtitle:link { @extend %link_selected; }
 
     button,
     button.image-button,


### PR DESCRIPTION
libsass 3.6.3 do not support any more compound selector

Fixes: #2079