### PR TITLE
Backdrop text improvements

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -80,15 +80,6 @@ $ambiance: null !default;
       &.dnd { border-style: none; }
     }
 
-    .nautilus-list-view .view:selected {
-      &:backdrop {
-        &, &:dir(ltr), &:dir(rtl) {
-          &, image, label, row { color: if($variant=='light', darken($backdrop_fg_color, 7%), lighten($backdrop_fg_color, 6%)); }
-          background-color: if($variant=='light', darken($bg_color, 7%), lighten($bg_color, 6%));
-        }  
-      }
-    }
-
     notebook > header {
       background: $bg_color;
     }
@@ -141,8 +132,8 @@ $ambiance: null !default;
       }
 
       &:backdrop {
-        background-color: transparentize($fg_color, 0.8);
-        color: $backdrop_text_color;
+        background-color: $selected_bg_color;
+        color: $backdrop_selected_fg_color;
       }
     }
 }

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -108,7 +108,7 @@ $ambiance: null !default;
       border-radius: 5px;
       border: 1px solid if($ambiance, darken($headerbar_bg_color, 9%), $borders_color);
       &:backdrop { border-color: if($ambiance, $headerbar_bg_color, $backdrop_borders_color);}
-      background-color: if($ambiance, lighten($headerbar_bg_color, 3%), $bg_color);
+      background-color: if($ambiance, lighten($headerbar_bg_color, 6.5%), $bg_color);
       padding-right: 6px;
       &:backdrop { border-color: if($ambiance, darken($inkstone, 9%), $backdrop_borders_color); }
     }

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -70,7 +70,7 @@ $ambiance: null !default;
       border-left: 1px;
 
       &:hover {background-color: $bg_color;}
-      &:backdrop { background-color: if($variant=='light', #EEEFF0, $backdrop_base_color);} // It should be _backdrop_color(white); but that does not work.
+      &:backdrop { background-color: $backdrop_base_color;}
     }
 
     .nautilus-list-view .view {
@@ -78,6 +78,15 @@ $ambiance: null !default;
 
       // Hide superfluous treeview drop target indication
       &.dnd { border-style: none; }
+    }
+
+    .nautilus-list-view .view:selected {
+      &:backdrop {
+        &, &:dir(ltr), &:dir(rtl) {
+          &, image, label, row { color: if($variant=='light', darken($backdrop_fg_color, 7%), lighten($backdrop_fg_color, 6%)); }
+          background-color: if($variant=='light', darken($bg_color, 7%), lighten($bg_color, 6%));
+        }  
+      }
     }
 
     notebook > header {
@@ -101,6 +110,7 @@ $ambiance: null !default;
       &:backdrop { border-color: if($ambiance, $headerbar_bg_color, $backdrop_borders_color);}
       background-color: if($ambiance, lighten($headerbar_bg_color, 3%), $bg_color);
       padding-right: 6px;
+      &:backdrop { border-color: if($ambiance, darken($inkstone, 9%), $backdrop_borders_color); }
     }
 
     .nautilus-path-bar button {

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -57,7 +57,7 @@ $insensitive_borders_color: $borders_color;
 $backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 1%));
 $backdrop_text_color: mix($text_color, $backdrop_base_color, 80%);
 $backdrop_bg_color: $bg_color;
-$backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 50%);
+$backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 80%);
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
 $backdrop_borders_color: mix($borders_color, $bg_color, 80%);

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -13,7 +13,7 @@ headerbar,
 
   .title, label.title {
     color: $headerbar_fg_color;
-    &:backdrop { color: $backdrop_headerbar_fg_color; opacity: 0.7; }
+    &:backdrop { color: $backdrop_headerbar_fg_color; }
   }
 
   &:backdrop {

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -11,8 +11,9 @@ headerbar,
   color: $headerbar_fg_color;
   border-color: darken($headerbar_bg_color, 7%);
 
-  label .title {
+  .title, label.title {
     color: $headerbar_fg_color;
+    &:backdrop { color: $backdrop_headerbar_fg_color; opacity: 0.7; }
   }
 
   &:backdrop {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -474,6 +474,9 @@ window.background.csd.unified {
 .nautilus-window.sidebar-row, row, row:dir(ltr), row:dir(rtl) {
   outline-color: $focus_border_color;
   -gtk-outline-radius: 0;
+  &:backdrop {
+    &, image, label { color: transparentize($backdrop_fg_color, 0.04); }
+  }
   &:selected {
     &, &.activatable {
       &, &:hover {
@@ -481,7 +484,7 @@ window.background.csd.unified {
         &, image, label { color: if($variant=='light', mix($fg_color, $text_color, 0.5), $selected_fg_color); }
       }      
       &:backdrop {
-        &, image, label { color: $backdrop_text_color; }
+        &, image, label { color: transparentize($backdrop_fg_color, 0.02); }
         background-color: transparentize($color: $fg_color, $amount: if($variant=='light', 0.85, 0.92));
       }
     }    

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -475,7 +475,7 @@ window.background.csd.unified {
   outline-color: $focus_border_color;
   -gtk-outline-radius: 0;
   &:backdrop {
-    &, image, label { color: transparentize($backdrop_fg_color, 0.04); }
+    &, image, label { &:not(switch &) {color: transparentize($backdrop_fg_color, 0.04); } }
   }
   &:selected {
     &, &.activatable {
@@ -493,5 +493,14 @@ window.background.csd.unified {
 .nautilus-window.sidebar-row {
   &:backdrop {
     &, image, label { opacity: $_placesidebar_icons_opacity; }
+  }
+}
+
+// Reduce hyper prominent dark theme check switch border in backdrop
+switch {
+  &:backdrop {
+    &:checked {
+      &, slider { border-color: if($variant=='light', $checkradio_borders_color, $backdrop_borders_color); }
+    }
   }
 }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -469,30 +469,6 @@ window.background.csd.unified {
   }
 }
 
-// Align all sidebar (not treeview) row selections to upstream nautilus 
-// Upstream only applies this if the theme is "Adwaita"
-.nautilus-window.sidebar-row, row, row:dir(ltr), row:dir(rtl) {
-  outline-color: $focus_border_color;
-  -gtk-outline-radius: 0;
-  &:backdrop {
-    &, image, label { color: $backdrop_fg_color; }
-    switch image { color: transparent; }
-  }
-  &:selected {
-    &, &.activatable {
-      slider, trough, progress, button, check, radio { border-color: $borders_color; }
-      &, &:hover {
-        background-color: if($variant=='light', darken($bg_color, 7%), lighten($bg_color, 6%));
-        &, image, label { color: if($variant=='light', black, white); }
-      }      
-      &:backdrop {
-        &, image, label { color: $backdrop_fg_color; }
-        background-color: if($variant=='light', darken($backdrop_bg_color, 7%), lighten($backdrop_bg_color, 5%));
-      }
-    }    
-  }
-}
-
 // Reduce hyper prominent dark theme check switch border in backdrop
 switch {
   &:backdrop {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -475,24 +475,21 @@ window.background.csd.unified {
   outline-color: $focus_border_color;
   -gtk-outline-radius: 0;
   &:backdrop {
-    &, image, label { &:not(switch &) {color: transparentize($backdrop_fg_color, 0.04); } }
+    &, image, label { color: $backdrop_fg_color; }
+    switch image { color: transparent; }
   }
   &:selected {
     &, &.activatable {
+      slider, trough, progress, button, check, radio { border-color: $borders_color; }
       &, &:hover {
-        background-color: transparentize($fg_color, if($variant=='light', 0.85, 0.88));  
-        &, image, label { color: if($variant=='light', mix($fg_color, $text_color, 0.5), $selected_fg_color); }
+        background-color: if($variant=='light', darken($bg_color, 7%), lighten($bg_color, 6%));
+        &, image, label { color: if($variant=='light', black, white); }
       }      
       &:backdrop {
-        &, image, label { color: transparentize($backdrop_fg_color, 0.02); }
-        background-color: transparentize($color: $fg_color, $amount: if($variant=='light', 0.85, 0.92));
+        &, image, label { color: $backdrop_fg_color; }
+        background-color: if($variant=='light', darken($backdrop_bg_color, 7%), lighten($backdrop_bg_color, 5%));
       }
     }    
-  }
-}
-.nautilus-window.sidebar-row {
-  &:backdrop {
-    &, image, label { opacity: $_placesidebar_icons_opacity; }
   }
 }
 


### PR DESCRIPTION
- align all sidebars to have the same backdrop color, like the rest of the window
- fix default theme headerbar to have the intended, but never correctly set, backdrop color

Closes #2388 

Before:
![image](https://user-images.githubusercontent.com/3986894/95016442-471bf980-0653-11eb-8c50-aa355b8413de.png)

After:
Dark theme:
![grafik](https://user-images.githubusercontent.com/15329494/95023680-aba07e00-067e-11eb-9e0d-1048a065ebe2.png)
![grafik](https://user-images.githubusercontent.com/15329494/95023842-8c562080-067f-11eb-80af-0b721428d855.png)


Default theme:
![grafik](https://user-images.githubusercontent.com/15329494/95023707-cbd03d00-067e-11eb-9f41-1e3e2c22b295.png)
![grafik](https://user-images.githubusercontent.com/15329494/95023829-76486000-067f-11eb-935f-49c340c3dc3b.png)


Light theme:
![grafik](https://user-images.githubusercontent.com/15329494/95023730-e6a2b180-067e-11eb-9efa-2299b4224b95.png)
![grafik](https://user-images.githubusercontent.com/15329494/95023833-7f393180-067f-11eb-8253-4712b2af9c88.png)


@madsrh please test and see if you see stuff I've missed