### PR TITLE
Create LP issue

### DIFF
--- a/.github/lpbugtracker.py
+++ b/.github/lpbugtracker.py
@@ -11,12 +11,14 @@ stored in the json file to show if any new issue was created since last check.
 import os
 import json
 import argparse
+import subprocess
 from launchpadlib.launchpad import Launchpad
 
 HOME = os.path.expanduser("~")
 CACHEDIR = os.path.join(HOME, ".launchpadlib", "cache")
 YARU_LP_BUGS_FILE = "yaru_lp_bugs.json"
 YARU_LP_BUGS_DIR = "launchpad"
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -38,6 +40,21 @@ def main():
 
     if args.diff_bugs:
         diff_bugs(args.source, args.destination)
+
+
+def create_issue(id, title, weblink):
+    """ Create a new Bug using HUB """
+    subprocess.run(
+        [
+            "hub",
+            "issue",
+            "create",
+            "--message",
+            "LP:#{} {}".format(id, title),
+            "--message",
+            "Reported first on Launchpad at {}".format(weblink),
+        ]
+    )
 
 
 def get_lp_bugs(dest):
@@ -70,7 +87,9 @@ def diff_bugs(source, destination):
             bugs_diff[id] = bugs_ref[id]
 
     if len(bugs_diff):
-        save_bug_list(bugs_diff, destination)
+        # save_bug_list(bugs_diff, destination)
+        for id, data in bugs_diff.items():
+            create_issue(id, data["title"], data["link"])
 
 
 def get_yaru_launchpad_bugs():
@@ -114,4 +133,3 @@ def get_bug_list(source):
 
 if __name__ == "__main__":
     main()
-

--- a/.github/lpbugtracker.py
+++ b/.github/lpbugtracker.py
@@ -46,7 +46,7 @@ def create_issue(id, title, weblink):
     """ Create a new Bug using HUB """
     subprocess.run(
         [
-            "hub",
+            ".github/hub",
             "issue",
             "create",
             "--message",

--- a/.github/lpbugtracker.py
+++ b/.github/lpbugtracker.py
@@ -18,6 +18,27 @@ CACHEDIR = os.path.join(HOME, ".launchpadlib", "cache")
 YARU_LP_BUGS_FILE = "yaru_lp_bugs.json"
 YARU_LP_BUGS_DIR = "launchpad"
 
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--get-lp-bugs", action="store_true", help="get Yaru active bugs on Launchpad"
+    )
+    parser.add_argument(
+        "--diff-bugs",
+        action="store_true",
+        help="compare bug lists and save the new bugs.",
+    )
+    parser.add_argument("--destination", help="json file path to save a bug list")
+    parser.add_argument("--source", help="json file path containing a bug list to read")
+
+    args = parser.parse_args()
+
+    if args.get_lp_bugs:
+        get_lp_bugs(args.destination)
+
+    if args.diff_bugs:
+        diff_bugs(args.source, args.destination)
+
 
 def get_lp_bugs(dest):
     """ Get LP active bugs and save in dest as json file """
@@ -92,22 +113,5 @@ def get_bug_list(source):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--get-lp-bugs", action="store_true", help="get Yaru active bugs on Launchpad"
-    )
-    parser.add_argument(
-        "--diff-bugs",
-        action="store_true",
-        help="compare bug lists and save the new bugs.",
-    )
-    parser.add_argument("--destination", help="json file path to save a bug list")
-    parser.add_argument("--source", help="json file path containing a bug list to read")
+    main()
 
-    args = parser.parse_args()
-
-    if args.get_lp_bugs:
-        get_lp_bugs(args.destination)
-
-    if args.diff_bugs:
-        diff_bugs(args.source, args.destination)

--- a/.github/lpbugtracker.py
+++ b/.github/lpbugtracker.py
@@ -50,7 +50,7 @@ def create_issue(id, title, weblink):
             "issue",
             "create",
             "--message",
-            "LP:#{} {}".format(id, title),
+            "LP#{} {}".format(id, title),
             "--message",
             "Reported first on Launchpad at {}".format(weblink),
         ]

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -42,6 +42,7 @@ jobs:
           YARU_BUGS: launchpad/yaru_lp_bugs.json
           LP_BUGS: /tmp/lpbugs.json
           DIFF_BUGS: /tmp/diffbugs.json
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create or update Pull Request
         if: steps.getlpbugs.outputs.modified == 'true'
         uses: peter-evans/create-pull-request@v2

--- a/launchpad/yaru_lp_bugs.json
+++ b/launchpad/yaru_lp_bugs.json
@@ -1,8 +1,4 @@
 {
-  "1787629": {
-    "title": "\"Split out yaru-theme-gtk2\"",
-    "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1787629"
-  },
   "1896334": {
     "title": "\"SRU 3.36.6\"",
     "link": "https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1896334"


### PR DESCRIPTION
The goal of this PR is to automatically port issues from Launchpad.
In order to do so, we use [hub](https://github.com/github/hub) inside the LP Github Action. I opted for HUB, because it is advertised as working fine inside a Github Action, reusing the GITHUB_TOKEN.

Hub is not available as debian package, nor as snap (or at least, is discouraged its use), then to avoid build from sources inside the github action, I prebuilt it in my system and uploaded it with this change. Not sure it will work fine.

The script will add only new issues, that is, issues not already saved into launchpad/yaru_lp_issues.json.