### PR TITLE
Make wacom overlay visible

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -34,7 +34,7 @@ $tooltip_borders_color: $osd_outer_borders_color;
 $shadow_color: transparentize(black, 0.9);
 
 //insensitive state derived colors
-$insensitive_fg_color: mix($fg_color, $bg_color, 50%);
+$insensitive_fg_color: mix($fg_color, $bg_color, 70%);
 $insensitive_bg_color: mix($bg_color, $base_color, 60%);
 $insensitive_borders_color: $borders_color;
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_osd.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_osd.scss
@@ -30,7 +30,12 @@ $osd_levelbar_height:8px;
 /* Pad OSD */
 .pad-osd-window {
   padding: 32px;
-  background-color: transparentize(#000, 0.2);
+  background-color: $osd_bg_color;
+  color: $osd_fg_color;
+
+  &.button {
+    @extend %button;
+  }
 
   .pad-osd-title-box { spacing: 12px; }
   .pad-osd-title-menu-box { spacing: 6px; }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_osd.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_osd.scss
@@ -33,8 +33,9 @@ $osd_levelbar_height:8px;
   background-color: $osd_bg_color;
   color: $osd_fg_color;
 
-  &.button {
+  .button {
     @extend %button;
+    &:insensitive { color: $fg_color; }
   }
 
   .pad-osd-title-box { spacing: 12px; }


### PR DESCRIPTION
Style .button with %button and use osd colors for the window

![Screenshot from 2020-06-01 11-05-35](https://user-images.githubusercontent.com/15329494/83394126-4ef33500-a3f8-11ea-8853-817595b9f560.png)

@madsrh @clobrano they want to fix it for 3.38 I think (looking at their tags), and since I think this bug should be fixed as soon as possible for 20.04 wacom users, let's get this in?

Closes #2099 