### PR TITLE
Use MESON_INSTALL_DESTDIR_PREFIX in post_install.py

### DIFF
--- a/gtk/src/post_install.py
+++ b/gtk/src/post_install.py
@@ -6,7 +6,7 @@ import sys
 from os import environ, path
 from shutil import move
 
-PREFIX = environ.get('MESON_INSTALL_PREFIX', '/usr')
+PREFIX = environ.get('MESON_INSTALL_DESTDIR_PREFIX', '/usr')
 data_dir = sys.argv[1]
 project_name = sys.argv[2]
 flavours = sys.argv[3:]


### PR DESCRIPTION
The Arch AUR package was failing to build after #1884

This is because the new `post_install.py` script uses the `MESON_INSTALL_PREFIX` environment variable to determine which paths to rename, whereas the Arch package is installed to `DESTDIR` with:

`DESTDIR="${pkgdir}" ninja -C build install`

to install all files to `${pkgdir}` for later installation onto an actual system.

This is essentially the same issue that occurred in #1583

I believe using `MESON_INSTALL_DESTDIR_PREFIX` instead solves the issue. At least, it works for the AUR package, and since I made essentially the same fix for the gnome-shell theme in #1585 I am guessing this works for installs not using `DESTDIR` as well. Since IIUC `MESON_INSTALL_DESTDIR_PREFIX` is always set and is the concatenation of `DESTDIR` (if any) with `MESON_INSTALL_PREFIX`, this makes sense.