### PR TITLE
Add missing Gnome-screenshot icons

### DIFF
--- a/icons/Suru/scalable/actions/selection-symbolic.svg
+++ b/icons/Suru/scalable/actions/selection-symbolic.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   id="svg7384"
+   version="1.1"
+   width="16"
+   sodipodi:docname="selection-symbolic.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     id="namedview27"
+     showgrid="true"
+     inkscape:zoom="35.708892"
+     inkscape:cx="12.240616"
+     inkscape:cy="6.5775748"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384">
+    <inkscape:grid
+       type="xygrid"
+       id="grid859" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata20854">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title></dc:title>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4526"
+       osb:paint="solid">
+      <stop
+         id="stop4528"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4"
+       osb:paint="gradient">
+      <stop
+         id="stop3602-7"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1" />
+      <stop
+         id="stop3604-6"
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <path
+     id="rect7774"
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 7 0 C 5.892 0 5 0.669 5 1.5 L 5 3 L 4 3 L 4 4 L 5 4 L 5 9.5 C 5 10.331 5.892 11 7 11 L 12 11 L 12 12 L 13 12 L 13 11 L 14 11 C 15.108 11 16 10.331 16 9.5 L 16 1.5 C 16 0.669 15.108 1.856848e-17 14 0 L 7 0 z M 6 3 L 7 3 L 7 4 L 6 4 L 6 3 z M 8 3 L 9 3 L 9 4 L 8 4 L 8 3 z M 3 3.0253906 C 2.263869 3.0439906 1.6123619 3.0950869 1.0917969 3.3730469 L 1.8691406 4.1503906 C 2.1378236 4.0856906 2.536506 4.05319 3 4.03125 L 3 3.0253906 z M 10 3.0253906 C 10.736131 3.0439906 11.387638 3.0950869 11.908203 3.3730469 L 11.130859 4.1503906 C 10.862176 4.0856906 10.463494 4.05319 10 4.03125 L 10 3.0253906 z M 0.37304688 4.0683594 C 0.31559686 4.1669594 0.26611036 4.2722625 0.22460938 4.3828125 C 0.05994537 4.8214725 -1.8503717e-17 5.34239 0 6 L 1 6 C 1 5.46469 1.0548797 5.0938213 1.1367188 4.8320312 L 0.37304688 4.0683594 z M 12.626953 4.0683594 C 12.684403 4.1669594 12.73389 4.2722625 12.775391 4.3828125 C 12.940055 4.8214725 13 5.34239 13 6 L 12 6 C 12 5.46469 11.94512 5.0938213 11.863281 4.8320312 L 12.626953 4.0683594 z M 0 7 L 0 8 L 1 8 L 1 7 L 0 7 z M 12 7 L 13 7 L 13 8 L 12 8 L 12 7 z M 0 9 L 0 10 L 1 10 L 1 9 L 0 9 z M 12 9 L 13 9 L 13 10 L 12 10 L 12 9 z M 0 11 L 0 12 L 1 12 L 1 11 L 0 11 z M 0 13 C -3.7007434e-17 13.65761 0.05994537 14.178528 0.22460938 14.617188 C 0.26611036 14.727736 0.31559686 14.833041 0.37304688 14.931641 L 1.1367188 14.167969 C 1.0548798 13.906179 1 13.53531 1 13 L 0 13 z M 12 13 C 12 13.53531 11.94512 13.906179 11.863281 14.167969 L 12.626953 14.931641 C 12.684403 14.833041 12.73389 14.727736 12.775391 14.617188 C 12.940055 14.178527 13 13.65761 13 13 L 12 13 z M 1.8691406 14.849609 L 1.0917969 15.626953 C 1.6123619 15.904913 2.263869 15.956009 3 15.974609 L 3 14.96875 C 2.536506 14.94681 2.1378236 14.914309 1.8691406 14.849609 z M 11.130859 14.849609 C 10.862176 14.914309 10.463494 14.94681 10 14.96875 L 10 15.974609 C 10.736131 15.956009 11.387638 15.904913 11.908203 15.626953 L 11.130859 14.849609 z M 4 15 L 4 16 L 5 16 L 5 15 L 4 15 z M 6 15 L 6 16 L 7 16 L 7 15 L 6 15 z M 8 15 L 8 16 L 9 16 L 9 15 L 8 15 z " />
+  <g
+     id="layer9"
+     label="status"
+     style="display:inline"
+     transform="translate(-293.0002,227)" />
+  <g
+     id="layer2"
+     style="display:inline"
+     transform="translate(-52,-140)" />
+  <g
+     id="layer4"
+     style="display:inline"
+     transform="translate(-52,-140)" />
+  <g
+     id="g1812"
+     style="display:inline"
+     transform="translate(-52,-140)" />
+  <g
+     id="g6217"
+     style="display:inline"
+     transform="translate(-52,-140)" />
+  <g
+     id="layer3"
+     style="display:inline"
+     transform="translate(-52,-140)" />
+  <g
+     id="g1833"
+     style="display:inline"
+     transform="translate(-52,-140)" />
+</svg>

--- a/icons/Suru/scalable/actions/window-symbolic.svg
+++ b/icons/Suru/scalable/actions/window-symbolic.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="window-symbolic.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path823"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     id="namedview10"
+     showgrid="true"
+     inkscape:snap-global="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="32.000001"
+     inkscape:cx="12.840483"
+     inkscape:cy="7.0693208"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8"
+     showborder="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3353" />
+  </sodipodi:namedview>
+  <g
+     color="#000"
+     fill="gray"
+     id="g6">
+    <path
+       id="path5525-3"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00079;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 3.9492188 1 C 2.7050526 1.01457 1.7951413 0.9694457 1.0507812 1.3847656 C 0.6786064 1.5924156 0.38549025 1.9441555 0.22265625 2.3828125 C 0.05977925 2.8214735 0 3.34239 0 4 L 0 8 L 0 13 C 0 13.65761 0.05982125 14.178513 0.22265625 14.617188 C 0.38548025 15.055843 0.6786064 15.407574 1.0507812 15.615234 C 1.7951412 16.0306 2.7050428 15.9855 3.9492188 16 L 3.953125 16 L 5.9335938 16 L 7 16 L 9 16 L 10.066406 16 L 12.046875 16 L 12.050781 16 C 13.294957 15.9855 14.204859 16.0306 14.949219 15.615234 C 15.321394 15.407574 15.61452 15.055843 15.777344 14.617188 C 15.94018 14.178513 16 13.65761 16 13 L 16 8 L 16 4 C 16 3.34239 15.940221 2.8214735 15.777344 2.3828125 C 15.61451 1.9441555 15.321394 1.5924156 14.949219 1.3847656 C 14.204859 0.96944572 13.294947 1.01457 12.050781 1 L 12.046875 1 L 10.066406 1 L 9 1 L 7 1 L 5.9335938 1 L 3.953125 1 L 3.9492188 1 z M 1.1132812 4 L 5.9335938 4 L 7 4 L 9 4 L 10.066406 4 L 14.886719 4 C 14.974529 6.323039 15.010878 9.876828 15.011719 12 C 15.011719 13 15.218612 14.328181 14.246094 14.775391 C 13.512176 15.01562 12.044113 15 10.066406 15 L 9 15 L 7 15 L 5.9335938 15 C 3.9558868 15 2.4878243 15.015624 1.7539062 14.775391 C 0.7813884 14.328181 0.98828125 13 0.98828125 12 C 0.98912225 9.876828 1.0254714 6.323039 1.1132812 4 z " />
+  </g>
+</svg>

--- a/icons/Suru/scalable/devices/display-symbolic.svg
+++ b/icons/Suru/scalable/devices/display-symbolic.svg
@@ -1,0 +1,1 @@
+video-display-symbolic.svg

--- a/icons/src/symlinks/symbolic/devices.list
+++ b/icons/src/symlinks/symbolic/devices.list
@@ -15,3 +15,4 @@ smartphone-symbolic.svg phone-htc-g1-white-symbolic.svg
 smartphone-symbolic.svg phone-palm-pre-symbolic.svg
 smartphone-symbolic.svg phone-samsung-galaxy-s-symbolic.svg
 tablet-symbolic.svg computer-apple-ipad-symbolic.svg
+video-display-symbolic.svg display-symbolic.svg


### PR DESCRIPTION
![Capture d’écran du 2020-09-18 17-03-11](https://user-images.githubusercontent.com/36476595/93616115-95cf5f80-f9d4-11ea-98ef-a42a0c079cff.png)

Closes #2352