### PR TITLE
added symlinks to alarm-centerd-symbolic, globe-centered-symbolic for gnome-clocks

### DIFF
--- a/icons/Suru/scalable/actions/globe-centered-symbolic.svg
+++ b/icons/Suru/scalable/actions/globe-centered-symbolic.svg
@@ -1,0 +1,1 @@
+globe-symbolic.svg

--- a/icons/Suru/scalable/status/alarm-centered-symbolic.svg
+++ b/icons/Suru/scalable/status/alarm-centered-symbolic.svg
@@ -1,0 +1,1 @@
+alarm-symbolic.svg

--- a/icons/src/symlinks/symbolic/actions.list
+++ b/icons/src/symlinks/symbolic/actions.list
@@ -8,6 +8,7 @@ format-indent-less-symbolic.svg format-indent-more-rtl-symbolic.svg
 format-indent-less-symbolic.svg format-indent-more-symbolic-rtl.svg
 format-indent-more-symbolic.svg format-indent-less-rtl-symbolic.svg
 format-indent-more-symbolic.svg format-indent-less-symbolic-rtl.svg
+globe-symbolic.svg globe-centered-symbolic.svg
 go-first-symbolic.svg go-first-symbolic-rtl.svg
 go-first-symbolic.svg go-last-rtl-symbolic.svg
 go-first-symbolic.svg go-last-symbolic-rtl.svg

--- a/icons/src/symlinks/symbolic/status.list
+++ b/icons/src/symlinks/symbolic/status.list
@@ -1,3 +1,4 @@
+alarm-symbolic.svg alarm-centered-symbolic.svg
 microphone-sensitivity-high-symbolic.svg audio-input-microphone-high-symbolic.svg
 microphone-sensitivity-low-symbolic.svg audio-input-microphone-low-symbolic.svg
 microphone-sensitivity-medium-symbolic.svg audio-input-microphone-medium-symbolic.svg


### PR DESCRIPTION
hi,

alarm-centerd-symbolic, globe-centered-symbolic are used in gnome-clocks

This will symlink 
**globe-symbolic.svg** to **globe-centered-symbolic.svg** in **scalable/actions**
**alarm-symbolic.svg** to **alarm-centered-symbolic.svg** in **scalable/status**

### before:

![before](https://user-images.githubusercontent.com/54065734/95000806-accf9d80-05e1-11eb-9d92-dcaa0e9eb3c6.gif)

### after:

![after](https://user-images.githubusercontent.com/54065734/95000816-b822c900-05e1-11eb-82ed-ae555f975faa.gif)



thanks !
