### PR TITLE
Nemo selected text highlighting and inactive pane shading

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -419,6 +419,11 @@ terminal-window {
 
     }
 
+    .nemo-inactive-pane .view, .nemo-inactive-pane iconview {
+      // Shades the background of the inactive pane
+      background-color: $bg_color;
+    }
+
     .nemo-window-pane {
       widget.entry {
         // Add border around rename text entry

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -421,7 +421,7 @@ terminal-window {
 
     .nemo-inactive-pane .view, .nemo-inactive-pane iconview {
       // Shades the background of the inactive pane
-      background-color: $bg_color;
+      background-color: $backdrop_bg_color;
     }
 
     .nemo-window-pane {

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -416,6 +416,26 @@ terminal-window {
           &:not(:backdrop):hover { background-image: image($base_hover_color); }
         }
       }
+
+    }
+
+    .nemo-window-pane {
+      widget.entry {
+        // Add border around rename text entry
+        border: 1px solid;
+        border-radius: 3px;
+        color: $fg_color;
+        border-color: $selected_bg_color;
+        background-color: $bg_color;
+      }
+      widget.entry:selected {
+        // Add highlighting to selected text in rename text entry
+        border: 1px solid;
+        border-radius: 3px;
+        color: $selected_fg_color;
+        border-color: $selected_bg_color;
+        background-color: $selected_bg_color;
+      }
     }
 
     .view {


### PR DESCRIPTION
Added missing highlighting for selected text when renaming files in Nemo (#2183), as well as shading for the unfocused pane in split pane mode (the right pane in the screenshots). (Based on the fallback code that implements this in Nemo for unsupported themes.)

(2nd PR, as #2218 didn't update with new commit)

![Screenshot from 2020-06-28 19-11-54](https://user-images.githubusercontent.com/10012625/86126893-fa1a0b80-bad6-11ea-8763-3388076fa759.png)
![Screenshot from 2020-06-28 19-12-07](https://user-images.githubusercontent.com/10012625/86126897-fbe3cf00-bad6-11ea-8cac-b074abcf986f.png)
