### PR TITLE
Sync gtk3 button metrics with upstream & groovy

### DIFF
--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -12,14 +12,14 @@ $window_radius: $button_radius + 3;
 $popover_radius: $button_radius + 2;
 
 // Optional compact sizes for buttons, headerbar and headerbar widgets
-$_sizevariant: 'compact'; //compact otherwise
+$_sizevariant: 'default'; //compact otherwise
 $_headerbar_height: if($_sizevariant=='default', 46px, 40px);
 $_entry_height: if($_sizevariant=='default', 32px, 28px);
 $_btn_pad: if($_sizevariant=='default', 4px 9px, 2px 6px);
 $_hb_btn_pad: if($_sizevariant=='default', 6px, 5px);
 $_img_btn_pad: if($_sizevariant=='default', 5px, 2px);
 $_sel_menu_pad: if($_sizevariant=='default', 6px 10px, 4px 10px);
-$_circ_btn_pad: if($_sizevariant=='default', 4px, 2px 6px);
+$_circ_btn_pad: if($_sizevariant=='default', 4px, 2px);
 $_switch_margin: if($_sizevariant=='default', 10px, 7px);
 
 * {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -337,10 +337,6 @@ treeview.view radio {
 
 treeview:hover { background: $popover_hover_color; }
 
-// Fix for slimed down circular buttons, could need a change upstream since this happens for
-// Some of the circular buttons there too
-* { & button.circular { min-width: 0; } }
-
 scale {
   slider {
     .osd & {


### PR DESCRIPTION
- in groovy we moved away from altering the upstream button sizes, because those sizes are sometimes hardcoded in gtk apps, which ends in inconsistent button sizes in the desktop (slim beneath big, or vice versa) and because it can cause newer gtk3 apps to have a stretched headerbar
- additionally because gtk-common-themes will receive the updated yaru version from groovy this change destroys the chance gtk3 snaps using yaru have different button sizes than gtk3 debs using yaru

Before:
![grafik](https://user-images.githubusercontent.com/15329494/96837135-38508780-1446-11eb-8d96-0d5262f1b985.png)


After:
![grafik](https://user-images.githubusercontent.com/15329494/96836910-edcf0b00-1445-11eb-9c93-c0575d3f72a1.png)

Closes #2447 