### PR TITLE
Fix spinner typo in tweaks.scss

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -78,7 +78,7 @@ spinner {
   }
   button.suggested-action &, button.destructive-action & {
     color: $selected_fg_color;
-    &:backrop { color: $backdrop_selected_fg_color; }
+    &:backdrop { color: $backdrop_selected_fg_color; }
   }
 }
 


### PR DESCRIPTION
"backrop" instead than "backdrop"

Fixes: #2207