### PR TITLE
gnome-shell: Use $osd_fg_color for all the login messages

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
@@ -84,7 +84,7 @@
   }
 
   .caps-lock-warning-label,
-  .login-dialog-message-warning {
+  .login-dialog-message {
     color: $osd_fg_color;
   }
 }


### PR DESCRIPTION
LP: #1873320