### PR TITLE
Special case  spinners in destructive, suggested action buttons

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -71,10 +71,14 @@ headerbar *, button * {
   -gtk-icon-shadow: none;
 }
 
-// blue spinner
+// blue spinner, white spinner for colored buttons
 spinner {
   &:not(:backdrop) {
     color: $blue;
+  }
+  button.suggested-ation &, button.destructive-action & {
+    color: $selected_fg_color;
+    &:backrop { color: $backdrop_selected_fg_color; }
   }
 }
 

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -76,7 +76,7 @@ spinner {
   &:not(:backdrop) {
     color: $blue;
   }
-  button.suggested-ation &, button.destructive-action & {
+  button.suggested-action &, button.destructive-action & {
     color: $selected_fg_color;
     &:backrop { color: $backdrop_selected_fg_color; }
   }


### PR DESCRIPTION
Bright blue spinners on bright green/red buttons looks weird. This can happen in simple-scan.
This special cases those situations and uses selected_fg_color instead, keeps the blue spinner for the rest.
Closes https://github.com/ubuntu/yaru/issues/2182

@clobrano please test this