### PR TITLE
Use OSD fg color on switcher OSDs

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_switcher-popup.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_switcher-popup.scss
@@ -48,9 +48,9 @@
 
 .switcher-arrow {
   border-color: rgba(0,0,0,0);
-  color: transparentize($fg_color,0.2);
+  color: transparentize($osd_fg_color,0.2);
   &:highlighted {
-    color: $fg_color;
+    color: $osd_fg_color;
   }
 }
 


### PR DESCRIPTION
Use OSD fg color on switcher OSDs

Using $fg_color is wrong and does not work on the light theme in this case. Should be reported upstream someday...

Closes #2320 

![Screencast_30 08 2020_18 17 07](https://user-images.githubusercontent.com/15329494/91664247-404b1580-eaee-11ea-8623-6755fe3a0df9.gif)
