### PR TITLE
Gtk upstream sync for groovy & several fixes

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -95,38 +95,30 @@ $ambiance: null !default;
       margin: 5px;
     }
 
-    .nautilus-path-bar button { /* undecorate the buttons */
+    .path-bar-box {
+      border-radius: 5px;
+      $_bg: if($variant=='light', lighten($headerbar_bg_color, 3%), lighten($headerbar_bg_color, 1%));
+      border: 1px solid if($ambiance, darken($headerbar_bg_color, 9%), $borders_color);
+      &:backdrop { border-color: if($ambiance, $headerbar_bg_color, $backdrop_borders_color);}
+      background-color: $_bg;
+      padding-right: 6px;
+    }
+
+    .nautilus-path-bar button {
       margin: 0px;
     }
 
-    .path-bar-box {
-      transition: border 200ms;
-      transition: background-color 200ms;
-      border-radius: $button_radius;
+    .nautilus-path-bar button:first-child {
+      border-width: 0px 1px 0px 0px;
+      border-radius: 3.5px 0px 0px 3.5px;
     }
 
-    .path-bar-box.width-maximized {
-      @if $ambiance {
-        $_bg: if($variant=='light', lighten($headerbar_bg_color, 3%),
-                                    lighten($headerbar_bg_color, 1%));
-        border: 1px solid if($ambiance, darken($headerbar_bg_color, 9%), $borders_color);
-        &:backdrop { border-color: if($ambiance, $headerbar_bg_color, $backdrop_borders_color);}
-        background-color: $_bg;
-      } @else {
-        border: 1px solid $borders_color;
-        background-color: $bg_color;
-      }
+    .nautilus-path-bar button:not(:first-child) {
+      border-width: 0px 1px 0px 1px;
+      border-radius: 0px 0px 0px 0px;
     }
 
-    .path-bar-box.width-maximized button:first-child {
-        border-radius: ($button_radius - 1.5) 0px 0px ($button_radius - 1.5);
-        border-width: 0px 1px 0px 0px;
-    }
-
-    .path-bar-box.width-maximized button:not(:first-child) {
-        border-width: 0px 1px 0px 1px;
-        border-radius: 0px 0px 0px 0px;
-    }
+    .nautilus-path-bar button:not(:checked) image { opacity: 0.8; } /* dim the icon when not checked */
 
     // This is the Icon + Text beneath - it's one widget
     .nautilus-canvas-item {

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -97,10 +97,9 @@ $ambiance: null !default;
 
     .path-bar-box {
       border-radius: 5px;
-      $_bg: if($variant=='light', lighten($headerbar_bg_color, 3%), lighten($headerbar_bg_color, 1%));
       border: 1px solid if($ambiance, darken($headerbar_bg_color, 9%), $borders_color);
       &:backdrop { border-color: if($ambiance, $headerbar_bg_color, $backdrop_borders_color);}
-      background-color: $_bg;
+      background-color: if($ambiance, lighten($headerbar_bg_color, 3%), $bg_color);
       padding-right: 6px;
     }
 

--- a/gtk/src/default/gtk-3.20/_colors-public.scss
+++ b/gtk/src/default/gtk-3.20/_colors-public.scss
@@ -112,5 +112,8 @@ read if you used those and something break with a version upgrade you're on your
 
 //FIXME this is really an API
 
+/* content view background such as thumbnails view in Photos or Boxes */
 @define-color content_view_bg #{"" + $base_color};
 
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #{"" + if($variant == 'light', $base_color, darken($base_color,6%))};

--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -6,20 +6,20 @@ $ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);
 $asset_suffix: if($variant=='dark', '-dark', '');
 $backdrop_transition: 200ms ease-out;
 $button_transition: all 200ms $ease-out-quad;
-$button_radius: 4px;
-$menu_radius: 4px;
+$button_radius: 4px; // Yaru change: we want everything to be less round
+$menu_radius: 4px; // Yaru change: we want everything to be less round
 $window_radius: $button_radius + 3;
-$popover_radius: $button_radius + 2;
+$popover_radius: $button_radius + 2; // Yaru change: we want everything to be less round
 
 // Optional compact sizes for buttons, headerbar and headerbar widgets
-$_sizevariant: 'compact'; //compact otherwise
+$_sizevariant: 'default'; //compact otherwise
 $_headerbar_height: if($_sizevariant=='default', 46px, 40px);
 $_entry_height: if($_sizevariant=='default', 32px, 28px);
 $_btn_pad: if($_sizevariant=='default', 4px 9px, 2px 6px);
 $_hb_btn_pad: if($_sizevariant=='default', 6px, 5px);
 $_img_btn_pad: if($_sizevariant=='default', 5px, 2px);
 $_sel_menu_pad: if($_sizevariant=='default', 6px 10px, 4px 10px);
-$_circ_btn_pad: if($_sizevariant=='default', 4px, 2px 6px);
+$_circ_btn_pad: if($_sizevariant=='default', 4px, 2px);
 $_switch_margin: if($_sizevariant=='default', 10px, 7px);
 
 * {
@@ -205,6 +205,12 @@ label {
   &:backdrop {
     selection { @extend %selected_items_backdrop; }
   }
+
+  &.error {
+    color: $error_color;
+    &:disabled { color: transparentize($error_color,0.5); }
+    &:disabled:backdrop { color: transparentize($error_color,0.6); }
+  }
 }
 
 .dim-label {
@@ -274,7 +280,6 @@ spinner {
 .large-title {
    font-weight: 300;
    font-size: 24pt;
-   letter-spacing: 0.2rem;
 }
 .title-1 {
    font-weight: 800;
@@ -474,6 +479,8 @@ entry {
       + combobox > box > button.combo { border-top-color: $drop_target_color; }
     }
   }
+
+  &.error { color: $error_color; }
 }
 
 treeview entry {
@@ -1599,7 +1606,7 @@ headerbar {
   button.toggle:checked {
 
     background: if($variant == 'light', image(darken($bg_color, 17%)), image(darken($bg_color, 9%)));
-    border-color: darken($borders_color, 6%);
+    border-color: darken($borders_color, 6%); // Yaru change: with our paper buttons we dont need this
     // border-top-color: darken($borders_color, 8%);
     &:backdrop {
       @include button(backdrop-active);
@@ -2376,11 +2383,11 @@ notebook {
       > tabs {
         margin-bottom: -2px;
         > tab {
-          &:hover { box-shadow: inset 0 -3px $borders_color; }
+          &:hover { box-shadow: inset 0 -3px $borders_color; } // Yaru change: 4px underlines are too much
 
           &:backdrop { box-shadow: none; }
 
-          &:checked { box-shadow: inset 0 -3px $selected_bg_color; }
+          &:checked { box-shadow: inset 0 -3px $selected_bg_color; } // Yaru change: 4px underlines are too much
         }
       }
     }
@@ -2390,11 +2397,11 @@ notebook {
       > tabs {
         margin-top: -2px;
         > tab {
-          &:hover { box-shadow: inset 0 3px $borders_color; }
+          &:hover { box-shadow: inset 0 3px $borders_color; } // Yaru change: 4px underlines are too much
 
           &:backdrop { box-shadow: none; }
 
-          &:checked { box-shadow: inset 0 3px $selected_bg_color; }
+          &:checked { box-shadow: inset 0 3px $selected_bg_color; } // Yaru change: 4px underlines are too much
         }
       }
     }
@@ -2404,11 +2411,11 @@ notebook {
       > tabs {
         margin-right: -2px;
         > tab {
-          &:hover { box-shadow: inset -3px 0 $borders_color; }
+          &:hover { box-shadow: inset -3px 0 $borders_color; } // Yaru change: 4px underlines are too much
 
           &:backdrop { box-shadow: none; }
 
-          &:checked { box-shadow: inset -3px 0 $selected_bg_color; }
+          &:checked { box-shadow: inset -3px 0 $selected_bg_color; } // Yaru change: 4px underlines are too much
         }
       }
     }
@@ -2418,11 +2425,11 @@ notebook {
       > tabs {
         margin-left: -2px;
         > tab {
-          &:hover { box-shadow: inset 3px 0 $borders_color; }
+          &:hover { box-shadow: inset 3px 0 $borders_color; } // Yaru change: 4px underlines are too much
 
           &:backdrop { box-shadow: none; }
 
-          &:checked { box-shadow: inset 3px 0 $selected_bg_color; }
+          &:checked { box-shadow: inset 3px 0 $selected_bg_color; } // Yaru change: 4px underlines are too much
         }
       }
     }
@@ -2500,14 +2507,15 @@ notebook {
 
       outline-offset: -5px;
 
-      color: $insensitive_fg_color;
-      font-weight: bold;
+      color: $fg_color;
+      font-weight: normal;
 
       border-width: 1px;         // for reorderable tabs
       border-color: transparent; //
 
       &:hover {
-        color: mix($insensitive_fg_color, $fg_color, 50%);
+        color: $fg_color;
+        background-color: darken($bg_color,4%);
 
         &.reorderable-page {
           border-color: transparentize($borders_color, 0.7);
@@ -2820,7 +2828,7 @@ switch {
     color: $selected_fg_color;
     border-color: $checkradio_borders_color;
     background-color: $checkradio_bg_color;
-    text-shadow: 0 1px transparentize($checkradio_borders_color, 0.5),
+    text-shadow: 0 1px transparentize($selected_borders_color, 0.5),
                  0 0 2px transparentize(white, 0.4);
   }
 
@@ -2841,7 +2849,7 @@ switch {
     &:checked {
       @if $variant == 'light' { color: $backdrop_bg_color; }
       border-color: if($variant == 'light', $checkradio_borders_color,
-                                            $checkradio_borders_color);
+                                            $selected_borders_color);
       background-color: $checkradio_bg_color;
     }
 
@@ -2929,7 +2937,7 @@ switch {
   (':backdrop:checked', '-gtk-icontheme(\'object-select-symbolic\')', '#{transparentize($osd_fg_color, 0.2)}', '#{desaturate($checkradio_bg_color, 100%)}'), {
 
   .view.content-view.check#{$check_state}:not(list),
-  .content-view .tile check#{$check_state}:not(list) {
+  .content-view:not(list) check#{$check_state} {
     margin: 4px;
     min-width: 32px;
     min-height: 32px;
@@ -4573,8 +4581,6 @@ decoration {
   .tiled-left & { border-radius: 0; }
 
   .popup & { box-shadow: none; }
-
-  .csd & { background-color: black; } // transparent makes gtk3 leak light on the corners #2537
 
   // server-side decorations as used by mutter
   .ssd & { box-shadow: 0 0 0 1px $_wm_border; } //just doing borders, wm draws actual shadows

--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -1606,7 +1606,7 @@ headerbar {
   button.toggle:checked {
 
     background: if($variant == 'light', image(darken($bg_color, 17%)), image(darken($bg_color, 9%)));
-    border-color: darken($borders_color, 6%); // Yaru change: with our paper buttons we dont need this
+    border-color: darken($borders_color, 6%); // Yaru change: with our button styling we do not want a stronger bottom border
     // border-top-color: darken($borders_color, 8%);
     &:backdrop {
       @include button(backdrop-active);

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -21,15 +21,15 @@
   box-shadow: $shadows;
 }
 
-// entries
+// entries  // Yaru change: we detached focus from selection
 @function entry_focus_border($fc:$focus_border_color) {
   @if $variant == 'light' { @return $fc; }
   @else { @return $focus_border_color }
 }
 
-@function entry_focus_shadow($fc:$focus_border_color) { @return inset 0 0 0 1px $fc; }
+@function entry_focus_shadow($fc:$focus_border_color) { @return inset 0 0 0 1px $fc; }  // Yaru change: we detached focus from selection
 
-@mixin entry($t, $fc:$focus_border_color, $edge: none) {
+@mixin entry($t, $fc:$focus_border_color, $edge: none) {  // Yaru change: we detached focus from selection
 //
 // Entries drawing function
 //
@@ -193,13 +193,14 @@
   // normal button
   //
     color: $tc;
-    outline-color: $focus_border_color;
+    outline-color: $focus_border_color; // Yaru change: we detached focus from selection
     border-color: if($c != $bg_color, _border_color($c), $borders_color);
     // border-bottom-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
+    // Yaru change: we don't want to use gradients on buttons
     $button_fill: if($c == $bg_color, if($variant == 'light', image(lighten($c, 2%)), image(lighten($c, 4%))), image(lighten($c, 2%))) !global;
     background-image: $button_fill;
     @include _button_text_shadow($tc, $c);
-    @include _shadows(0 1px transparentize(black, 0.9));
+    @include _shadows(0 1px transparentize(black, 0.9)); // Yaru change: paper effect shadow
   }
 
   @else if $t==hover {
@@ -207,7 +208,7 @@
   // hovered button
   //
     color: $tc;
-    outline-color: $focus_border_color;
+    outline-color: $focus_border_color; // Yaru change: we detached focus from selection
     border-color: if($c != $bg_color, _border_color($c), $borders_color);
     border-bottom-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
     @if $variant == 'light' {
@@ -220,7 +221,7 @@
       @include _button_text_shadow($tc,lighten($c, 6%));
       @include _shadows(inset 0 1px _button_hilight_color(darken($c, 2%)), $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85));
+    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85)); // Yaru change: paper effect
     background-image: if($c == $bg_color, if($variant == 'light', image(lighten($c, 4%)), image(lighten($c, 6%))), image(lighten($c, 4%)));
   }
 
@@ -229,7 +230,7 @@
   // normal button alternative look
   //
     color: $tc;
-    outline-color: $focus_border_color;
+    outline-color: $focus_border_color; // Yaru change: we detached focus from selection
     border-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
     @include _button_text_shadow($tc, $c);
     @if $variant == 'light' {
@@ -242,8 +243,8 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85));
-    background-image: image(lighten($c, 10%));
+    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85)); // Yaru change: paper effect
+    background-image: image(lighten($c, 10%)); // Yaru change: brighter alt
   }
 
   @else if $t==hover-alt {
@@ -251,7 +252,7 @@
   // hovered button alternative look
   //
     color: $tc;
-    outline-color: $focus_border_color;
+    outline-color: $focus_border_color; // Yaru change: we detached focus from selection
     border-color: if($c != $bg_color, _border_color($c, true), $alt_borders_color);
     @if $variant == 'light' {
       $button_fill: linear-gradient(to bottom, lighten($c, 9%) 10%, lighten($c, 4%) 90%) !global;
@@ -263,8 +264,8 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    background-image: image(lighten($c, 6%));
-    box-shadow: 0 1px transparentize(black, 0.8);
+    background-image: image(lighten($c, 6%)); // Yaru change: brighter alt hover
+    box-shadow: 0 1px transparentize(black, 0.8); // Yaru change: paper effect
   }
 
   @else if $t==active {
@@ -272,7 +273,7 @@
   // pushed button
   //
     color: $tc;
-    outline-color: $focus_border_color;
+    outline-color: $focus_border_color; // Yaru change: we detached focus from selection
     border-color: if($c != $bg_color, _border_color($c), $borders_color);
     $button_fill: if($variant == 'light', image(darken($c, 14%)), image(darken($c, 9%))) !global;
     background-image: $button_fill;
@@ -288,8 +289,7 @@
   //
     $_bg: if($c != $bg_color, mix($c, $base_color, 85%), $insensitive_bg_color);
 
-    label, & { color: if($tc != $fg_color, mix($tc, $_bg, 50%), $insensitive_fg_color); }
-
+    color: if($tc != $fg_color, mix($tc, $_bg, 50%), $insensitive_fg_color);
     border-color: if($c != $bg_color, _border_color($c), $insensitive_borders_color);
     $button_fill: image($_bg) !global;
     background-image: $button_fill;
@@ -307,8 +307,7 @@
     $_bg: if($variant == 'light', darken(mix($c, $base_color, 85%), 8%), darken(mix($c, $base_color, 85%), 6%));
     $_bc: if($c != $bg_color, _border_color($c), $insensitive_borders_color);
 
-    label, & { color: if($c != $bg_color, mix($tc, $_bg, 60%), $insensitive_fg_color); }
-
+    color: if($c != $bg_color, mix($tc, $_bg, 60%), $insensitive_fg_color);
     border-color: $_bc;
     $button_fill: image($_bg) !global;
     background-image: $button_fill;
@@ -324,8 +323,7 @@
     $_bg: if($c != $bg_color, $c, $backdrop_bg_color);
     $_bc: if($variant == 'light', $c, _border_color($c));
 
-    label, & { color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color); }
-
+    color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color);
     border-color: if($c != $bg_color, $_bc, $backdrop_borders_color);
     $button_fill: image($_bg) !global;
     background-image: $button_fill;
@@ -341,8 +339,7 @@
     $_bg: if($variant == 'light', darken(mix($c, $base_color, 85%), 8%), darken(mix($c, $base_color, 85%), 4%));
     $_bc: if($variant == 'light', $_bg ,_border_color($c));
 
-    label, & { color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color); }
-
+    color: if($tc != $fg_color, mix($tc, $_bg, 80%), $backdrop_fg_color);
     border-color: if($c != $bg_color, $_bc, $backdrop_borders_color);
     $button_fill: image($_bg) !global;
     background-image: $button_fill;
@@ -357,8 +354,7 @@
     $_bg: if($c != $bg_color, mix($c, $base_color, 85%), $insensitive_bg_color);
     $_bc: if($variant == 'light', $_bg,_border_color($c));
 
-    label, & { color: if($c != $bg_color, mix($tc, $_bg, 35%), $backdrop_insensitive_color); }
-
+    color: if($c != $bg_color, mix($tc, $_bg, 35%), $backdrop_insensitive_color);
     border-color: if($c != $bg_color, $_bc, $backdrop_borders_color);
     $button_fill: image($_bg) !global;
     background-image: $button_fill;
@@ -377,8 +373,7 @@
     $_bg: if($variant == 'light', darken(mix($c, $base_color, 85%), 8%), darken(mix($c, $base_color, 85%), 4%));
     $_bc: if($variant == 'light', $_bg, _border_color($c));
 
-    label { color: if($c != $bg_color, mix($tc, $_bg, 35%), $backdrop_insensitive_color); }
-
+    color: if($c != $bg_color, mix($tc, $_bg, 35%), $backdrop_insensitive_color);
     border-color: if($c != $bg_color, $_bc, $backdrop_borders_color);
     $button_fill: image($_bg) !global;
     background-image: $button_fill;
@@ -389,7 +384,7 @@
   //
   // normal osd button
   //
-    $_bg: if($c != $bg_color, transparentize($c, 0.5), lighten($osd_bg_color, 9%));
+    $_bg: if($c != $bg_color, transparentize($c, 0.5), lighten($osd_bg_color, 9%)); // Yaru change: make osd buttons visible
 
     color: $osd_fg_color;
     border-color: $osd_borders_color;
@@ -397,7 +392,7 @@
     $button_fill: image($_bg) !global;
     background-image: $button_fill;
     background-clip: padding-box;
-    // box-shadow: inset 0 1px transparentize(white, 0.9);
+    // box-shadow: inset 0 1px transparentize(white, 0.9); // Yaru change: remove the shadow
     text-shadow: 0 1px black;
     -gtk-icon-shadow: 0 1px black;
     outline-color: transparentize($osd_fg_color, 0.7);
@@ -415,7 +410,7 @@
     $button_fill: image($_bg) !global;
     background-image: $button_fill;
     background-clip: padding-box;
-    // box-shadow: inset 0 1px transparentize(white, 0.9);
+    // box-shadow: inset 0 1px transparentize(white, 0.9); // Yaru change: remove the shadow
     text-shadow: 0 1px black;
     -gtk-icon-shadow: 0 1px black;
     outline-color: transparentize($osd_fg_color, 0.7);
@@ -495,9 +490,9 @@
 // $hc: top highlight color
 // $ov: a background layer for background shorthand (hence no commas!)
 //
-  $gradient: linear-gradient(to top, darken($c, 0%), lighten($c, 0%));
+  $gradient: linear-gradient(to top, darken($c, 0%), lighten($c, 0%)); // Yaru change: no gradiensts
 
-  @if $variant == 'dark' { $gradient: linear-gradient(to top, lighten($c, 3%), lighten($c, 3%)); }
+  @if $variant == 'dark' { $gradient: linear-gradient(to top, lighten($c, 3%), lighten($c, 3%)); } // Yaru change: no gradiensts
 
   @if $ov != none { background: $c $ov, $gradient; }
   @else { background: $c $gradient; }
@@ -602,7 +597,7 @@
   $_border_color: if($c==$checkradio_bg_color, $c, $alt_borders_color);
   $_dim_border_color: transparentize($_border_color, if($variant == 'light', 0.3, 0.7));
 
-  @if $t==normal  {
+  @if $t==normal  { // Yaru change: no gradients, better borders
     background-clip: if($checked, border-box, padding-box);
     background-image: image(lighten($c, if($variant=='dark', if($c==$checkradio_bg_color, 0%, 5%), 0%)));
     border-color: $_border_color;

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -200,7 +200,7 @@
     $button_fill: if($c == $bg_color, if($variant == 'light', image(lighten($c, 2%)), image(lighten($c, 4%))), image(lighten($c, 2%))) !global;
     background-image: $button_fill;
     @include _button_text_shadow($tc, $c);
-    @include _shadows(0 1px transparentize(black, 0.9)); // Yaru change: paper effect shadow
+    @include _shadows(0 1px transparentize(black, 0.9)); // Yaru change: stronger shadows for flatter buttons
   }
 
   @else if $t==hover {
@@ -221,7 +221,7 @@
       @include _button_text_shadow($tc,lighten($c, 6%));
       @include _shadows(inset 0 1px _button_hilight_color(darken($c, 2%)), $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85)); // Yaru change: paper effect
+    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85)); // Yaru change: stronger shadows for flatter buttons
     background-image: if($c == $bg_color, if($variant == 'light', image(lighten($c, 4%)), image(lighten($c, 6%))), image(lighten($c, 4%)));
   }
 
@@ -243,7 +243,7 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85)); // Yaru change: paper effect
+    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85)); // Yaru change: stronger shadows for flatter buttons
     background-image: image(lighten($c, 10%)); // Yaru change: brighter alt
   }
 
@@ -265,7 +265,7 @@
                         $_button_edge, $_button_shadow);
     }
     background-image: image(lighten($c, 6%)); // Yaru change: brighter alt hover
-    box-shadow: 0 1px transparentize(black, 0.8); // Yaru change: paper effect
+    box-shadow: 0 1px transparentize(black, 0.8); // Yaru change: stronger shadows for flatter buttons
   }
 
   @else if $t==active {
@@ -490,9 +490,9 @@
 // $hc: top highlight color
 // $ov: a background layer for background shorthand (hence no commas!)
 //
-  $gradient: linear-gradient(to top, darken($c, 0%), lighten($c, 0%)); // Yaru change: no gradiensts
+  $gradient: linear-gradient(to top, darken($c, 0%), lighten($c, 0%)); // Yaru change: no gradients
 
-  @if $variant == 'dark' { $gradient: linear-gradient(to top, lighten($c, 3%), lighten($c, 3%)); } // Yaru change: no gradiensts
+  @if $variant == 'dark' { $gradient: linear-gradient(to top, lighten($c, 3%), lighten($c, 3%)); } // Yaru change: no gradients
 
   @if $ov != none { background: $c $ov, $gradient; }
   @else { background: $c $gradient; }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -395,3 +395,8 @@ decoration {
                 0 0 0 1px $_wm_border;
   }
 }
+
+// Fix "hdy" windows border radius used in "newer" gtk apps
+// Need to investigate how upstream does this without changing _common.scss
+deck box headerbar { border-radius: $window_radius $window_radius 0 0; }
+window.csd.unified  { border-radius: $window_radius $window_radius 0 0; }

--- a/gtk/upstream/gtk+3.0/Adwaita/_colors-public.scss
+++ b/gtk/upstream/gtk+3.0/Adwaita/_colors-public.scss
@@ -112,5 +112,8 @@ read if you used those and something break with a version upgrade you're on your
 
 //FIXME this is really an API
 
+/* content view background such as thumbnails view in Photos or Boxes */
 @define-color content_view_bg #{"" + $base_color};
 
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #{"" + if($variant == 'light', $base_color, darken($base_color,6%))};

--- a/gtk/upstream/gtk+3.0/Adwaita/_common.scss
+++ b/gtk/upstream/gtk+3.0/Adwaita/_common.scss
@@ -205,6 +205,12 @@ label {
   &:backdrop {
     selection { @extend %selected_items_backdrop; }
   }
+
+  &.error {
+    color: $error_color;
+    &:disabled { color: transparentize($error_color,0.5); }
+    &:disabled:backdrop { color: transparentize($error_color,0.6); }
+  }
 }
 
 .dim-label {
@@ -274,7 +280,6 @@ spinner {
 .large-title {
    font-weight: 300;
    font-size: 24pt;
-   letter-spacing: 0.2rem;
 }
 .title-1 {
    font-weight: 800;
@@ -474,6 +479,8 @@ entry {
       + combobox > box > button.combo { border-top-color: $drop_target_color; }
     }
   }
+
+  &.error { color: $error_color; }
 }
 
 treeview entry {
@@ -2376,11 +2383,11 @@ notebook {
       > tabs {
         margin-bottom: -2px;
         > tab {
-          &:hover { box-shadow: inset 0 -3px $borders_color; }
+          &:hover { box-shadow: inset 0 -4px $borders_color; }
 
           &:backdrop { box-shadow: none; }
 
-          &:checked { box-shadow: inset 0 -3px $selected_bg_color; }
+          &:checked { box-shadow: inset 0 -4px $selected_bg_color; }
         }
       }
     }
@@ -2390,11 +2397,11 @@ notebook {
       > tabs {
         margin-top: -2px;
         > tab {
-          &:hover { box-shadow: inset 0 3px $borders_color; }
+          &:hover { box-shadow: inset 0 4px $borders_color; }
 
           &:backdrop { box-shadow: none; }
 
-          &:checked { box-shadow: inset 0 3px $selected_bg_color; }
+          &:checked { box-shadow: inset 0 4px $selected_bg_color; }
         }
       }
     }
@@ -2404,11 +2411,11 @@ notebook {
       > tabs {
         margin-right: -2px;
         > tab {
-          &:hover { box-shadow: inset -3px 0 $borders_color; }
+          &:hover { box-shadow: inset -4px 0 $borders_color; }
 
           &:backdrop { box-shadow: none; }
 
-          &:checked { box-shadow: inset -3px 0 $selected_bg_color; }
+          &:checked { box-shadow: inset -4px 0 $selected_bg_color; }
         }
       }
     }
@@ -2418,11 +2425,11 @@ notebook {
       > tabs {
         margin-left: -2px;
         > tab {
-          &:hover { box-shadow: inset 3px 0 $borders_color; }
+          &:hover { box-shadow: inset 4px 0 $borders_color; }
 
           &:backdrop { box-shadow: none; }
 
-          &:checked { box-shadow: inset 3px 0 $selected_bg_color; }
+          &:checked { box-shadow: inset 4px 0 $selected_bg_color; }
         }
       }
     }
@@ -2500,14 +2507,15 @@ notebook {
 
       outline-offset: -5px;
 
-      color: $insensitive_fg_color;
-      font-weight: bold;
+      color: $fg_color;
+      font-weight: normal;
 
       border-width: 1px;         // for reorderable tabs
       border-color: transparent; //
 
       &:hover {
-        color: mix($insensitive_fg_color, $fg_color, 50%);
+        color: $fg_color;
+        background-color: darken($bg_color,4%);
 
         &.reorderable-page {
           border-color: transparentize($borders_color, 0.7);
@@ -2929,7 +2937,7 @@ switch {
   (':backdrop:checked', '-gtk-icontheme(\'object-select-symbolic\')', '#{transparentize($osd_fg_color, 0.2)}', '#{desaturate($checkradio_bg_color, 100%)}'), {
 
   .view.content-view.check#{$check_state}:not(list),
-  .content-view .tile check#{$check_state}:not(list) {
+  .content-view:not(list) check#{$check_state} {
     margin: 4px;
     min-width: 32px;
     min-height: 32px;
@@ -4573,8 +4581,6 @@ decoration {
   .tiled-left & { border-radius: 0; }
 
   .popup & { box-shadow: none; }
-
-  .csd & { background-color: black; } // transparent makes gtk3 leak light on the corners #2537
 
   // server-side decorations as used by mutter
   .ssd & { box-shadow: 0 0 0 1px $_wm_border; } //just doing borders, wm draws actual shadows

--- a/gtk/upstream/gtk+3.0/Adwaita/gtk-contained-dark.css
+++ b/gtk/upstream/gtk+3.0/Adwaita/gtk-contained-dark.css
@@ -57,6 +57,12 @@ label:disabled:backdrop { color: #5b5b5b; }
 
 button label:disabled:backdrop { color: inherit; }
 
+label.error { color: #cc0000; }
+
+label.error:disabled { color: rgba(204, 0, 0, 0.5); }
+
+label.error:disabled:backdrop { color: rgba(204, 0, 0, 0.4); }
+
 .dim-label, .titlebar:not(headerbar) .subtitle, headerbar .subtitle, label.separator { opacity: 0.55; text-shadow: none; }
 
 assistant .sidebar { background-color: #2d2d2d; border-top: 1px solid #1b1b1b; }
@@ -85,7 +91,7 @@ spinner:checked { opacity: 1; animation: spin 1s linear infinite; }
 spinner:checked:disabled { opacity: 0.5; }
 
 /********************** General Typography * */
-.large-title { font-weight: 300; font-size: 24pt; letter-spacing: 0.2rem; }
+.large-title { font-weight: 300; font-size: 24pt; }
 
 .title-1 { font-weight: 800; font-size: 20pt; }
 
@@ -177,6 +183,8 @@ spinbutton:not(.vertical) progress:backdrop, entry progress:backdrop { backgroun
 .linked.vertical > spinbutton:focus.error:not(:only-child):not(.vertical) + spinbutton:not(.vertical), .linked.vertical > spinbutton:focus.error:not(:only-child):not(.vertical) + entry, .linked.vertical > spinbutton:focus.error:not(:only-child):not(.vertical) + button, .linked.vertical > spinbutton:focus.error:not(:only-child):not(.vertical) + combobox > box > button.combo, .linked.vertical > entry:focus.error:not(:only-child) + spinbutton:not(.vertical), .linked.vertical > entry:focus.error:not(:only-child) + entry, .linked.vertical > entry:focus.error:not(:only-child) + button, .linked.vertical > entry:focus.error:not(:only-child) + combobox > box > button.combo { border-top-color: #1a0000; }
 
 .linked.vertical > spinbutton:drop(active):not(:only-child):not(.vertical) + spinbutton:not(.vertical), .linked.vertical > spinbutton:drop(active):not(:only-child):not(.vertical) + entry, .linked.vertical > spinbutton:drop(active):not(:only-child):not(.vertical) + button, .linked.vertical > spinbutton:drop(active):not(:only-child):not(.vertical) + combobox > box > button.combo, .linked.vertical > entry:drop(active):not(:only-child) + spinbutton:not(.vertical), .linked.vertical > entry:drop(active):not(:only-child) + entry, .linked.vertical > entry:drop(active):not(:only-child) + button, .linked.vertical > entry:drop(active):not(:only-child) + combobox > box > button.combo { border-top-color: #4e9a06; }
+
+spinbutton.error:not(.vertical), entry.error { color: #cc0000; }
 
 treeview entry:focus:dir(rtl), treeview entry:focus:dir(ltr) { background-color: #2d2d2d; transition-property: color, background; }
 
@@ -837,41 +845,41 @@ notebook > header.top { border-bottom-style: solid; }
 
 notebook > header.top > tabs { margin-bottom: -2px; }
 
-notebook > header.top > tabs > tab:hover { box-shadow: inset 0 -3px #1b1b1b; }
+notebook > header.top > tabs > tab:hover { box-shadow: inset 0 -4px #1b1b1b; }
 
 notebook > header.top > tabs > tab:backdrop { box-shadow: none; }
 
-notebook > header.top > tabs > tab:checked { box-shadow: inset 0 -3px #15539e; }
+notebook > header.top > tabs > tab:checked { box-shadow: inset 0 -4px #15539e; }
 
 notebook > header.bottom { border-top-style: solid; }
 
 notebook > header.bottom > tabs { margin-top: -2px; }
 
-notebook > header.bottom > tabs > tab:hover { box-shadow: inset 0 3px #1b1b1b; }
+notebook > header.bottom > tabs > tab:hover { box-shadow: inset 0 4px #1b1b1b; }
 
 notebook > header.bottom > tabs > tab:backdrop { box-shadow: none; }
 
-notebook > header.bottom > tabs > tab:checked { box-shadow: inset 0 3px #15539e; }
+notebook > header.bottom > tabs > tab:checked { box-shadow: inset 0 4px #15539e; }
 
 notebook > header.left { border-right-style: solid; }
 
 notebook > header.left > tabs { margin-right: -2px; }
 
-notebook > header.left > tabs > tab:hover { box-shadow: inset -3px 0 #1b1b1b; }
+notebook > header.left > tabs > tab:hover { box-shadow: inset -4px 0 #1b1b1b; }
 
 notebook > header.left > tabs > tab:backdrop { box-shadow: none; }
 
-notebook > header.left > tabs > tab:checked { box-shadow: inset -3px 0 #15539e; }
+notebook > header.left > tabs > tab:checked { box-shadow: inset -4px 0 #15539e; }
 
 notebook > header.right { border-left-style: solid; }
 
 notebook > header.right > tabs { margin-left: -2px; }
 
-notebook > header.right > tabs > tab:hover { box-shadow: inset 3px 0 #1b1b1b; }
+notebook > header.right > tabs > tab:hover { box-shadow: inset 4px 0 #1b1b1b; }
 
 notebook > header.right > tabs > tab:backdrop { box-shadow: none; }
 
-notebook > header.right > tabs > tab:checked { box-shadow: inset 3px 0 #15539e; }
+notebook > header.right > tabs > tab:checked { box-shadow: inset 4px 0 #15539e; }
 
 notebook > header.top > tabs > arrow { border-top-style: none; }
 
@@ -899,9 +907,9 @@ notebook > header > tabs > arrow:hover:not(:active):not(:backdrop) { background-
 
 notebook > header > tabs > arrow:disabled { border-color: transparent; background-color: transparent; background-image: none; box-shadow: inset 0 1px rgba(255, 255, 255, 0); text-shadow: none; -gtk-icon-shadow: none; }
 
-notebook > header tab { min-height: 30px; min-width: 30px; padding: 3px 12px; outline-offset: -5px; color: #919190; font-weight: bold; border-width: 1px; border-color: transparent; }
+notebook > header tab { min-height: 30px; min-width: 30px; padding: 3px 12px; outline-offset: -5px; color: #eeeeec; font-weight: normal; border-width: 1px; border-color: transparent; }
 
-notebook > header tab:hover { color: #c0c0be; }
+notebook > header tab:hover { color: #eeeeec; background-color: #2b2b2b; }
 
 notebook > header tab:hover.reorderable-page { border-color: rgba(27, 27, 27, 0.3); background-color: rgba(53, 53, 53, 0.2); }
 
@@ -1064,21 +1072,21 @@ switch:backdrop:checked > slider { border-color: #030c17; }
 switch:backdrop:disabled slider { color: #5b5b5b; border-color: #202020; background-image: image(#323232); text-shadow: none; -gtk-icon-shadow: none; box-shadow: inset 0 1px rgba(255, 255, 255, 0); }
 
 /************************* Check and Radio items * */
-.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view .tile check:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view:not(list) check { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
 
-.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view .tile check:hover:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view:not(list) check:hover { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
 
-.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view .tile check:active:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view:not(list) check:active { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
 
-.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view .tile check:backdrop:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #737373; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view:not(list) check:backdrop { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #737373; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
 
-.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view .tile check:checked:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view:not(list) check:checked { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
 
-.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view .tile check:checked:hover:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view:not(list) check:checked:hover { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
 
-.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view .tile check:checked:active:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view:not(list) check:checked:active { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #1b6acb; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
 
-.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view .tile check:backdrop:checked:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: rgba(238, 238, 236, 0.8); background-color: #737373; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view:not(list) check:backdrop:checked { margin: 4px; min-width: 32px; min-height: 32px; color: rgba(238, 238, 236, 0.8); background-color: #737373; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
 
 checkbutton.text-button, radiobutton.text-button { padding: 2px 0; outline-offset: 0; }
 
@@ -1826,15 +1834,15 @@ colorchooser .popover.osd { border-radius: 5px; }
 .scale-popup button:hover { background-color: rgba(238, 238, 236, 0.1); border-radius: 5px; }
 
 /********************** Window Decorations * */
-decoration { border-radius: 8px 8px 0 0; border-width: 0px; background-color: black; /* transparent makes gtk3 leak light on the corners #2537 */ box-shadow: 0 3px 9px 1px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(27, 27, 27, 0.9); margin: 10px; }
+decoration { border-radius: 8px 8px 0 0; border-width: 0px; box-shadow: 0 3px 9px 1px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(27, 27, 27, 0.9); margin: 10px; }
 
 decoration:backdrop { box-shadow: 0 3px 9px 1px transparent, 0 2px 6px 2px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(27, 27, 27, 0.9); transition: 200ms ease-out; }
 
 .maximized decoration, .fullscreen decoration, .tiled decoration, .tiled-top decoration, .tiled-right decoration, .tiled-bottom decoration, .tiled-left decoration { border-radius: 0; }
 
-.popup decoration { box-shadow: none; background: none; }
+.popup decoration { box-shadow: none; }
 
-.ssd decoration { background: none; box-shadow: 0 0 0 1px rgba(27, 27, 27, 0.9); }
+.ssd decoration { box-shadow: 0 0 0 1px rgba(27, 27, 27, 0.9); }
 
 .csd.popup decoration { border-radius: 5px; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(27, 27, 27, 0.8); }
 
@@ -2017,4 +2025,7 @@ read if you used those and something break with a version upgrade you're on your
 @define-color wm_button_active_color_a shade(#353535, 0.85);
 @define-color wm_button_active_color_b shade(#353535, 0.89);
 @define-color wm_button_active_color_c shade(#353535, 0.9);
+/* content view background such as thumbnails view in Photos or Boxes */
 @define-color content_view_bg #2d2d2d;
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #1e1e1e;

--- a/gtk/upstream/gtk+3.0/Adwaita/gtk-contained.css
+++ b/gtk/upstream/gtk+3.0/Adwaita/gtk-contained.css
@@ -57,6 +57,12 @@ label:disabled:backdrop { color: #d4cfca; }
 
 button label:disabled:backdrop { color: inherit; }
 
+label.error { color: #cc0000; }
+
+label.error:disabled { color: rgba(204, 0, 0, 0.5); }
+
+label.error:disabled:backdrop { color: rgba(204, 0, 0, 0.4); }
+
 .dim-label, .titlebar:not(headerbar) .subtitle, headerbar .subtitle, label.separator { opacity: 0.55; text-shadow: none; }
 
 assistant .sidebar { background-color: #ffffff; border-top: 1px solid #cdc7c2; }
@@ -85,7 +91,7 @@ spinner:checked { opacity: 1; animation: spin 1s linear infinite; }
 spinner:checked:disabled { opacity: 0.5; }
 
 /********************** General Typography * */
-.large-title { font-weight: 300; font-size: 24pt; letter-spacing: 0.2rem; }
+.large-title { font-weight: 300; font-size: 24pt; }
 
 .title-1 { font-weight: 800; font-size: 20pt; }
 
@@ -177,6 +183,8 @@ spinbutton:not(.vertical) progress:backdrop, entry progress:backdrop { backgroun
 .linked.vertical > spinbutton:focus.error:not(:only-child):not(.vertical) + spinbutton:not(.vertical), .linked.vertical > spinbutton:focus.error:not(:only-child):not(.vertical) + entry, .linked.vertical > spinbutton:focus.error:not(:only-child):not(.vertical) + button, .linked.vertical > spinbutton:focus.error:not(:only-child):not(.vertical) + combobox > box > button.combo, .linked.vertical > entry:focus.error:not(:only-child) + spinbutton:not(.vertical), .linked.vertical > entry:focus.error:not(:only-child) + entry, .linked.vertical > entry:focus.error:not(:only-child) + button, .linked.vertical > entry:focus.error:not(:only-child) + combobox > box > button.combo { border-top-color: #cc0000; }
 
 .linked.vertical > spinbutton:drop(active):not(:only-child):not(.vertical) + spinbutton:not(.vertical), .linked.vertical > spinbutton:drop(active):not(:only-child):not(.vertical) + entry, .linked.vertical > spinbutton:drop(active):not(:only-child):not(.vertical) + button, .linked.vertical > spinbutton:drop(active):not(:only-child):not(.vertical) + combobox > box > button.combo, .linked.vertical > entry:drop(active):not(:only-child) + spinbutton:not(.vertical), .linked.vertical > entry:drop(active):not(:only-child) + entry, .linked.vertical > entry:drop(active):not(:only-child) + button, .linked.vertical > entry:drop(active):not(:only-child) + combobox > box > button.combo { border-top-color: #4e9a06; }
+
+spinbutton.error:not(.vertical), entry.error { color: #cc0000; }
 
 treeview entry:focus:dir(rtl), treeview entry:focus:dir(ltr) { background-color: #ffffff; transition-property: color, background; }
 
@@ -845,41 +853,41 @@ notebook > header.top { border-bottom-style: solid; }
 
 notebook > header.top > tabs { margin-bottom: -2px; }
 
-notebook > header.top > tabs > tab:hover { box-shadow: inset 0 -3px #cdc7c2; }
+notebook > header.top > tabs > tab:hover { box-shadow: inset 0 -4px #cdc7c2; }
 
 notebook > header.top > tabs > tab:backdrop { box-shadow: none; }
 
-notebook > header.top > tabs > tab:checked { box-shadow: inset 0 -3px #3584e4; }
+notebook > header.top > tabs > tab:checked { box-shadow: inset 0 -4px #3584e4; }
 
 notebook > header.bottom { border-top-style: solid; }
 
 notebook > header.bottom > tabs { margin-top: -2px; }
 
-notebook > header.bottom > tabs > tab:hover { box-shadow: inset 0 3px #cdc7c2; }
+notebook > header.bottom > tabs > tab:hover { box-shadow: inset 0 4px #cdc7c2; }
 
 notebook > header.bottom > tabs > tab:backdrop { box-shadow: none; }
 
-notebook > header.bottom > tabs > tab:checked { box-shadow: inset 0 3px #3584e4; }
+notebook > header.bottom > tabs > tab:checked { box-shadow: inset 0 4px #3584e4; }
 
 notebook > header.left { border-right-style: solid; }
 
 notebook > header.left > tabs { margin-right: -2px; }
 
-notebook > header.left > tabs > tab:hover { box-shadow: inset -3px 0 #cdc7c2; }
+notebook > header.left > tabs > tab:hover { box-shadow: inset -4px 0 #cdc7c2; }
 
 notebook > header.left > tabs > tab:backdrop { box-shadow: none; }
 
-notebook > header.left > tabs > tab:checked { box-shadow: inset -3px 0 #3584e4; }
+notebook > header.left > tabs > tab:checked { box-shadow: inset -4px 0 #3584e4; }
 
 notebook > header.right { border-left-style: solid; }
 
 notebook > header.right > tabs { margin-left: -2px; }
 
-notebook > header.right > tabs > tab:hover { box-shadow: inset 3px 0 #cdc7c2; }
+notebook > header.right > tabs > tab:hover { box-shadow: inset 4px 0 #cdc7c2; }
 
 notebook > header.right > tabs > tab:backdrop { box-shadow: none; }
 
-notebook > header.right > tabs > tab:checked { box-shadow: inset 3px 0 #3584e4; }
+notebook > header.right > tabs > tab:checked { box-shadow: inset 4px 0 #3584e4; }
 
 notebook > header.top > tabs > arrow { border-top-style: none; }
 
@@ -907,9 +915,9 @@ notebook > header > tabs > arrow:hover:not(:active):not(:backdrop) { background-
 
 notebook > header > tabs > arrow:disabled { border-color: transparent; background-color: transparent; background-image: none; box-shadow: inset 0 1px rgba(255, 255, 255, 0); text-shadow: none; -gtk-icon-shadow: none; }
 
-notebook > header tab { min-height: 30px; min-width: 30px; padding: 3px 12px; outline-offset: -5px; color: #929595; font-weight: bold; border-width: 1px; border-color: transparent; }
+notebook > header tab { min-height: 30px; min-width: 30px; padding: 3px 12px; outline-offset: -5px; color: #2e3436; font-weight: normal; border-width: 1px; border-color: transparent; }
 
-notebook > header tab:hover { color: #606566; }
+notebook > header tab:hover { color: #2e3436; background-color: #edebe9; }
 
 notebook > header tab:hover.reorderable-page { border-color: rgba(205, 199, 194, 0.3); background-color: rgba(246, 245, 244, 0.2); }
 
@@ -1078,21 +1086,21 @@ row:selected switch:backdrop { border-color: #15539e; }
 row:selected switch > slider:checked, row:selected switch > slider { border-color: #15539e; }
 
 /************************* Check and Radio items * */
-.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view .tile check:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+.view.content-view.check:not(list), iconview.content-view.check:not(list), .content-view:not(list) check { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
 
-.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view .tile check:hover:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+.view.content-view.check:hover:not(list), iconview.content-view.check:hover:not(list), .content-view:not(list) check:hover { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
 
-.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view .tile check:active:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+.view.content-view.check:active:not(list), iconview.content-view.check:active:not(list), .content-view:not(list) check:active { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
 
-.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view .tile check:backdrop:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #8d8d8d; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
+.view.content-view.check:backdrop:not(list), iconview.content-view.check:backdrop:not(list), .content-view:not(list) check:backdrop { margin: 4px; min-width: 32px; min-height: 32px; color: transparent; background-color: #8d8d8d; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: none; -gtk-icon-shadow: none; }
 
-.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view .tile check:checked:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+.view.content-view.check:checked:not(list), iconview.content-view.check:checked:not(list), .content-view:not(list) check:checked { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
 
-.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view .tile check:checked:hover:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+.view.content-view.check:checked:hover:not(list), iconview.content-view.check:checked:hover:not(list), .content-view:not(list) check:checked:hover { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
 
-.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view .tile check:checked:active:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+.view.content-view.check:checked:active:not(list), iconview.content-view.check:checked:active:not(list), .content-view:not(list) check:checked:active { margin: 4px; min-width: 32px; min-height: 32px; color: #eeeeec; background-color: #3584e4; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
 
-.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view .tile check:backdrop:checked:not(list) { margin: 4px; min-width: 32px; min-height: 32px; color: rgba(238, 238, 236, 0.8); background-color: #8d8d8d; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
+.view.content-view.check:backdrop:checked:not(list), iconview.content-view.check:backdrop:checked:not(list), .content-view:not(list) check:backdrop:checked { margin: 4px; min-width: 32px; min-height: 32px; color: rgba(238, 238, 236, 0.8); background-color: #8d8d8d; border-radius: 5px; background-image: none; transition: 200ms; box-shadow: none; border-width: 0; -gtk-icon-source: -gtk-icontheme('object-select-symbolic'); -gtk-icon-shadow: none; }
 
 checkbutton.text-button, radiobutton.text-button { padding: 2px 0; outline-offset: 0; }
 
@@ -1842,15 +1850,15 @@ colorchooser .popover.osd { border-radius: 5px; }
 .scale-popup button:hover { background-color: rgba(46, 52, 54, 0.1); border-radius: 5px; }
 
 /********************** Window Decorations * */
-decoration { border-radius: 8px 8px 0 0; border-width: 0px; background-color: black; /* transparent makes gtk3 leak light on the corners #2537 */ box-shadow: 0 3px 9px 1px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 0, 0, 0.23); margin: 10px; }
+decoration { border-radius: 8px 8px 0 0; border-width: 0px; box-shadow: 0 3px 9px 1px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 0, 0, 0.23); margin: 10px; }
 
 decoration:backdrop { box-shadow: 0 3px 9px 1px transparent, 0 2px 6px 2px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(0, 0, 0, 0.18); transition: 200ms ease-out; }
 
 .maximized decoration, .fullscreen decoration, .tiled decoration, .tiled-top decoration, .tiled-right decoration, .tiled-bottom decoration, .tiled-left decoration { border-radius: 0; }
 
-.popup decoration { box-shadow: none; background: none; }
+.popup decoration { box-shadow: none; }
 
-.ssd decoration { background: none; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.23); }
+.ssd decoration { box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.23); }
 
 .csd.popup decoration { border-radius: 5px; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(0, 0, 0, 0.13); }
 
@@ -2033,4 +2041,7 @@ read if you used those and something break with a version upgrade you're on your
 @define-color wm_button_active_color_a shade(#f6f5f4, 0.85);
 @define-color wm_button_active_color_b shade(#f6f5f4, 0.89);
 @define-color wm_button_active_color_c shade(#f6f5f4, 0.9);
+/* content view background such as thumbnails view in Photos or Boxes */
 @define-color content_view_bg #ffffff;
+/* Very contrasty background for text views (@theme_text_color foreground) */
+@define-color text_view_bg #ffffff;

--- a/gtk/upstream/nautilus/Adwaita.css
+++ b/gtk/upstream/nautilus/Adwaita.css
@@ -45,32 +45,28 @@
 
 /* Path bar */
 
-.nautilus-path-bar button { /* undecorate the buttons */
+.path-bar-box {
+  border-radius: 5px;
+  border: 1px @borders solid;
+  background-color: @theme_bg_color;
+  padding-right: 6px;
+}
+
+.nautilus-path-bar button {
   margin: 0px;
 }
 
+.nautilus-path-bar button:first-child {
+  border-width: 0px 1px 0px 0px;
+  border-radius: 3.5px 0px 0px 3.5px;
+}
+
+.nautilus-path-bar button:not(:first-child) {
+  border-width: 0px 1px 0px 1px;
+  border-radius: 0px 0px 0px 0px;
+}
+
 .nautilus-path-bar button:not(:checked) image { opacity: 0.8; } /* dim the icon when not checked */
-
-.path-bar-box {
-  transition: border 200ms;
-  transition: background-color 200ms;
-  border-radius: 5px;
-}
-
-.path-bar-box.width-maximized {
-  border: 1px @borders solid;
-  background-color: @theme_bg_color;
-}
-
-.path-bar-box.width-maximized button:first-child {
-    border-radius: 3.5px 0px 0px 3.5px;
-    border-width: 0px 1px 0px 0px;
-}
-
-.path-bar-box.width-maximized button:not(:first-child) {
-    border-width: 0px 1px 0px 1px;
-    border-radius: 0px 0px 0px 0px;
-}
 
 /* Make the tags fit into the box */
 entry.search > * {


### PR DESCRIPTION
- Upstream fixes for error labels in _common and _drawing
- Exported colors also received two new colors from upstream
- dropping the slim yaru button padding for now, as there are more and more gtk apps using those new big hdy (mobile ready), transformable headerbars, which think of the adwaita padding and thus stretch our small buttons plus custom button widgets that use the adwaita padding can be found across the desktop small buttons look weird along along side these
- added comments for our changes to make it easier for other maintainers to keep our style
- for some reason I had to put code into _tweaks to fix the corners, I checked what upstream does and found nothing on their scss files or in the app css of screenshot and geary, yet adwaita doesnt have this issue. Anyways, fix is in _tweaks for this

![grafik](https://user-images.githubusercontent.com/15329494/93711692-8412c700-fb50-11ea-8042-dc0fda06b385.png)


Closes #2356 

Closes #2357 

Closes #2355 

Closes #2360