### PR TITLE
Nautilus: fix gray label in backdrop

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -16,20 +16,6 @@ $ambiance: null !default;
    * Nautilus *
    ***********/
   .nautilus-window {
-    .nautilus-canvas-item.dim-label,
-    .nautilus-list-dim-label {
-      color: mix($text_color, $base_color);
-      &:backdrop {
-        color: transparentize(mix($text_color, $base_color), 0.2);
-      }
-      &:selected {
-        color: transparentize($selected_fg_color, 0.3);
-        &:backdrop {
-          color: transparentize(mix($text_color, $base_color), 0.4);
-        }
-      }
-    }
-
     // keep details box visible
     // details box looks ugly when many items are selected and it floats above the orange
     background-image: none;


### PR DESCRIPTION
Nautilus column label color is too gray and unreadable when selected and
in backdrop.

This seems to be due to a previous fix (#2113) which I can not reproduce
anymore anyway, so the best thing to do is to remove the old code.

Closes: #2216