### PR TITLE
Dash to dock padding fixes

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -67,6 +67,8 @@
     &.top #dash, &.right #dash,
     &.bottom #dash, &.left #dash {
       border-radius: 0;
+      padding-top: 0px;
+      padding-bottom: 0px;
     }
 
     &.top #dash, &.bottom #dash {
@@ -171,10 +173,13 @@
   &.dashtodock.left #dash,
   &.shrink.right #dash,
   &.dashtodock.right #dash {
-    // don't let the first icon be too close to the shadow + panel
     background: $dash_bg_color;
-    padding-top: 2px;
-    padding-bottom: 2px;
+
+    // don't let the first icon be too close to the shadow + panel
+    #dashtodockDashScrollview {
+      padding-top: 2px;
+      padding-bottom: 2px;
+    }
   }
 
   .show-apps {

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -82,6 +82,12 @@
     }
   }
 
+  &.top #dash .placeholder,
+  &.bottom #dash .placeholder {
+    width: 32px;
+    height: 1px;
+  }
+
   &.running-dots .app-well-app.running > .overview-icon,
   &.dashtodock .app-well-app.running > .overview-icon {
     /* Running and focused application style */
@@ -100,6 +106,21 @@
     #dash {
       background: #2e3436;
     }
+  }
+
+ /*
+  * These are applied to a dummy actor. Only the alpha value for the background
+  * and border color and the transition-duration are used
+  */
+  &.dummy-opaque {
+    background-color: rgba(0, 0, 0, 0.8);
+    border-color: rgba(0, 0, 0, 0.4);
+    transition-duration: 300ms;
+  }
+  &.dummy-transparent {
+    background-color: rgba(0, 0, 0, 0.2);
+    border-color: rgba(0, 0, 0, 0.1);
+    transition-duration: 500ms;
   }
 
   &.opaque {


### PR DESCRIPTION
And sync settings from [upstream stylesheet](https://github.com/micheleg/dash-to-dock/blob/ubuntu-dock/stylesheet.css).