### PR TITLE
Add gnome-disks-state-standby-symbolic icon

### DIFF
--- a/icons/Suru/scalable/apps/gnome-disks-state-standby-symbolic.svg
+++ b/icons/Suru/scalable/apps/gnome-disks-state-standby-symbolic.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   sodipodi:docname="gnome-disks-state-standby-symbolic.svg"
+   version="1.1"
+   height="16"
+   width="16">
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:cy="8.7115255"
+     pagecolor="#ffffff"
+     borderopacity="1"
+     showborder="true"
+     inkscape:bbox-paths="true"
+     guidetolerance="10"
+     inkscape:object-paths="true"
+     inkscape:window-width="1920"
+     showguides="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-bbox="true"
+     inkscape:pageshadow="2"
+     inkscape:guide-bbox="true"
+     inkscape:snap-nodes="true"
+     bordercolor="#666666"
+     objecttolerance="10"
+     id="namedview88"
+     showgrid="true"
+     inkscape:window-maximized="1"
+     inkscape:window-x="1920"
+     inkscape:snap-global="true"
+     inkscape:window-y="32"
+     gridtolerance="10"
+     inkscape:window-height="1011"
+     inkscape:snap-to-guides="true"
+     inkscape:current-layer="layer9"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="28.151689"
+     inkscape:cx="3.5541934"
+     inkscape:snap-grids="true"
+     inkscape:pageopacity="1"
+     inkscape:showpageshadow="true"
+     borderlayer="false"
+     inkscape:snap-page="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-object-midpoints="false"
+     inkscape:snap-center="true"
+     inkscape:snap-others="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-midpoints="true">
+    <inkscape:grid
+       spacingx="1"
+       spacingy="1"
+       id="grid4866"
+       empspacing="2"
+       enabled="true"
+       type="xygrid"
+       snapvisiblegridlinesonly="true"
+       visible="true"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:label="status"
+     transform="translate(-181.0002,-237)"
+     inkscape:groupmode="layer"
+     id="layer9"
+     style="display:inline">
+    <path
+       id="path853"
+       d="m 187.0002,242 v 1 h 3.64648 l -3.64648,4 v 1 h 5 v -1 h -3.64844 l 3.64844,-4 v -1 z"
+       style="opacity:0.8;fill:#6d6d6f;fill-opacity:0.94117647;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.6;fill:#6d6d6f;fill-opacity:0.94117647;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 183.0002,239 v 1 h 3.64648 l -3.64648,4 v 1 h 5 v -1 h -3.64844 l 3.64844,-4 v -1 z"
+       id="path855" />
+    <g
+       inkscape:label="lock"
+       transform="translate(161.0002,-39)"
+       id="g4053"
+       style="fill:#bebebe;fill-opacity:1" />
+    <path
+       style="opacity:1;fill:#6d6d6f;fill-opacity:0.94117647;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 191.0002,245 v 1 h 3.64648 l -3.64648,4 v 1 h 5 v -1 h -3.64844 l 3.64844,-4 v -1 z"
+       id="rect837"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="devices"
+     transform="translate(-181.0002,-237)"
+     inkscape:groupmode="layer"
+     id="layer10" />
+  <g
+     inkscape:label="apps"
+     transform="translate(-181.0002,-237)"
+     inkscape:groupmode="layer"
+     id="layer11" />
+  <g
+     inkscape:label="actions"
+     transform="translate(-181.0002,-237)"
+     inkscape:groupmode="layer"
+     id="layer12" />
+  <g
+     inkscape:label="places"
+     transform="translate(-181.0002,-237)"
+     inkscape:groupmode="layer"
+     id="layer13" />
+  <g
+     inkscape:label="mimetypes"
+     transform="translate(-181.0002,-237)"
+     inkscape:groupmode="layer"
+     id="layer14" />
+  <g
+     inkscape:label="emblems"
+     transform="translate(-181.0002,-237)"
+     inkscape:groupmode="layer"
+     id="layer15"
+     style="display:inline" />
+  <g
+     inkscape:label="categories"
+     transform="translate(-181.0002,-237)"
+     inkscape:groupmode="layer"
+     id="g4953"
+     style="display:inline" />
+</svg>


### PR DESCRIPTION
I reused the same metaphor as upstream (zzz), adding a light gradient of opacity:

![2020-08-16_14-44](https://user-images.githubusercontent.com/36476595/90334581-f54de000-dfce-11ea-8e43-2330d5103122.png)

Closes #2324 