### PR TITLE
Ubuntu colors into Gnome Clocks

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -307,6 +307,29 @@ terminal-window {
     box-shadow: inset 0 0 10px 10px $success_color;
   }
 
+  /****************
+   * GNOME Clocks *
+   ****************/
+
+   @keyframes clocks-blink {
+       0% { color: #9E9DA1; }
+       100% { color: if($variant=='light', $aubergine, darken($aubergine, 8%)); }
+   }
+
+   .seconds-label,
+   .miliseconds-label,
+   .timer-countdown.timer-running {
+       color: if($variant=='light', $aubergine, darken($aubergine, 8%));
+   }
+
+   .positive-lap {
+       color: $success_color;
+   }
+
+   .negative-lap {
+       color: $destructive_color;
+    }
+
   /*********
    * Gedit *
    *********/


### PR DESCRIPTION
Add Ubuntu colors into Gnome Clocks instead of Adwaita ones.
I will check these changes with a VM.

#2224