### PR TITLE
calendar-other-month-day color shall not change if the day has an event.

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
@@ -153,9 +153,11 @@
   }
 
   .calendar-day-with-events {
-    color: lighten($fg_color,10%);
-    font-weight: bold;
     background-image: url("resource:///org/gnome/shell/theme/calendar-today.svg");
+    &.calendar-work-day:not(.calendar-other-month-day) {
+       color: lighten($fg_color,10%);
+       font-weight: bold;
+    }
   }
 
   .calendar-other-month-day {


### PR DESCRIPTION
"calendar-other-month-day" with event has a different color than
"calendar-other-month-day" without an event.

"calendar-other-month-day" is a special day, like non-working day, and
should not have a different color, or it would be mistaken for an
in-current-month working day.

Prevent this changing the color of a day with an event only if not a
"calendar-other-month-day".

Closes: #2164