### PR TITLE
Shell: popup and notification improvements

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -9,7 +9,7 @@ $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $selected_fg_color: #ffffff;
 $selected_bg_color: if($variant == 'light', $orange, darken($orange, 4%));
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 9%));
+$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 11%));
 $alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));

--- a/gnome-shell/src/gnome-shell-sass/widgets/_notifications.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_notifications.scss
@@ -15,6 +15,8 @@ $notification_banner_width: 34em;
   .notification-button {
     @extend %bubble_button;
   }
+  box-shadow: 0 1px 3px 1px transparentize(black, 0.8);
+  border-color: $borders_color;
 }
 
 // counter


### PR DESCRIPTION
Light/Dark shell theme: add a dedicated box-shadow to notifications to make them more visible against different backgrounds
Dark shell theme: adapt $borders_color to the gtk3 $borders_color which makes shell popups and notifications more visible and more sharp and less blurry against different backgrounds. Also increases consistency with the gtk3 theme

Closes #2217 

(zoom in)
![Screenshot from 2020-07-09 10-08-11](https://user-images.githubusercontent.com/15329494/87017290-19e4ba00-c1d0-11ea-9f8a-d40591c34070.png)
![Screenshot from 2020-07-09 10-23-16](https://user-images.githubusercontent.com/15329494/87017231-06395380-c1d0-11ea-82e7-5f153bec9c6a.png)
![Screenshot from 2020-07-09 10-23-03](https://user-images.githubusercontent.com/15329494/87017278-16513300-c1d0-11ea-9f77-05dddd094100.png)
