### PR TITLE
Adding second user to system-users-symbolic

### DIFF
--- a/icons/Suru/scalable/apps/system-users-symbolic.svg
+++ b/icons/Suru/scalable/apps/system-users-symbolic.svg
@@ -1,36 +1,125 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16.000099' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata20854'>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16.000099"
+   id="svg7384"
+   version="1.1"
+   width="16"
+   sodipodi:docname="system-users-symbolic.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="780"
+     inkscape:window-height="480"
+     id="namedview7724"
+     showgrid="false"
+     inkscape:zoom="5.2148802"
+     inkscape:cx="8"
+     inkscape:cy="8.0000496"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7384" />
+  <metadata
+     id="metadata20854">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:title/>
+      <cc:Work
+         rdf:about="">
+        <dc:title />
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient id='linearGradient4526' osb:paint='solid'>
-      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         id="stop4528"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
-      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
-      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
+    <linearGradient
+       id="linearGradient3600-4"
+       osb:paint="gradient">
+      <stop
+         id="stop3602-7"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1" />
+      <stop
+         id="stop3604-6"
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1" />
     </linearGradient>
   </defs>
-  <g id='layer9' label='status' style='display:inline' transform='translate(-873.00022,187)'/>
-  <g id='layer2' style='display:inline' transform='translate(-632.00002,-180)'/>
-  <g id='layer4' style='display:inline' transform='translate(-632.00002,-180)'/>
-  <g id='g1812' style='display:inline' transform='translate(-632.00002,-180)'/>
-  <g id='g6217' style='display:inline' transform='translate(-632.00002,-180)'/>
-  <g id='layer3' style='display:inline' transform='translate(-632.00002,-180)'/>
-  <g id='g1833' style='display:inline' transform='translate(-632.00002,-180)'>
-    
-    <path d='m 640.00004,181 c -0.5287,0 -1.03154,0.0977 -1.49414,0.29492 -0.45986,0.18776 -0.8678,0.46333 -1.20703,0.82031 l -0.002,0.004 -0.002,0.002 c -0.33049,0.35865 -0.58621,0.79003 -0.76562,1.2793 -0.18275,0.48966 -0.26953,1.0259 -0.26953,1.59961 0,0.58157 0.0864,1.12267 0.26953,1.61328 0.17983,0.48185 0.43594,0.90784 0.76562,1.26563 l 0.002,0.002 0.002,0.002 c 0.33844,0.35616 0.74339,0.63577 1.20117,0.83203 l 0.004,0.002 0.004,0.002 c 0.46162,0.18779 0.9641,0.28092 1.492,0.28092 0.5278,0 1.02823,-0.0932 1.49023,-0.28125 v -0.002 c 0.4574,-0.1961 0.85906,-0.47653 1.18946,-0.83399 0.3395,-0.35783 0.60075,-0.78575 0.78125,-1.26953 0.1838,-0.49061 0.27148,-1.03171 0.27148,-1.61328 h 0.008 c 0,-0.57304 -0.0871,-1.10848 -0.26953,-1.59766 -0.1798,-0.49134 -0.44105,-0.9243 -0.78125,-1.2832 -0.3312,-0.3586 -0.73581,-0.63642 -1.19531,-0.82422 C 641.03178,181.09731 640.52914,181 640.00004,181 Z m 0,1 c 0.4062,0 0.77086,0.0735 1.10156,0.21484 l 0.01,0.004 0.01,0.002 c 0.3299,0.13484 0.60699,0.3262 0.83789,0.57618 v 0.006 0.004 c 0.2398,0.25296 0.43086,0.56352 0.56836,0.93945 v 0.002 0.004 c 0.1307,0.3506 0.19402,0.75253 0.19922,1.20117 V 185 c 0,0.48184 -0.072,0.9 -0.20703,1.26172 v 0.002 c -0.1372,0.3676 -0.32781,0.67603 -0.57031,0.93164 l -0.01,0.004 v 0.004 c -0.2332,0.25229 -0.51385,0.45039 -0.84765,0.59376 -0.32634,0.13143 -0.68744,0.20288 -1.09204,0.20288 -0.4099,0 -0.7766,-0.072 -1.10938,-0.20703 -9.9e-4,-4.4e-4 -0.003,4.4e-4 -0.004,0 -0.32499,-0.14054 -0.59973,-0.33671 -0.83789,-0.58203 l -0.0508,-0.0703 -0.008,-0.006 c -0.21279,-0.24477 -0.39416,-0.52471 -0.52343,-0.8711 -0.13561,-0.36337 -0.20703,-0.78282 -0.20703,-1.26367 0,-0.47122 0.071,-0.88558 0.20703,-1.25 l 0.002,-0.002 v -0.004 c 0.13798,-0.37629 0.32457,-0.68362 0.55469,-0.93555 l 0.0117,-0.01 c 0.23979,-0.25006 0.52018,-0.44362 0.84961,-0.57813 l 0.006,-0.004 0.008,-0.002 C 639.22998,182.07368 639.59424,182 640.00004,182 Z' id='path3307' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:&apos;Ubuntu, Normal&apos;;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
-    <path d='m 646.99994,195.9995 -1,5e-4 c -5e-4,-0.86468 -0.069,-1.29913 -0.2348,-1.83263 -0.1654,-0.53351 -0.41,-0.90462 -0.8144,-1.20997 -0.8089,-0.6107 -2.1094,-0.93361 -4.9218,-0.93361 -2.81251,0 -4.16498,0.32183 -4.97477,0.93274 -0.4049,0.30545 -0.64974,0.67683 -0.81592,1.21046 -0.16618,0.53362 -0.23582,0.9684 -0.23779,1.83311 l -1.00049,-0.002 c 0.002,-0.91456 0.069,-1.44005 0.2832,-2.12793 0.21421,-0.68788 0.59372,-1.27765 1.16846,-1.71123 1.14948,-0.86718 2.69586,-1.13432 5.57721,-1.13432 2.8813,0 4.3759,0.26781 5.5248,1.13519 0.5745,0.43369 0.9532,1.02372 1.1665,1.71172 0.2134,0.68801 0.2792,1.21381 0.2799,2.12841 z' id='path3309' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:&apos;Ubuntu, Normal&apos;;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
-  </g>
-  <g id='layer1' style='display:inline' transform='translate(-632.00002,-180)'/>
+  <g
+     id="layer9"
+     label="status"
+     style="display:inline"
+     transform="translate(-873.00022,187)" />
+  <g
+     id="layer2"
+     style="display:inline"
+     transform="translate(-632.00002,-180)" />
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(-632.00002,-180)" />
+  <g
+     id="g1812"
+     style="display:inline"
+     transform="translate(-632.00002,-180)" />
+  <g
+     id="g6217"
+     style="display:inline"
+     transform="translate(-632.00002,-180)" />
+  <g
+     id="layer3"
+     style="display:inline"
+     transform="translate(-632.00002,-180)" />
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(-632.00002,-180)" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.88976383;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 8,12.000099 c -2.216,0 -4,1.784 -4,4 h 1 c 0,-1.662 1.338,-3 3,-3 h 4 c 1.662,0 3,1.338 3,3 h 1 c 0,-2.216 -1.784,-4 -4,-4 z"
+     id="rect5341" />
+  <path
+     inkscape:connector-curvature="0"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 10,4.0020492 c -0.45935,0 -0.89692,0.0853 -1.29883,0.25782 -0.39955,0.16424 -0.75214,0.4045 -1.04687,0.71679 l -0.004,0.004 -0.002,0.002 c -0.28714,0.31374 -0.50819,0.69114 -0.66406,1.11914 -0.15878,0.42836 -0.23438,0.89853 -0.23438,1.40039 0,0.50876 0.0753,0.98099 0.23438,1.41016 0.15624,0.42152 0.37762,0.79443 0.66406,1.1074198 l 0.002,0.002 0.004,0.002 c 0.29405,0.31157 0.64524,0.55682 1.04297,0.72851 l 0.002,0.002 0.004,0.002 c 0.40108,0.16427 0.83823,0.24609 1.29688,0.24609 0.45856,0 0.89352,-0.0816 1.29492,-0.24609 v -0.002 c 0.39741,-0.17155 0.74615,-0.41777 1.0332,-0.73047 0.29498,-0.3130298 0.52286,-0.6861798 0.67969,-1.1093798 0.1597,-0.42918 0.23438,-0.90336 0.23438,-1.41211 h 0.008 c 0,-0.50128 -0.0759,-0.96854 -0.23438,-1.39648 -0.15621,-0.42981 -0.38216,-0.80908 -0.67773,-1.12305 -0.28776,-0.31369 -0.63983,-0.55641 -1.03906,-0.7207 -0.40191,-0.17431 -0.83913,-0.25977 -1.29883,-0.25977 z m -0.11328,1.03907 c 0.54235,-0.0425 1.11014,0.10554 1.51758,0.47656 0.76785,0.62626 0.93583,1.71677 0.74804,2.64258 -0.12867,0.83869 -0.78758,1.60117 -1.63281,1.76367 -0.82209,0.1882998 -1.76697,-0.0641 -2.26172,-0.7793 -0.53019,-0.69173 -0.55046,-1.62181 -0.39843,-2.44336 0.21073,-0.92005 1.05679,-1.69785 2.02734,-1.66015 z"
+     id="path3307-6" />
+  <path
+     style="display:inline;opacity:0.5;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.88976383;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 6,1.0020492 c -0.45935,0 -0.89692,0.0853 -1.29883,0.25782 -0.39955,0.16424 -0.75214,0.4045 -1.04687,0.71679 l -0.004,0.004 -0.002,0.002 c -0.28714,0.31374 -0.5082,0.69114 -0.66406,1.11914 -0.15878,0.42836 -0.23438,0.89853 -0.23438,1.40039 0,0.50876 0.0753,0.98099 0.23438,1.41016 0.15624,0.42152 0.37762,0.79443 0.66406,1.10742 l 0.002,0.002 0.004,0.002 c 0.29405,0.31157 0.64524,0.55682 1.04297,0.72851 l 0.002,0.002 0.004,0.002 c 0.33388,0.13674 0.69682,0.20372 1.07227,0.22656 -0.009,-0.0844 -0.0153,-0.16909 -0.0195,-0.2539 -0.0107,-0.25498 -9e-4,-0.51046 0.0293,-0.76368 -0.59869,-0.0499 -1.17681,-0.31359 -1.52735,-0.82031 -0.53019,-0.69173 -0.55049,-1.62181 -0.39843,-2.44336 0.21073,-0.92005 1.05679,-1.69785 2.02734,-1.66015 0.54235,-0.0425 1.11014,0.10554 1.51758,0.47656 0.32032,0.26125 0.5309,0.60524 0.66015,0.98242 0.30293,-0.16576 0.62359,-0.29232 0.95508,-0.37695 -0.002,-0.006 -0.002,-0.012 -0.004,-0.0176 -0.1562,-0.42981 -0.38216,-0.80908 -0.67773,-1.12305 -0.28776,-0.31369 -0.63983,-0.55641 -1.03906,-0.7207 -0.40191,-0.17431 -0.83913,-0.25977 -1.29883,-0.25977 z m -2,7.99805 c -2.216,0 -4,1.7839998 -4,3.9999998 v 1 h 1.00001 l -1e-5,-1 c -10e-6,-1.662 1.338,-3 3,-3 H 6.4707 C 6.2745,9.6888692 6.11572,9.3529392 5.99805,9.0000992 Z"
+     id="rect5341-7"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="scccccscccccccccccccccccccsssccssccss" />
 </svg>

--- a/icons/src/scalable/source-symbolic.svg
+++ b/icons/src/scalable/source-symbolic.svg
@@ -14,7 +14,7 @@
    width="1200"
    height="600"
    id="svg7384"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
    sodipodi:docname="source-symbolic.svg"
    inkscape:export-filename="/home/sam/Junk/elementary-icon-theme-symbolic.png"
    inkscape:export-xdpi="384"
@@ -31,14 +31,14 @@
      inkscape:window-width="1294"
      inkscape:window-height="704"
      id="namedview88"
-     showgrid="false"
-     inkscape:zoom="15.999999"
-     inkscape:cx="77.355129"
-     inkscape:cy="274.85624"
+     showgrid="true"
+     inkscape:zoom="5.6568539"
+     inkscape:cx="683.42843"
+     inkscape:cy="404.90119"
      inkscape:window-x="72"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="g1833"
      showborder="true"
      inkscape:snap-nodes="true"
      inkscape:snap-bbox="true"
@@ -8201,32 +8201,6 @@
     </g>
     <g
        style="display:inline"
-       inkscape:label="system-users"
-       id="g3311"
-       transform="translate(-361.00016,207)">
-      <rect
-         transform="rotate(90)"
-         y="-1009.0002"
-         x="-27"
-         height="16"
-         width="16"
-         id="rect3305"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:3.99920893;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 760,341 c -0.5287,0 -1.03154,0.0977 -1.49414,0.29492 -0.45986,0.18776 -0.8678,0.46333 -1.20703,0.82031 l -0.002,0.004 -0.002,0.002 c -0.33049,0.35865 -0.58621,0.79003 -0.76562,1.2793 -0.18275,0.48966 -0.26953,1.0259 -0.26953,1.59961 0,0.58157 0.0864,1.12267 0.26953,1.61328 0.17983,0.48185 0.43594,0.90784 0.76562,1.26563 l 0.002,0.002 0.002,0.002 c 0.33844,0.35616 0.74339,0.63577 1.20117,0.83203 l 0.004,0.002 0.004,0.002 C 758.96962,348.90687 759.4721,349 760,349 c 0.5278,0 1.02823,-0.0932 1.49023,-0.28125 v -0.002 c 0.4574,-0.1961 0.85906,-0.47653 1.18946,-0.83399 0.3395,-0.35783 0.60075,-0.78575 0.78125,-1.26953 0.1838,-0.49061 0.27148,-1.03171 0.27148,-1.61328 h 0.008 c 0,-0.57304 -0.0871,-1.10848 -0.26953,-1.59766 -0.1798,-0.49134 -0.44105,-0.9243 -0.78125,-1.2832 -0.3312,-0.3586 -0.73581,-0.63642 -1.19531,-0.82422 C 761.03174,341.09731 760.5291,341 760,341 Z m 0,1 c 0.4062,0 0.77086,0.0735 1.10156,0.21484 l 0.01,0.004 0.01,0.002 c 0.3299,0.13484 0.60699,0.3262 0.83789,0.57618 v 0.006 0.004 c 0.2398,0.25296 0.43086,0.56352 0.56836,0.93945 v 0.002 0.004 c 0.1307,0.3506 0.19402,0.75253 0.19922,1.20117 V 345 c 0,0.48184 -0.072,0.9 -0.20703,1.26172 v 0.002 c -0.1372,0.3676 -0.32781,0.67603 -0.57031,0.93164 l -0.01,0.004 v 0.004 c -0.2332,0.25229 -0.51385,0.45039 -0.84765,0.59376 C 760.7657,347.92855 760.4046,348 760,348 c -0.4099,0 -0.7766,-0.072 -1.10938,-0.20703 -9.9e-4,-4.4e-4 -0.003,4.4e-4 -0.004,0 -0.32499,-0.14054 -0.59973,-0.33671 -0.83789,-0.58203 l -0.0508,-0.0703 -0.008,-0.006 c -0.21279,-0.24477 -0.39416,-0.52471 -0.52343,-0.8711 -0.13561,-0.36337 -0.20703,-0.78282 -0.20703,-1.26367 0,-0.47122 0.071,-0.88558 0.20703,-1.25 l 0.002,-0.002 v -0.004 c 0.13798,-0.37629 0.32457,-0.68362 0.55469,-0.93555 l 0.0117,-0.01 c 0.23979,-0.25006 0.52018,-0.44362 0.84961,-0.57813 l 0.006,-0.004 0.008,-0.002 C 759.22994,342.07368 759.5942,342 760,342 Z"
-         transform="translate(241.0002,-367)"
-         id="path3307"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3309"
-         d="m 1008.0001,-11.0005 -1,5e-4 c -5e-4,-0.86468 -0.069,-1.299133 -0.2348,-1.832633 -0.1654,-0.53351 -0.41,-0.90462 -0.8144,-1.20997 -0.8089,-0.6107 -2.1094,-0.93361 -4.9218,-0.93361 -2.81251,0 -4.16498,0.32183 -4.97477,0.93274 -0.4049,0.30545 -0.64974,0.67683 -0.81592,1.21046 -0.16618,0.53362 -0.23582,0.968403 -0.23779,1.833113 l -1.00049,-0.002 c 0.002,-0.91456 0.069,-1.440053 0.2832,-2.127933 0.21421,-0.68788 0.59372,-1.27765 1.16846,-1.71123 1.14948,-0.86718 2.69586,-1.13432 5.57721,-1.13432 2.8813,0 4.3759,0.26781 5.5248,1.13519 0.5745,0.43369 0.9532,1.02372 1.1665,1.71172 0.2134,0.68801 0.2792,1.213813 0.2799,2.128413 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         sodipodi:nodetypes="ccccsccccccscccc" />
-    </g>
-    <g
-       style="display:inline"
        id="g3396"
        transform="translate(4.2001252e-5,-20)"
        inkscape:label="preferences-system-time">
@@ -10463,6 +10437,34 @@
          style="display:inline;opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          d="M 556.5 309 C 554.561 309 553 310.561 553 312.5 C 553 314.439 554.561 316 556.5 316 L 563.5 316 C 565.439 316 567 314.439 567 312.5 C 567 310.561 565.439 309 563.5 309 L 556.5 309 z M 556.37305 310.00391 A 2.5 2.5 0 0 1 558.99609 312.37109 L 558.99609 312.37305 A 2.5 2.5 0 0 1 556.62695 314.99609 A 2.5 2.5 0 0 1 554.00391 312.62695 A 2.5 2.5 0 0 1 556.37305 310.00391 z "
          id="rect5308-3" />
+    </g>
+    <g
+       id="g5468"
+       inkscape:label="system-users"
+       transform="translate(-52)">
+      <path
+         id="rect5341"
+         d="m 692,192 c -2.216,0 -4,1.784 -4,4 h 1 c 0,-1.662 1.338,-3 3,-3 h 4 c 1.662,0 3,1.338 3,3 h 1 c 0,-2.216 -1.784,-4 -4,-4 z"
+         style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.88976383;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path3307-6"
+         d="m 694,184.00195 c -0.45935,0 -0.89692,0.0853 -1.29883,0.25782 -0.39955,0.16424 -0.75214,0.4045 -1.04687,0.71679 l -0.004,0.004 -0.002,0.002 c -0.28714,0.31374 -0.50819,0.69114 -0.66406,1.11914 -0.15878,0.42836 -0.23438,0.89853 -0.23438,1.40039 0,0.50876 0.0753,0.98099 0.23438,1.41016 0.15624,0.42152 0.37762,0.79443 0.66406,1.10742 l 0.002,0.002 0.004,0.002 c 0.29405,0.31157 0.64524,0.55682 1.04297,0.72851 l 0.002,0.002 0.004,0.002 c 0.40108,0.16427 0.83823,0.24609 1.29688,0.24609 0.45856,0 0.89352,-0.0816 1.29492,-0.24609 v -0.002 c 0.39741,-0.17155 0.74615,-0.41777 1.0332,-0.73047 0.29498,-0.31303 0.52286,-0.68618 0.67969,-1.10938 0.1597,-0.42918 0.23438,-0.90336 0.23438,-1.41211 h 0.008 c 0,-0.50128 -0.0759,-0.96854 -0.23438,-1.39648 -0.15621,-0.42981 -0.38216,-0.80908 -0.67773,-1.12305 -0.28776,-0.31369 -0.63983,-0.55641 -1.03906,-0.7207 -0.40191,-0.17431 -0.83913,-0.25977 -1.29883,-0.25977 z m -0.11328,1.03907 c 0.54235,-0.0425 1.11014,0.10554 1.51758,0.47656 0.76785,0.62626 0.93583,1.71677 0.74804,2.64258 -0.12867,0.83869 -0.78758,1.60117 -1.63281,1.76367 -0.82209,0.1883 -1.76697,-0.0641 -2.26172,-0.7793 -0.53019,-0.69173 -0.55046,-1.62181 -0.39843,-2.44336 0.21073,-0.92005 1.05679,-1.69785 2.02734,-1.66015 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="scccccscccccccccccccccccccsssccssccss"
+         inkscape:connector-curvature="0"
+         id="rect5341-7"
+         d="m 690,181.00195 c -0.45935,0 -0.89692,0.0853 -1.29883,0.25782 -0.39955,0.16424 -0.75214,0.4045 -1.04687,0.71679 l -0.004,0.004 -0.002,0.002 c -0.28714,0.31374 -0.5082,0.69114 -0.66406,1.11914 -0.15878,0.42836 -0.23438,0.89853 -0.23438,1.40039 0,0.50876 0.0753,0.98099 0.23438,1.41016 0.15624,0.42152 0.37762,0.79443 0.66406,1.10742 l 0.002,0.002 0.004,0.002 c 0.29405,0.31157 0.64524,0.55682 1.04297,0.72851 l 0.002,0.002 0.004,0.002 c 0.33388,0.13674 0.69682,0.20372 1.07227,0.22656 -0.009,-0.0844 -0.0153,-0.16909 -0.0195,-0.2539 -0.0107,-0.25498 -9e-4,-0.51046 0.0293,-0.76368 -0.59869,-0.0499 -1.17681,-0.31359 -1.52735,-0.82031 -0.53019,-0.69173 -0.55049,-1.62181 -0.39843,-2.44336 0.21073,-0.92005 1.05679,-1.69785 2.02734,-1.66015 0.54235,-0.0425 1.11014,0.10554 1.51758,0.47656 0.32032,0.26125 0.5309,0.60524 0.66015,0.98242 0.30293,-0.16576 0.62359,-0.29232 0.95508,-0.37695 -0.002,-0.006 -0.002,-0.012 -0.004,-0.0176 -0.1562,-0.42981 -0.38216,-0.80908 -0.67773,-1.12305 -0.28776,-0.31369 -0.63983,-0.55641 -1.03906,-0.7207 -0.40191,-0.17431 -0.83913,-0.25977 -1.29883,-0.25977 z M 688,189 c -2.216,0 -4,1.784 -4,4 v 1 h 1.00001 L 685,193 c -10e-6,-1.662 1.338,-3 3,-3 h 2.4707 c -0.1962,-0.31123 -0.35498,-0.64716 -0.47265,-1 z"
+         style="display:inline;opacity:0.5;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.88976383;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="180"
+         x="684"
+         height="16"
+         width="16"
+         id="rect5461"
+         style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:1.88976383;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     </g>
   </g>
   <g


### PR DESCRIPTION
As requested for Lollypop, which uses this symbol to stand for Compilations:

![image](https://user-images.githubusercontent.com/38893390/84685936-f90fa880-af32-11ea-8e73-7da38a577228.png)

![image](https://user-images.githubusercontent.com/38893390/84686022-193f6780-af33-11ea-9d8b-c8c594bcd3b2.png)

Closes #1988 ???