### PR TITLE
Lp bug tracker

### DIFF
--- a/.github/lpbugtracker.py
+++ b/.github/lpbugtracker.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vi: set ft=python :
+"""
+LP Bug Tracker uses launchpadlib to get the Yaru-theme bugs.
+The first time, the full list is saved in a json file.
+The next times, the newly get list of LP yaru-theme bugs are compared with the ones
+stored in the json file to show if any new issue was created since last check.
+"""
+
+import os
+import json
+import argparse
+from launchpadlib.launchpad import Launchpad
+
+HOME = os.path.expanduser("~")
+CACHEDIR = os.path.join(HOME, ".launchpadlib", "cache")
+YARU_LP_BUGS_FILE = "yaru_lp_bugs.json"
+YARU_LP_BUGS_DIR = "launchpad"
+
+
+def get_lp_bugs(dest):
+    """ Get LP active bugs and save in dest as json file """
+    bugs = get_yaru_launchpad_bugs()
+    if not dest:
+        dest = YARU_LP_BUGS_FILE
+    elif os.path.isdir(dest):
+        dest = os.path.join(dest, YARU_LP_BUGS_FILE)
+
+    save_bug_list(bugs, dest)
+
+
+def diff_bugs(source, destination):
+    """Reads a list of bugs from the {source} json file,
+    compares them with the ones stored in Yaru repo and
+    save the list of the untracked bugs as json file in
+    {destination}."""
+
+    bugs_ref = get_bug_list(source)
+    if not bugs_ref:
+        print("[!] cannot find bugs in %s" % source)
+        return
+
+    bugs_stored = get_bug_list(os.path.join(YARU_LP_BUGS_DIR, YARU_LP_BUGS_FILE))
+    bugs_diff = {}
+    for id in bugs_ref:
+        if bugs_stored.get(id, None) is None:
+            print("Untracked LP bug: %s - %s" % (id, bugs_ref[id]["title"]))
+            bugs_diff[id] = bugs_ref[id]
+
+    if len(bugs_diff):
+        save_bug_list(bugs_diff, destination)
+
+
+def get_yaru_launchpad_bugs():
+    """Get a list of active bugs from Launchpad"""
+
+    lp = Launchpad.login_anonymously(
+        "Yaru LP bug checker", "production", CACHEDIR, version="devel"
+    )
+
+    ubuntu = lp.distributions["ubuntu"]
+    archive = ubuntu.main_archive
+
+    packages = archive.getPublishedSources(source_name="yaru")
+    package = ubuntu.getSourcePackage(name=packages[0].source_package_name)
+
+    bug_tasks = package.searchTasks()
+    bugs = {}
+
+    for task in bug_tasks:
+        id = str(task.bug.id)
+        title = task.title.split(": ")[1]
+        link = "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/" + str(id)
+        bugs[id] = {"title": title, "link": link}
+
+    return bugs
+
+
+def save_bug_list(bugs, destination):
+    with open(destination, "w") as f:
+        f.write(json.dumps(bugs, indent=2))
+
+
+def get_bug_list(source):
+    try:
+        with open(source, "r") as f:
+            bugs = json.loads(f.read())
+    except FileNotFoundError:
+        bugs = {}
+    return bugs
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--get-lp-bugs", action="store_true", help="get Yaru active bugs on Launchpad"
+    )
+    parser.add_argument(
+        "--diff-bugs",
+        action="store_true",
+        help="compare bug lists and save the new bugs.",
+    )
+    parser.add_argument("--destination", help="json file path to save a bug list")
+    parser.add_argument("--source", help="json file path containing a bug list to read")
+
+    args = parser.parse_args()
+
+    if args.get_lp_bugs:
+        get_lp_bugs(args.destination)
+
+    if args.diff_bugs:
+        diff_bugs(args.source, args.destination)
+
+    # lp_bugs = get_yaru_launchpad_bugs()
+    # already_stored_bugs = get_bug_list(YARU_LP_BUGS_FILE)
+
+    # lp_bugs_new = []
+    # for id in lp_bugs:
+    # if already_stored_bugs.get(id, None) is None:
+    # lp_bugs_new.append(id)
+    # print(lp_bugs_new)
+    # if len(lp_bugs_new):
+    # save_bug_list(lp_bugs, YARU_LP_BUGS_FILE)
+
+    # save_bug_list(lp_bugs)

--- a/.github/lpbugtracker.py
+++ b/.github/lpbugtracker.py
@@ -111,16 +111,3 @@ if __name__ == "__main__":
 
     if args.diff_bugs:
         diff_bugs(args.source, args.destination)
-
-    # lp_bugs = get_yaru_launchpad_bugs()
-    # already_stored_bugs = get_bug_list(YARU_LP_BUGS_FILE)
-
-    # lp_bugs_new = []
-    # for id in lp_bugs:
-    # if already_stored_bugs.get(id, None) is None:
-    # lp_bugs_new.append(id)
-    # print(lp_bugs_new)
-    # if len(lp_bugs_new):
-    # save_bug_list(lp_bugs, YARU_LP_BUGS_FILE)
-
-    # save_bug_list(lp_bugs)

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -34,16 +34,18 @@ jobs:
           rm -f ${YARU_BUGS}
           cp -a ${LP_BUGS} ${YARU_BUGS}
           [[ $(diff -q ${YARU_BUGS} ${LP_BUGS} 2>/dev/null) != 0 ]] && hasModif="true"
-          echo "::set-output name=modified::${hasModif}"
+          echo "MODIFIED_BUGS=${hasModif}" >> $GITHUB_ENV
 
           [ -f ${DIFF_BUGS} ] && hasNew="true"
-          echo "::set-output name=new::${hasNew}"
+          echo "NEW_BUGS=${hasNew}" >> $GITHUB_ENV
         env:
           YARU_BUGS: launchpad/yaru_lp_bugs.json
           LP_BUGS: /tmp/lpbugs.json
           DIFF_BUGS: /tmp/diffbugs.json
+          MODIFIED_BUGS: false
+          NEW_BUGS: false
       - name: Create or update Pull Request
-        if: steps.getlpbugs.outputs.modified == 'true'
+        if: ${{ MODIFIED_BUGS }} == 'true'
         uses: peter-evans/create-pull-request@v2
         with:
           commit-message: Update LP bug list

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -2,7 +2,7 @@ name: Report LP issue on GitHub
 on:
   push:
     paths:
-      - '.github/workflows/open-pr-on-changes.yaml'
+      - '.github/workflows/track-lp-issues.yaml'
   schedule:
     - cron: '8 0 * * *'
 

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -13,12 +13,15 @@ jobs:
 
     steps:
       # Checkout code
-      - name: add dependencies
-        run: |
-          apt update
-          apt install -y python3 python3-pip
-          pip3 install launchpadlib
       - uses: actions/checkout@v2
+      - name: Install Python 3
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install launchpadlib
       - name: Download Yaru bugs from Launchpad
         id: getlpbugs
         run: |

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -28,8 +28,8 @@ jobs:
           hasModif="false"
           hasNew="false"
 
-          python3 .github/lpbugtracker.py --get-lp-bugs --destination ${LP_BUGS}
-          python3 .github/lpbugtracker.py --diff-bugs --source ${LP_BUGS} --destination ${DIFF_BUGS}
+          python .github/lpbugtracker.py --get-lp-bugs --destination ${LP_BUGS}
+          python .github/lpbugtracker.py --diff-bugs --source ${LP_BUGS} --destination ${DIFF_BUGS}
 
           rm -f ${YARU_BUGS}
           cp -a ${LP_BUGS} ${YARU_BUGS}

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -34,18 +34,16 @@ jobs:
           rm -f ${YARU_BUGS}
           cp -a ${LP_BUGS} ${YARU_BUGS}
           [[ $(diff -q ${YARU_BUGS} ${LP_BUGS} 2>/dev/null) != 0 ]] && hasModif="true"
-          echo "MODIFIED_BUGS=${hasModif}" >> $GITHUB_ENV
+          echo "::set-output name=modified::${hasModif}"
 
           [ -f ${DIFF_BUGS} ] && hasNew="true"
-          echo "NEW_BUGS=${hasNew}" >> $GITHUB_ENV
+          echo "::set-output name=new::${hasNew}"
         env:
           YARU_BUGS: launchpad/yaru_lp_bugs.json
           LP_BUGS: /tmp/lpbugs.json
           DIFF_BUGS: /tmp/diffbugs.json
-          MODIFIED_BUGS: false
-          NEW_BUGS: false
       - name: Create or update Pull Request
-        if: ${{ MODIFIED_BUGS }} == 'true'
+        if: steps.getlpbugs.outputs.modified == 'true'
         uses: peter-evans/create-pull-request@v2
         with:
           commit-message: Update LP bug list

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -1,0 +1,51 @@
+name: Report LP issue on GitHub
+on:
+  push:
+    paths:
+      - '.github/workflows/open-pr-on-changes.yaml'
+  schedule:
+    - cron: '8 0 * * *'
+
+jobs:
+  add-lp-issues:
+    name: Port LP issues into Yaru bug tracker
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout code
+      - name: add dependencies
+        run: |
+          apt update
+          apt install -y python3 python3-pip
+          pip3 install launchpadlib
+      - uses: actions/checkout@v2
+      - name: Download Yaru bugs from Launchpad
+        id: getlpbugs
+        run: |
+          hasModif="false"
+          hasNew="false"
+
+          python3 .github/lpbugtracker.py --get-lp-bugs --destination ${LP_BUGS}
+          python3 .github/lpbugtracker.py --diff-bugs --source ${LP_BUGS} --destination ${DIFF_BUGS}
+
+          rm -f ${YARU_BUGS}
+          cp -a ${LP_BUGS} ${YARU_BUGS}
+          [[ $(diff -q ${YARU_BUGS} ${LP_BUGS} 2>/dev/null) != 0 ]] && hasModif="true"
+          echo "::set-output name=modified::${hasModif}"
+
+          [ -f ${DIFF_BUGS} ] && hasNew="true"
+          echo "::set-output name=new::${hasNew}"
+        env:
+          YARU_BUGS: launchpad/yaru_lp_bugs.json
+          LP_BUGS: /tmp/lpbugs.json
+          DIFF_BUGS: /tmp/diffbugs.json
+      - name: Create or update Pull Request
+        if: steps.getlpbugs.outputs.modified == 'true'
+        uses: peter-evans/create-pull-request@v2
+        with:
+          commit-message: Update LP bug list
+          title: Auto update list of Yaru bugs on Launchpad
+          labels: automated pr, launchpad
+          body: "The list of Yaru bugs on Launchpad on launchpad/yaru_lp_bugs.json was updated."
+          branch: launchpad-tracker-update
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/launchpad/yaru_lp_bugs.json
+++ b/launchpad/yaru_lp_bugs.json
@@ -1,0 +1,70 @@
+{
+  "1787629": {
+    "title": "\"Split out yaru-theme-gtk2\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1787629"
+  },
+  "1896334": {
+    "title": "\"SRU 3.36.6\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1896334"
+  },
+  "1899283": {
+    "title": "\"[UIFe] New Yaru theme with upstream fixes\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1899283"
+  },
+  "1795745": {
+    "title": "\"Combobox opens at wrong vertical position\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1795745"
+  },
+  "1852091": {
+    "title": "\"No icon for VirtualboxVM\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1852091"
+  },
+  "1873365": {
+    "title": "\"gedit icon is too pale\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1873365"
+  },
+  "1878998": {
+    "title": "\"Value in Yaru-dark/gnome-shell/gnome-shell.css not used\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1878998"
+  },
+  "1889991": {
+    "title": "\"Highlight for the task switcher is too subtle\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1889991"
+  },
+  "1707831": {
+    "title": "\"[enhancement] Replace/extend the \"Activities\" label with the Ubuntu icon/logo/glyph\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1707831"
+  },
+  "1787969": {
+    "title": "\"Upload yaru-theme to Debian and maintain it there\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1787969"
+  },
+  "1873346": {
+    "title": "\"Remove the grey border/background from the Files (nautilus) icon\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1873346"
+  },
+  "1875993": {
+    "title": "\"yaru-theme-icon missing category icons\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1875993"
+  },
+  "1792604": {
+    "title": "\"Installing yaru should try to remove the communitheme snap\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1792604"
+  },
+  "1842886": {
+    "title": "\"Yaru-dark shell menus and dialogs are not dark\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1842886"
+  },
+  "1857191": {
+    "title": "\"Dark themes don't work well with highlighted current line in gedit\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1857191"
+  },
+  "1871386": {
+    "title": "\"Duplicate CSS Yaru-dark gnome-shell theme\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1871386"
+  },
+  "1899261": {
+    "title": "\"gnome 3.38 app's CSD header bar buttons are cropped\"",
+    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1899261"
+  }
+}


### PR DESCRIPTION
This is an initial deploy for the resources needed to automatically
track LP issues on Yaru-theme package.

This commit contains:
- a python script that uses launchpadlib to get a list of yaru-theme
  bugs on Launchpad.
- a new GitHub action yaml file to configure the automation.
- the first copy of the json file containing the LP issues.

The automation is initially supposed to:
1. download the list of LP issues for Yaru and store them in a json file.
2. compare the above list with the one under launchpad/yaru_lp_bugs.json.
3. if the two files differs, the new one is stored and a PR is created.

A maintainer is then supposed to take the list, which contains ID, Title,
and web link, and manually check the issues, eventually adding or removing
bugs.

The python script is able to extract which bugs are actually new, and it is
possible that a future configuration will create the bugs automatically,
but this is left for future development, once this first step is working fine.