### PR TITLE
Gtk theme: less shadows, gray sidebars

### DIFF
--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -200,7 +200,7 @@
     $button_fill: if($c == $bg_color, if($variant == 'light', image(lighten($c, 2%)), image(lighten($c, 4%))), image(lighten($c, 2%))) !global;
     background-image: $button_fill;
     @include _button_text_shadow($tc, $c);
-    @include _shadows(0 1px transparentize(black, 0.9)); // Yaru change: stronger shadows for flatter buttons
+    @include _shadows(0 1px transparentize(black, 0.95)); // Yaru change: stronger shadows for flatter buttons
   }
 
   @else if $t==hover {
@@ -221,7 +221,7 @@
       @include _button_text_shadow($tc,lighten($c, 6%));
       @include _shadows(inset 0 1px _button_hilight_color(darken($c, 2%)), $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85)); // Yaru change: stronger shadows for flatter buttons
+    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.85, 0.9)); // Yaru change: stronger shadows for flatter buttons
     background-image: if($c == $bg_color, if($variant == 'light', image(lighten($c, 4%)), image(lighten($c, 6%))), image(lighten($c, 4%)));
   }
 
@@ -243,7 +243,7 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85)); // Yaru change: stronger shadows for flatter buttons
+    @include _shadows(0 1px transparentize(black, 0.95)); // Yaru change: stronger shadows for flatter buttons
     background-image: image(lighten($c, 10%)); // Yaru change: brighter alt
   }
 
@@ -264,8 +264,8 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    background-image: image(lighten($c, 6%)); // Yaru change: brighter alt hover
-    box-shadow: 0 1px transparentize(black, 0.8); // Yaru change: stronger shadows for flatter buttons
+    background-image: image(lighten($c, 16%)); // Yaru change: brighter alt hover
+    box-shadow: 0 1px transparentize(black, 0.85); // Yaru change: stronger shadows for flatter buttons
   }
 
   @else if $t==active {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -391,8 +391,8 @@ window.csd.unified  { border-radius: $window_radius $window_radius 0 0; }
   &:selected {
     &, &.activatable {
       &, &:hover {
-        background-color: transparentize($fg_color, if($variant=='light', 0.85, 0.9));  
-        &, image, label { color: mix($fg_color, $text_color, 0.5); }
+        background-color: transparentize($fg_color, if($variant=='light', 0.85, 0.88));  
+        &, image, label { color: if($variant=='light', mix($fg_color, $text_color, 0.5), $selected_fg_color); }
       }      
       &:backdrop {
         &, image, label { color: $backdrop_text_color; }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -226,9 +226,6 @@ button {
   outline-offset: -2px;
   outline-width: 2px;
   -gtk-outline-radius: $button-radius;
-
-  row:selected & { outline-color: $coloured_focus_border_color; }
-
   &.suggested-action, &.destructive-action{ &, &:hover, &:active { outline-color: $coloured_focus_border_color; } }
 }
 
@@ -237,7 +234,6 @@ switch {
   &:focus {
     box-shadow: 0 0 0 3px if($variant=='light', lighten(opacify($focus_border_color, 1), 20%), $focus_border_color);
   }
-  row:selected & { outline-color: $coloured_focus_border_color; }
 }
 
 checkbutton,
@@ -246,16 +242,6 @@ radiobutton {
   outline-offset: 1px;
   outline-width: 2px;
   row:selected & , treeview:selected & { outline-color: $coloured_focus_border_color; }
-}
-
-row {
-  outline-color: $focus_border_color;
-  outline-offset: -2px;
-  -gtk-outline-radius: 0px;
-
-  &:selected {
-    outline-color: $coloured_focus_border_color;
-  }
 }
 
 treeview {
@@ -396,3 +382,22 @@ decoration {
 // Need to investigate how upstream does this without changing _common.scss
 deck box headerbar { border-radius: $window_radius $window_radius 0 0; }
 window.csd.unified  { border-radius: $window_radius $window_radius 0 0; }
+
+// Align all sidebar (not treeview) row selections to upstream nautilus 
+// Upstream only applies this if the theme is "Adwaita"
+.nautilus-window.sidebar-row, row, row:dir(ltr), row:dir(rtl) {
+  outline-color: $focus_border_color;
+  -gtk-outline-radius: 0;
+  &:selected {
+    &, &.activatable {
+      &, &:hover {
+        background-color: transparentize($fg_color, if($variant=='light', 0.85, 0.9));  
+        &, image, label { color: mix($fg_color, $text_color, 0.5); }
+      }      
+      &:backdrop {
+        color: mix($backdrop_fg_color, $backdrop_text_color, 0.15);
+        background-color: transparentize($color: $fg_color, $amount: if($variant=='light', 0.85, 0.92));
+      }
+    }    
+  }
+}

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -395,9 +395,14 @@ window.csd.unified  { border-radius: $window_radius $window_radius 0 0; }
         &, image, label { color: mix($fg_color, $text_color, 0.5); }
       }      
       &:backdrop {
-        color: mix($backdrop_fg_color, $backdrop_text_color, 0.15);
+        &, image, label { color: $backdrop_text_color; }
         background-color: transparentize($color: $fg_color, $amount: if($variant=='light', 0.85, 0.92));
       }
     }    
+  }
+}
+.nautilus-window.sidebar-row {
+  &:backdrop {
+    &, image, label { opacity: $_placesidebar_icons_opacity; }
   }
 }


### PR DESCRIPTION
After we've aligned our button styling to upstream the theme suddenly felt a bit too bulky.
Reducing the button shadows opacity for normal and hover for all three themes by 0.05 and changing the sidebar row selection from orange + white focus ring to light gray + orange focus ring helps.

Closes #2373 

Pictures can be seen here: https://github.com/ubuntu/yaru/issues/2373#issuecomment-701519737

And here:  https://github.com/ubuntu/yaru/issues/2373#issuecomment-701431601

And here: https://github.com/ubuntu/yaru/issues/2373#issuecomment-701522049