### PR TITLE
shell/switcher-popup: improve contrast of highlighted app

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_switcher-popup.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_switcher-popup.scss
@@ -21,7 +21,7 @@
     }
 
     &:selected {
-      background-color: transparentize($osd_fg_color, 0.9);
+      background-color: transparentize($osd_fg_color, 0.8);
       color: $osd_fg_color;
     }
   }


### PR DESCRIPTION
Currently the highlighted app in switcher-popup has low contrast
respect the background, and eventually poor visibility in some
light conditions.

Improve contrast with a slightly brighter highlighted app background