### PR TITLE
Making new window icon slightly more rounded

### DIFF
--- a/icons/Suru/scalable/actions/window-new-symbolic.svg
+++ b/icons/Suru/scalable/actions/window-new-symbolic.svg
@@ -12,7 +12,7 @@
    version="1.1"
    id="svg8"
    sodipodi:docname="window-new-symbolic.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -21,7 +21,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -51,20 +51,21 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1196"
-     inkscape:window-height="848"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
      id="namedview10"
      showgrid="true"
-     inkscape:snap-global="false"
+     inkscape:snap-global="true"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:zoom="22.627417"
-     inkscape:cx="7.6348943"
+     inkscape:zoom="11.313709"
+     inkscape:cx="-16.561415"
      inkscape:cy="7.4757688"
-     inkscape:window-x="66"
+     inkscape:window-x="72"
      inkscape:window-y="27"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g6">
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g6"
+     showborder="false">
     <inkscape:grid
        type="xygrid"
        id="grid3353" />
@@ -78,17 +79,10 @@
        style="display:inline"
        id="g3340">
       <path
-         sodipodi:nodetypes="cssccccsssssscc"
-         inkscape:connector-curvature="0"
-         id="rect821"
-         d="m 82.40392,195.00371 h -8.826112 c -0.372934,0 -0.579801,-0.19626 -0.580179,-0.5625 l -0.01078,-10.44313 c 3.594886,0.0147 11.002903,0.009 14.012739,-4e-5 l 0.0039,6.41922 0.999096,0.004 v -7.89828 c 0,-0.85525 -0.716206,-1.55664 -1.587087,-1.55664 h -12.82597 c -0.870883,0 -1.587088,0.70139 -1.587088,1.55664 v 11.91797 c 0,0.85525 0.716205,1.5586 1.587088,1.5586 h 8.809875 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.91942537;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-      <path
-         sodipodi:nodetypes="ccccccccccccc"
-         id="path5525-3"
-         d="m 85,191 v 2 h -2 v 1 h 2 v 2 h 1 v -2 h 2 v -1 h -2 v -2 z"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00079155;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         inkscape:connector-curvature="0" />
+         d="M 3.9492188 1 C 2.7050527 1.01457 1.7951412 0.96944565 1.0507812 1.3847656 C 0.6786063 1.5924156 0.38549025 1.9441555 0.22265625 2.3828125 C 0.05977925 2.8214735 0 3.34239 0 4 L 0 8 L 0 13 C -3.7007434e-17 13.65761 0.05982125 14.178515 0.22265625 14.617188 C 0.38548025 15.055844 0.6786063 15.407574 1.0507812 15.615234 C 1.7951412 16.0306 2.7050428 15.9855 3.9492188 16 L 3.953125 16 L 5.9335938 16 L 10.011719 16 L 10.5 16 L 10.5 14.996094 C 10.320637 14.996045 10.200575 15 10.011719 15 L 5.9335938 15 C 3.9558868 15 2.4878243 15.015624 1.7539062 14.775391 C 0.7813883 14.328181 0.98828125 13 0.98828125 12 C 0.98912225 9.876828 1.0254714 6.323039 1.1132812 4 L 5.9335938 4 L 10.011719 4 L 14.832031 4 C 14.903066 5.8792334 14.933535 8.418833 14.945312 10.5 L 15.945312 10.5 L 15.945312 8 L 15.945312 4 C 15.945312 3.362006 15.885263 2.8214735 15.722656 2.3828125 C 15.559822 1.9441555 15.266706 1.5924156 14.894531 1.3847656 C 14.150171 0.96944965 13.24026 1.01457 11.996094 1 L 11.992188 1 L 10.011719 1 L 5.9335938 1 L 3.953125 1 L 3.9492188 1 z M 13.003906 11.001953 L 13.003906 13.001953 L 11.003906 13.001953 L 11.003906 14.001953 L 13.003906 14.001953 L 13.003906 16.001953 L 14.003906 16.001953 L 14.003906 14.001953 L 16.003906 14.001953 L 16.003906 13.001953 L 14.003906 13.001953 L 14.003906 11.001953 L 13.003906 11.001953 z "
+         transform="translate(71.996853,179.99766)"
+         id="path5525-3" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
Brace yerself guys, this is quite a radical change.  I've turned this:

![image](https://user-images.githubusercontent.com/38893390/90559562-a4d4af00-e195-11ea-942c-f515b618f10e.png)

...into this:

![image](https://user-images.githubusercontent.com/38893390/90559579-aaca9000-e195-11ea-8a27-ccdad49b4d24.png)

I know it's a tiny difference :) but this is quite a high profile symbol because it's used in Nautilus, etc..  What do you think?