### PR TITLE
_tweaks: remove circular button min-width

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -337,10 +337,6 @@ treeview.view radio {
 
 treeview:hover { background: $popover_hover_color; }
 
-// Fix for slimed down circular buttons, could need a change upstream since this happens for
-// Some of the circular buttons there too
-* { & button.circular { min-width: 0; } }
-
 scale {
   slider {
     .osd & {


### PR DESCRIPTION
no longer needed after we use adwaita padding. if we use it, it over trims circular buttons in rows

Before:

![beh](https://user-images.githubusercontent.com/15329494/94343179-b3c14380-0016-11eb-9104-d7da2cdf8581.png)


After:

![yay](https://user-images.githubusercontent.com/15329494/94343182-b754ca80-0016-11eb-938b-7d3b58427845.png)
