### PR TITLE
gnome-shell/calendar: darken event dot

### DIFF
--- a/gnome-shell/src/calendar-today.svg
+++ b/gnome-shell/src/calendar-today.svg
@@ -14,7 +14,7 @@
    height="24"
    id="svg10621"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
    sodipodi:docname="calendar-today.svg">
   <defs
      id="defs10623">
@@ -126,9 +126,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="8"
-     inkscape:cx="-23.537329"
-     inkscape:cy="-31.442864"
+     inkscape:zoom="32"
+     inkscape:cx="2.0105879"
+     inkscape:cy="2.1158397"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -136,10 +136,10 @@
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:window-width="2133"
-     inkscape:window-height="1241"
-     inkscape:window-x="238"
-     inkscape:window-y="88"
+     inkscape:window-width="1920"
+     inkscape:window-height="1015"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
      inkscape:window-maximized="0"
      borderlayer="true"
      inkscape:showpageshadow="false">
@@ -159,7 +159,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -169,7 +169,7 @@
      id="layer1"
      transform="translate(-469.08263,-537.99307)">
     <circle
-       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:0.23756906;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bbbbbb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        id="path7305"
        cx="481.57138"
        cy="559.4649"


### PR DESCRIPTION
In the default Yaru shell theme, the calendar dot of days having an
appointments is not visible. The dark shell theme is not affected.

The problem is due to the color of calendar-today.svg being too similar
to the calendar background.

Fix consists in changing the color of calendar-today.svg in a way that
is both visible in the light and dark shell theme.

Fixes: https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1870938

![image](https://user-images.githubusercontent.com/2883614/78507303-a457f080-777f-11ea-8d83-1216fb000470.png)
![image](https://user-images.githubusercontent.com/2883614/78507312-b0dc4900-777f-11ea-9b1a-14145206736e.png)
