### PR TITLE
Symbolic for Ubuntu Software

### DIFF
--- a/icons/Suru/scalable/apps/ubuntusoftware-symbolic.svg
+++ b/icons/Suru/scalable/apps/ubuntusoftware-symbolic.svg
@@ -1,0 +1,1 @@
+software-store-symbolic.svg


### PR DESCRIPTION
Hi,

This adds symbolic for Ubuntu-Software (Snap-store) which is used in the App-Menu: (Issue: #2461)

![ubuntusoftware-after](https://user-images.githubusercontent.com/54065734/96987154-3a970c80-1540-11eb-9781-543bbeb4664e.png)