### PR TITLE
Insync emblems

### DIFF
--- a/icons/Suru/16x16/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/16x16/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/16x16/emblems/emblem-insync-error.png
+++ b/icons/Suru/16x16/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/16x16/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/16x16/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/16x16/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/16x16/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/16x16/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/16x16/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/16x16/emblems/emblem-insync-synced.png
+++ b/icons/Suru/16x16/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/16x16/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/16x16/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/16x16/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/16x16/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/16x16@2x/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/16x16@2x/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/16x16@2x/emblems/emblem-insync-error.png
+++ b/icons/Suru/16x16@2x/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/16x16@2x/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/16x16@2x/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/16x16@2x/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/16x16@2x/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/16x16@2x/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/16x16@2x/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/16x16@2x/emblems/emblem-insync-synced.png
+++ b/icons/Suru/16x16@2x/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/16x16@2x/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/16x16@2x/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/16x16@2x/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/16x16@2x/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/24x24/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/24x24/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/24x24/emblems/emblem-insync-error.png
+++ b/icons/Suru/24x24/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/24x24/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/24x24/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/24x24/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/24x24/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/24x24/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/24x24/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/24x24/emblems/emblem-insync-synced.png
+++ b/icons/Suru/24x24/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/24x24/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/24x24/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/24x24/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/24x24/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/24x24@2x/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/24x24@2x/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/24x24@2x/emblems/emblem-insync-error.png
+++ b/icons/Suru/24x24@2x/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/24x24@2x/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/24x24@2x/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/24x24@2x/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/24x24@2x/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/24x24@2x/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/24x24@2x/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/24x24@2x/emblems/emblem-insync-synced.png
+++ b/icons/Suru/24x24@2x/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/24x24@2x/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/24x24@2x/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/24x24@2x/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/24x24@2x/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/256x256/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/256x256/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/256x256/emblems/emblem-insync-error.png
+++ b/icons/Suru/256x256/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/256x256/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/256x256/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/256x256/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/256x256/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/256x256/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/256x256/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/256x256/emblems/emblem-insync-synced.png
+++ b/icons/Suru/256x256/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/256x256/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/256x256/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/256x256/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/256x256/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/256x256@2x/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/256x256@2x/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/256x256@2x/emblems/emblem-insync-error.png
+++ b/icons/Suru/256x256@2x/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/256x256@2x/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/256x256@2x/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/256x256@2x/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/256x256@2x/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/256x256@2x/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/256x256@2x/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/256x256@2x/emblems/emblem-insync-synced.png
+++ b/icons/Suru/256x256@2x/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/256x256@2x/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/256x256@2x/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/256x256@2x/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/256x256@2x/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/32x32/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/32x32/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/32x32/emblems/emblem-insync-error.png
+++ b/icons/Suru/32x32/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/32x32/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/32x32/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/32x32/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/32x32/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/32x32/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/32x32/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/32x32/emblems/emblem-insync-synced.png
+++ b/icons/Suru/32x32/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/32x32/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/32x32/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/32x32/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/32x32/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/32x32@2x/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/32x32@2x/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/32x32@2x/emblems/emblem-insync-error.png
+++ b/icons/Suru/32x32@2x/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/32x32@2x/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/32x32@2x/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/32x32@2x/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/32x32@2x/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/32x32@2x/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/32x32@2x/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/32x32@2x/emblems/emblem-insync-synced.png
+++ b/icons/Suru/32x32@2x/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/32x32@2x/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/32x32@2x/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/32x32@2x/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/32x32@2x/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/48x48/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/48x48/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/48x48/emblems/emblem-insync-error.png
+++ b/icons/Suru/48x48/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/48x48/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/48x48/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/48x48/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/48x48/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/48x48/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/48x48/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/48x48/emblems/emblem-insync-synced.png
+++ b/icons/Suru/48x48/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/48x48/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/48x48/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/48x48/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/48x48/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/48x48@2x/emblems/emblem-insync-error-shared.png
+++ b/icons/Suru/48x48@2x/emblems/emblem-insync-error-shared.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/48x48@2x/emblems/emblem-insync-error.png
+++ b/icons/Suru/48x48@2x/emblems/emblem-insync-error.png
@@ -1,0 +1,1 @@
+emblem-unreadable.png

--- a/icons/Suru/48x48@2x/emblems/emblem-insync-synced-callbacks-active.png
+++ b/icons/Suru/48x48@2x/emblems/emblem-insync-synced-callbacks-active.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/48x48@2x/emblems/emblem-insync-synced-callbacks.png
+++ b/icons/Suru/48x48@2x/emblems/emblem-insync-synced-callbacks.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/48x48@2x/emblems/emblem-insync-synced-shared.png
+++ b/icons/Suru/48x48@2x/emblems/emblem-insync-synced-shared.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/48x48@2x/emblems/emblem-insync-synced.png
+++ b/icons/Suru/48x48@2x/emblems/emblem-insync-synced.png
@@ -1,0 +1,1 @@
+emblem-default.png

--- a/icons/Suru/48x48@2x/emblems/emblem-insync-syncing-shared.png
+++ b/icons/Suru/48x48@2x/emblems/emblem-insync-syncing-shared.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/Suru/48x48@2x/emblems/emblem-insync-syncing.png
+++ b/icons/Suru/48x48@2x/emblems/emblem-insync-syncing.png
@@ -1,0 +1,1 @@
+emblem-synchronizing.png

--- a/icons/src/symlinks/fullcolor/emblems.list
+++ b/icons/src/symlinks/fullcolor/emblems.list
@@ -5,3 +5,11 @@ emblem-unreadable.png emblem-dropbox-unsyncable.png
 emblem-list-add.png emblem-new.png
 emblem-danger.png emblem-important.png
 
+emblem-unreadable.png emblem-insync-error.png
+emblem-unreadable.png emblem-insync-error-shared.png
+emblem-default.png emblem-insync-synced-callbacks-active.png
+emblem-default.png emblem-insync-synced-callbacks.png
+emblem-default.png emblem-insync-synced.png
+emblem-default.png emblem-insync-synced-shared.png
+emblem-synchronizing.png emblem-insync-syncing.png
+emblem-synchronizing.png emblem-insync-syncing-shared.png


### PR DESCRIPTION
Link insync emblems to our ones.

```
emblem-unreadable.png    emblem-insync-error.png
emblem-unreadable.png    emblem-insync-error-shared.png
emblem-default.png       emblem-insync-synced-callbacks-active.png
emblem-default.png       emblem-insync-synced-callbacks.png
emblem-default.png       emblem-insync-synced.png
emblem-default.png       emblem-insync-synced-shared.png
emblem-synchronizing.png emblem-insync-syncing.png
emblem-synchronizing.png emblem-insync-syncing-shared.png

```
Can you test this @Feichtmeier please (I don't have a Google account)?

Closes #1973