### PR TITLE
gnome-shell/calendar: do not change color of day with events

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
@@ -153,8 +153,11 @@
   }
 
   .calendar-day-with-events {
-    font-weight: bold;
     background-image: url("resource:///org/gnome/shell/theme/calendar-today.svg");
+    &.calendar-work-day {
+      color: lighten($fg_color,10%);
+      font-weight: bold;
+    }
   }
 
   .calendar-other-month-day {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
@@ -156,6 +156,9 @@
     background-image: url("resource:///org/gnome/shell/theme/calendar-today.svg");
     &.calendar-work-day {
       color: lighten($fg_color,10%);
+      &.calendar-today {
+        color: $selected_fg_color;
+      }
       font-weight: bold;
     }
   }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
@@ -153,7 +153,6 @@
   }
 
   .calendar-day-with-events {
-    color: lighten($fg_color,10%);
     font-weight: bold;
     background-image: url("resource:///org/gnome/shell/theme/calendar-today.svg");
   }
@@ -166,7 +165,7 @@
     @include fontsize($base_font_size - 4);
     font-weight: bold;
     height: 1.8em;
-    width: 2.3em; 
+    width: 2.3em;
     border-radius: 2px;
     padding: 0.5em 0 0;
     margin: 6px;


### PR DESCRIPTION
When a non-working day has events, the color is different from other
non-working days without any event.

This happens because the color of days with events is set explicitly,
this might be wanted, but the view looks uneven this way.

To prevent this, do not explicitly set a specific color for days
with events. The color is expected to stay the same regardless the day
being a working or non-working one.