### PR TITLE
(gnome-shell): Add widget files to upstream sync script

### DIFF
--- a/gnome-shell/gnome-shell-sync.sh
+++ b/gnome-shell/gnome-shell-sync.sh
@@ -53,9 +53,44 @@ root=${data}/theme
 
 [ ! -d ${_destination} ] && echo ${_destination} folder does not exists && exit 1
 [ ! -d ${_destination}/gnome-shell-sass ] && mkdir ${_destination}/gnome-shell-sass
+[ ! -d ${_destination}/gnome-shell-sass/widgets] && mkdir ${_destination}/gnome-shell-sass/widgets
 [ ! -d ${_destination}/data ] && mkdir ${_destination}/data
 
 files=(
+  gnome-shell-sass/widgets/_a11y.scss
+  gnome-shell-sass/widgets/_app-grid.scss
+  gnome-shell-sass/widgets/_base.scss
+  gnome-shell-sass/widgets/_buttons.scss
+  gnome-shell-sass/widgets/_calendar.scss
+  gnome-shell-sass/widgets/_check-box.scss
+  gnome-shell-sass/widgets/_corner-ripple.scss
+  gnome-shell-sass/widgets/_dash.scss
+  gnome-shell-sass/widgets/_dialogs.scss
+  gnome-shell-sass/widgets/_entries.scss
+  gnome-shell-sass/widgets/_hotplug.scss
+  gnome-shell-sass/widgets/_ibus-popup.scss
+  gnome-shell-sass/widgets/_keyboard.scss
+  gnome-shell-sass/widgets/_login-dialog.scss
+  gnome-shell-sass/widgets/_looking-glass.scss
+  gnome-shell-sass/widgets/_message-list.scss
+  gnome-shell-sass/widgets/_misc.scss
+  gnome-shell-sass/widgets/_network-dialog.scss
+  gnome-shell-sass/widgets/_notifications.scss
+  gnome-shell-sass/widgets/_osd.scss
+  gnome-shell-sass/widgets/_overview.scss
+  gnome-shell-sass/widgets/_panel.scss
+  gnome-shell-sass/widgets/_popovers.scss
+  gnome-shell-sass/widgets/_screen-shield.scss
+  gnome-shell-sass/widgets/_scrollbars.scss
+  gnome-shell-sass/widgets/_search-entry.scss
+  gnome-shell-sass/widgets/_search-results.scss
+  gnome-shell-sass/widgets/_slider.scss
+  gnome-shell-sass/widgets/_switcher-popup.scss
+  gnome-shell-sass/widgets/_switches.scss
+  gnome-shell-sass/widgets/_tiled-previews.scss
+  gnome-shell-sass/widgets/_window-picker.scss
+  gnome-shell-sass/widgets/_workspace-switcher.scss
+  gnome-shell-sass/widgets/_workspace-thumbnails.scss
   gnome-shell-sass/_colors.scss
   gnome-shell-sass/_common.scss
   gnome-shell-sass/COPYING


### PR DESCRIPTION
GNOME Shell upstream has broken out widget styling into separate inherited files. Using the sync script does not fetch these files by default. This will add the new files to the list of files to fetch so that changes will be pulled in from upstream when necessary.