### PR TITLE
Fix for systemd mimetype icon in master

### DIFF
--- a/icons/src/fullcolor/mimetypes/text-x-systemd-unit.svg
+++ b/icons/src/fullcolor/mimetypes/text-x-systemd-unit.svg
@@ -33,10 +33,10 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.8279663"
-     inkscape:cx="357.10366"
-     inkscape:cy="144.3258"
-     inkscape:current-layer="g1094-8"
+     inkscape:zoom="3.6559326"
+     inkscape:cx="249.53107"
+     inkscape:cy="151.51109"
+     inkscape:current-layer="g1053"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
@@ -580,113 +580,8 @@
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient924);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
     </g>
     <g
-       inkscape:groupmode="layer"
-       id="layer10"
-       inkscape:label="pictogram_original_logo"
-       style="display:none">
-      <path
-         inkscape:connector-curvature="0"
-         overflow="visible"
-         font-weight="400"
-         d="m 76.072375,133.06124 v 45.87752 h 17.645199 v -7.05809 H 83.130456 v -31.76134 h 10.587118 v -7.05809 z m 134.204655,0 v 7.05809 h 10.58712 v 31.76134 h -10.58712 v 7.05809 h 17.6452 v -45.87752 z"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#201a26;stroke-width:1.76451981"
-         id="path2-1"
-         sodipodi:nodetypes="cccccccccccccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:#30d475;stroke-width:1.72516608"
-         d="m 155.44763,156 31.05299,-17.25166 v 34.50332 z"
-         id="path6-2" />
-      <circle
-         style="fill:#30d475;stroke-width:1.72516608"
-         cx="129.5719"
-         cy="156.00174"
-         r="15.526495"
-         id="circle8-9" />
-      <g
-         id="g1298"
-         transform="translate(-0.20429302,-0.055509)">
-        <path
-           sodipodi:nodetypes="cccccccccccccccccc"
-           id="path2-1-1"
-           style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#201a26;stroke-width:0.34868446;enable-background:new"
-           d="m 329.20898,79.562672 v 9.065797 h 3.48685 v -1.39474 h -2.09212 v -6.276317 h 2.09212 v -1.39474 z m 26.52,0 v 1.39474 h 2.09212 v 6.276317 h -2.09212 v 1.39474 h 3.48685 v -9.065797 z"
-           font-weight="400"
-           overflow="visible"
-           inkscape:connector-curvature="0" />
-        <path
-           id="path6-2-9"
-           d="m 345.06832,84.095571 6.13635,-3.409078 v 6.818155 z"
-           style="display:inline;fill:#30d475;stroke-width:0.34090781;enable-background:new"
-           inkscape:connector-curvature="0" />
-        <circle
-           id="circle8-9-4"
-           r="3.0681703"
-           cy="84.095917"
-           cx="339.78094"
-           style="display:inline;fill:#30d475;stroke-width:0.34090781;enable-background:new" />
-      </g>
-      <path
-         inkscape:connector-curvature="0"
-         overflow="visible"
-         font-weight="400"
-         d="m 326,145 v 6 l 2.39253,-0.005 -0.006,-0.995 H 327 v -4 h 1.38655 l 0.006,-1.01341 z m 17.61236,-0.006 10e-4,1.00689 H 345 v 4 h -1.38655 l -0.005,0.99765 L 346,151 v -6 z"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#201a26;stroke-width:0.23109321;enable-background:new"
-         id="path2-1-7"
-         sodipodi:nodetypes="cccccccccccccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="display:inline;fill:#30d475;stroke-width:0.22593918;enable-background:new"
-         d="m 336.47714,147.99081 4.06691,-2.25939 v 4.51878 z"
-         id="path6-2-8" />
-      <circle
-         style="display:inline;fill:#30d475;stroke-width:0.22593918;enable-background:new"
-         cx="333.08829"
-         cy="147.99104"
-         r="2.0334527"
-         id="circle8-9-45" />
-      <path
-         inkscape:connector-curvature="0"
-         overflow="visible"
-         font-weight="400"
-         d="m 323.99881,197.59051 v 4.83784 h 1.86071 v -0.74428 h -1.11643 v -3.34928 h 1.11643 v -0.74428 z m 14.15206,0 v 0.74428 h 1.11643 v 3.34928 h -1.11643 v 0.74428 h 1.86071 v -4.83784 z"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#201a26;stroke-width:0.18607108;enable-background:new"
-         id="path2-1-3"
-         sodipodi:nodetypes="cccccccccccccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="display:inline;fill:#30d475;stroke-width:0.18192118;enable-background:new"
-         d="m 332.36904,200.00943 3.27458,-1.81922 v 3.63844 z"
-         id="path6-2-6" />
-      <circle
-         style="display:inline;fill:#30d475;stroke-width:0.18192118;enable-background:new"
-         cx="329.64038"
-         cy="200.00966"
-         r="1.6372907"
-         id="circle8-9-7" />
-      <path
-         inkscape:connector-curvature="0"
-         overflow="visible"
-         font-weight="400"
-         d="m 323.05835,242.50136 v 3.00296 h 1.15499 v -0.46199 h -0.69299 v -2.07898 h 0.69299 v -0.46199 z m 8.78454,0 v 0.46199 h 0.69299 v 2.07898 h -0.69299 v 0.46199 h 1.15499 v -3.00296 z"
-         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#201a26;stroke-width:0.11549897;enable-background:new"
-         id="path2-1-3-5"
-         sodipodi:nodetypes="cccccccccccccccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="display:inline;fill:#30d475;stroke-width:0.11292302;enable-background:new"
-         d="m 328.25396,244.00284 2.03262,-1.12924 v 2.25848 z"
-         id="path6-2-6-3" />
-      <circle
-         style="display:inline;fill:#30d475;stroke-width:0.11292302;enable-background:new"
-         cx="326.56021"
-         cy="244.00298"
-         r="1.0163072"
-         id="circle8-9-7-5" />
-    </g>
-    <g
        style="display:inline"
-       inkscape:label="pictogram_sqeezed"
+       inkscape:label="Pictogram"
        id="g1053"
        inkscape:groupmode="layer">
       <g


### PR DESCRIPTION
I accidently pushed the _systemd_ icon to master 🤦‍♂️ 

In the .SVG there are two versions of the icon. The current hidden layer - that this PR removes - contains [the original logo](https://systemd.io/). I found the original logo to be not great at small sizes, so what's now in master (doh) is a squeezed version. 
The squeezed version also renders better, but it's a bit blasphemous to change a logo. Just imagine if it was something else:
![image](https://user-images.githubusercontent.com/3986894/88774160-6134e980-d183-11ea-90e1-5478a474e629.png)

Screenshots explains the two versions better: 😄  

![systemd_Untitled-2-Recovered](https://user-images.githubusercontent.com/3986894/88773239-3007e980-d182-11ea-9c8c-4ea5a03a4acf.gif)

This is the squeezed version:
![systemD](https://user-images.githubusercontent.com/3986894/88773442-65143c00-d182-11ea-8202-9cc209be6248.jpg)

@clobrano @Feichtmeier if you're fine with current version you can just merge this PR
