### PR TITLE
Gtk3: increase menu visibility

### DIFF
--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -19,7 +19,7 @@ $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
-$menu_color: if($variant == 'light', $base_color, lighten($inkstone, 1%));
+$menu_color: if($variant == 'light', #FAFAFA, lighten($inkstone, 1%));
 $popover_bg_color: if($variant == 'light', #FAFAFA, lighten($inkstone, 1%));
 $popover_hover_color: transparentize($fg_color, 0.85);
 

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -19,7 +19,7 @@ $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
-$menu_color: if($variant == 'light', #FAFAFA, lighten($inkstone, 1%));
+$menu_color: if($variant == 'light', $base_color, lighten($inkstone, 1%));
 $popover_bg_color: if($variant == 'light', #FAFAFA, lighten($inkstone, 1%));
 $popover_hover_color: transparentize($fg_color, 0.85);
 

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -391,7 +391,7 @@ decoration {
   $_wm_border: if($variant=='light', transparentize(black, 0.77), transparentize($borders_color, 0.1));
   .csd.popup & {
     border-radius: $menu_radius;
-    box-shadow: 0 2px 2px 1px transparentize(black, 0.7),
+    box-shadow: 0 1px 2px 1px transparentize(black, 0.7),
                 0 0 0 1px $_wm_border;
   }
 }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -385,3 +385,13 @@ levelbar {
     }
   }
 }
+
+// Strengthen the menu shadows to increase visibility
+decoration {
+  $_wm_border: if($variant=='light', transparentize(black, 0.77), transparentize($borders_color, 0.1));
+  .csd.popup & {
+    border-radius: $menu_radius;
+    box-shadow: 0 2px 2px 1px transparentize(black, 0.7),
+                0 0 0 1px $_wm_border;
+  }
+}


### PR DESCRIPTION
_colors.scss: Switch menu background color back to white to let them "pop" out more for the light theme(s), no change for the dark theme

_tweaks.css: Increase the menu shadow for all themes, to make them more visible on the background they are drawn upon

Closes #2221 

@clobrano and/or @madsrh and/or @ubuntujaggers and/or @Jupiter007-43 please test all three gtk3 themes and share your opinion. 
Preview screenshots following but I would really test this on your screens etc etc:
![grafik](https://user-images.githubusercontent.com/15329494/86630382-0cabad80-bfcd-11ea-95a1-d9d7a9c7339a.png)
![grafik](https://user-images.githubusercontent.com/15329494/86630534-3ebd0f80-bfcd-11ea-88c4-9f13e49d215d.png)
