### PR TITLE
Rework extract symbolic icons

### DIFF
--- a/icons/src/scalable/README.md
+++ b/icons/src/scalable/README.md
@@ -2,12 +2,16 @@
 
  - To add or modify a symbolic icon, edit source SVG file found in this directory
  - For simplified development, has various scripts to extract or render icons from the larger SVG source files.
- - To edit the icons you will need `inkscape` and you'll need `ruby` installed to run the render script.
+ - To edit the icons you will need `inkscape` and you'll need `ruby` installed to run the render script
 
 **[source-symbolic.svg](./source-symbolic.svg) - the source files that contains all of the symbolic icons**
  - each layer in this source file corresponds to a icon `context` and the icons are sorted accordingly
  - each icon should be drawn within an 16x16 pixel square and use only 1 colour
  - when complete, group all elements within a 16x16 rectangle (with no fill or stroke) and label that group with the `icon-name`
+
+**[extract-symbolic-icons.rb](./extract-symbolic-icons.rb) - the render script**
+This script allows you to render all the icons in a single run, or to select the list of icons to render, using the commands `all` and `only` as shown below.
+Icons that are already rendered (that is, whose .svg file is present under the Suru folder), won't be rendered again, unless the command `force` is used.
 
 ```
 Usage:
@@ -26,7 +30,8 @@ Examples:
     extract-symbolic-icons.rb force all           # render all images even if already rendered
 ```
 
+dependencies:
+- [inkscape](https://inkscape.org/)
+- [docopt](https://github.com/docopt/docopt.rb): command line option parser, that will make you smile
+- [svgo](https://github.com/svg/svgo): SVG Optimizer is a Nodejs-based tool for optimizing SVG vector graphics files.
 
-**[extract-symbolic-icons.rb](./extract-symbolic-icons.rb) - the render script**
- - extract any new symbolic icons from the source SVG by passing the icon name to this script: `./extract-symbolic-icons.rb <icon-name>`
- - or, if run generall, this script will look through the entire source file to render any new icons (if a new icon does not have a correct label the script will fail)

--- a/icons/src/scalable/README.md
+++ b/icons/src/scalable/README.md
@@ -9,6 +9,24 @@
  - each icon should be drawn within an 16x16 pixel square and use only 1 colour
  - when complete, group all elements within a 16x16 rectangle (with no fill or stroke) and label that group with the `icon-name`
 
+```
+Usage:
+    extract-symbolic-icons.rb [force] all
+    extract-symbolic-icons.rb [force] only <icon>...
+
+Options:
+    all     extract all icon in the SVG file
+    only    extract only the list of given icon names
+    force   force extraction of already existing icon [optional]
+
+Examples:
+    extract-symbolic-icons.rb only image1 image2  # render only image1 and image2 if not already rendered
+    extract-symbolic-icons.rb force only image3   # render only image3 even if already rendered
+    extract-symbolic-icons.rb all                 # render all images, if not already rendered
+    extract-symbolic-icons.rb force all           # render all images even if already rendered
+```
+
+
 **[extract-symbolic-icons.rb](./extract-symbolic-icons.rb) - the render script**
  - extract any new symbolic icons from the source SVG by passing the icon name to this script: `./extract-symbolic-icons.rb <icon-name>`
  - or, if run generall, this script will look through the entire source file to render any new icons (if a new icon does not have a correct label the script will fail)

--- a/icons/src/scalable/extract-symbolic-icons.rb
+++ b/icons/src/scalable/extract-symbolic-icons.rb
@@ -18,6 +18,7 @@
 # Thanks to the GNOME icon developers for the original version of this script
 
 
+require "open3"
 require "docopt"
 require "rexml/document"
 require "fileutils"
@@ -48,6 +49,22 @@ PREFIX = "../../Suru/scalable"
 
 # install with `sudo npm install -g svgo`
 SVGO = 'svgo'
+
+
+def check_deps(dependencies)
+    dependencies.each do |dependency|
+        begin
+            stdout, stderr, status = Open3.capture3("which", dependency)
+            if not status.success?
+                puts "could not find \"#{dependency}\". See README for needed dependencies"
+                exit 1
+            end
+        rescue
+            puts "rescue"
+            exit 1
+        end
+    end
+end
 
 def chopSVG(svg_file_name, icon)
 	FileUtils.mkdir_p(icon[:dir]) unless File.exists?(icon[:dir])
@@ -102,6 +119,8 @@ end
 
 
 begin
+    check_deps([INKSCAPE, SVGO])
+
     options = Docopt::docopt(doc)
 
     # Get all the icons from the SVG files

--- a/icons/src/scalable/extract-symbolic-icons.rb
+++ b/icons/src/scalable/extract-symbolic-icons.rb
@@ -77,6 +77,11 @@ def check_deps(dependencies)
     end
 end
 
+# extract the given icon from the collection in the
+# svg file
+# +svg_file_name+: SVG filename containing the given icon
+# +icon+: dictionary containing the following icon information: icon name,
+# image id, destination directory, destination filename
 def chopSVG(svg_file_name, icon)
 	FileUtils.mkdir_p(icon[:dir]) unless File.exists?(icon[:dir])
 	unless (File.exists?(icon[:file]) && !icon[:forcerender])

--- a/icons/src/scalable/extract-symbolic-icons.rb
+++ b/icons/src/scalable/extract-symbolic-icons.rb
@@ -39,12 +39,12 @@ Examples:
 DOCOPT
 
 # INKSCAPE = 'flatpak run org.inkscape.Inkscape'
-INKSCAPE = '/usr/bin/inkscape'
+INKSCAPE = 'inkscape'
 SRCS = ["./source-symbolic.svg"]
 PREFIX = "../../Suru/scalable"
 
 # install with `sudo npm install -g svgo`
-SVGO = '/usr/local/bin/svgo'
+SVGO = 'svgo'
 
 def chopSVG(svg_file_name, icon)
 	FileUtils.mkdir_p(icon[:dir]) unless File.exists?(icon[:dir])

--- a/icons/src/scalable/extract-symbolic-icons.rb
+++ b/icons/src/scalable/extract-symbolic-icons.rb
@@ -72,7 +72,8 @@ end
 # check whether the dependencies are met
 def check_deps(dependencies)
     dependencies.each do |dependency|
-        syscall("could not find #{dependency}", false, "which", dependency)
+        syscall("could not find #{dependency}. Please install the dependencies listed in the README", false,
+                "which", dependency)
     end
 end
 

--- a/icons/src/scalable/extract-symbolic-icons.rb
+++ b/icons/src/scalable/extract-symbolic-icons.rb
@@ -33,7 +33,7 @@ SVGO = '/usr/local/bin/svgo'
 def chopSVG(icon)
 	FileUtils.mkdir_p(icon[:dir]) unless File.exists?(icon[:dir])
 	unless (File.exists?(icon[:file]) && !icon[:forcerender])
-		FileUtils.cp(SRC,icon[:file]) 
+		FileUtils.cp(SRC,icon[:file])
 		puts " >> #{icon[:name]}"
 		cmd = "#{INKSCAPE} -f #{icon[:file]} --select #{icon[:id]} --verb=FitCanvasToSelection  --verb=EditInvertInAllLayers "
 		cmd += "--verb=EditDelete --verb=EditSelectAll --verb=SelectionUnGroup --verb=SelectionUnGroup --verb=SelectionUnGroup --verb=StrokeToPath --verb=FileVacuum "
@@ -47,8 +47,8 @@ def chopSVG(icon)
 		system(cmd)
 		# crop
 		svgcrop = Document.new(File.new(icon[:file], 'r'))
-		svgcrop.root.each_element("//rect") do |rect| 
-			w = ((rect.attributes["width"].to_f * 10).round / 10.0).to_i #get rid of 16 vs 15.99999 
+		svgcrop.root.each_element("//rect") do |rect|
+			w = ((rect.attributes["width"].to_f * 10).round / 10.0).to_i #get rid of 16 vs 15.99999
 			h = ((rect.attributes["width"].to_f * 10).round / 10.0).to_i #Inkscape bugs
 			if w == 16 && h == 16
 				rect.remove
@@ -78,8 +78,8 @@ svg = Document.new(File.new(SRC, 'r'))
 if (ARGV[0].nil?) #render all SVGs
 	puts "Rendering from icons in #{SRC}"
 	# Go through every layer.
-	svg.root.each_element("/svg/g[@inkscape:groupmode='layer']") do |context| 
-		context_name = context.attributes.get_attribute("inkscape:label").value  
+	svg.root.each_element("/svg/g[@inkscape:groupmode='layer']") do |context|
+		context_name = context.attributes.get_attribute("inkscape:label").value
 		puts "Going through layer '" + context_name + "'"
 		context.each_element("g") do |icon|
 			#puts "DEBUG #{icon.attributes.get_attribute('id')}"

--- a/icons/src/scalable/extract-symbolic-icons.rb
+++ b/icons/src/scalable/extract-symbolic-icons.rb
@@ -84,14 +84,15 @@ def chopSVG(svg_file_name, icon)
 
         puts "Rendering #{icon[:name]}..."
         syscall("could not extract icon #{icon[:name]}", true,
-                "#{INKSCAPE}", "--file=#{icon[:file]}",
+                "#{INKSCAPE}",
                 "--select=#{icon[:id]}", "--verb=FitCanvasToSelection", "--verb=EditInvertInAllLayers",
                 "--verb=EditDelete", "--verb=EditSelectAll", "--verb=SelectionUnGroup", "--verb=SelectionUnGroup",
-                "--verb=SelectionUnGroup", "--verb=StrokeToPath", "--verb=FileVacuum", "--verb=FileSave", "--verb=FileQuit")
+                "--verb=SelectionUnGroup", "--verb=StrokeToPath", "--verb=FileVacuum", "--verb=FileSave", "--verb=FileQuit",
+                "#{icon[:file]}")
 
 		# saving as plain SVG gets rid of the classes :/
         syscall("could not save #{icon[:file]} in plain SVG", true,
-                "#{INKSCAPE}", "--vacuum-defs", "--without-gui", "#{icon[:file]}", "--export-plain-svg=#{icon[:file]}")
+                "#{INKSCAPE}", "--vacuum-defs", "#{icon[:file]}", "--export-plain-svg=#{icon[:file]}")
 
 		# completely vaccuum with svgo
         syscall("could not clean #{icon[:file]} with svgo", true,

--- a/icons/src/scalable/extract-symbolic-icons.rb
+++ b/icons/src/scalable/extract-symbolic-icons.rb
@@ -62,11 +62,17 @@ def chopSVG(icon)
 	end
 end #end of function
 
-def get_output_filename(d,n)
-	if (/rtl$/.match(n))
-		outfile = "#{d}/#{n.chomp('-rtl')}-symbolic-rtl.svg"
+
+# Remove the "-rtl" substring from icon_name if exists
+# SVG file does not have "-rtl" substring even if the
+# icon name has it.
+# +directory+:: directory containing the SVG file
+# +icon_name+:: icon name
+def get_canonical_filename(directory, icon_name)
+	if (/rtl$/.match(icon_name))
+		outfile = "#{directory}/#{icon_name.chomp('-rtl')}-symbolic-rtl.svg"
 	else
-		outfile = "#{d}/#{n}-symbolic.svg"
+		outfile = "#{directory}/#{icon_name}-symbolic.svg"
 	end
 	return outfile
 end
@@ -91,7 +97,7 @@ if (ARGV[0].nil?) #render all SVGs
 				chopSVG({ :name => icon_name,
 						:id => icon.attributes.get_attribute("id"),
 						:dir => dir,
-						:file => get_output_filename(dir, icon_name)})
+						:file => get_canonical_filename(dir, icon_name)})
 			end
 		end
 	end
@@ -104,7 +110,7 @@ else #only render the icons passed
 		chopSVG({ :name => icon_name,
 				:id => icon.attributes["id"],
 				:dir => dir,
-				:file => get_output_filename(dir, icon_name),
+				:file => get_canonical_filename(dir, icon_name),
 				:forcerender => true})
 	end
 	puts "\nrendered #{ARGV.length} icons"

--- a/icons/src/scalable/extract-symbolic-icons.rb
+++ b/icons/src/scalable/extract-symbolic-icons.rb
@@ -34,7 +34,10 @@ Options:
     force   force extraction of already existing icon [optional]
 
 Examples:
-    #{__FILE__} only image1 image2
+    #{__FILE__} only image1 image2  # render only image1 and image2 if not already rendered
+    #{__FILE__} force only image3   # render only image3 even if already rendered
+    #{__FILE__} all                 # render all images, if not already rendered
+    #{__FILE__} force all           # render all images even if already rendered
 
 DOCOPT
 


### PR DESCRIPTION
Rework extract-symbolic-icons ruby script 

- streamline "main" function
- forbid running the app with no arguments to avoid using the script the wrong way
- improve CLI arguments parsing (it needs docopt, install it with gem install docopt)
- improve function naming when possible
- let the system chose which inkscape/svgo binaries to use
- improve documentation

This new version adds a help message, which examples

$ ./extract-symbolic-icons.rb --help
Usage:
    ./extract-symbolic-icons.rb [force] all
    ./extract-symbolic-icons.rb [force] only <icon>...

Options:
    all     extract all icon in the SVG file
    only    extract only the list of given icon names
    force   force extraction of already existing icon [optional]

Examples:
    ./extract-symbolic-icons.rb only image1 image2  # render only image1 and image2 if not already rendered
    ./extract-symbolic-icons.rb force only image3      # render only image3 even if already rendered
    ./extract-symbolic-icons.rb all                              # render all images, if not already rendered
    ./extract-symbolic-icons.rb force all                     # render all images even if already rendered