### PR TITLE
Focal groovy gtk theme button shadow sync

### DIFF
--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -12,14 +12,14 @@ $window_radius: $button_radius + 3;
 $popover_radius: $button_radius + 2;
 
 // Optional compact sizes for buttons, headerbar and headerbar widgets
-$_sizevariant: 'compact'; //compact otherwise
+$_sizevariant: 'default'; //compact otherwise
 $_headerbar_height: if($_sizevariant=='default', 46px, 40px);
 $_entry_height: if($_sizevariant=='default', 32px, 28px);
 $_btn_pad: if($_sizevariant=='default', 4px 9px, 2px 6px);
 $_hb_btn_pad: if($_sizevariant=='default', 6px, 5px);
 $_img_btn_pad: if($_sizevariant=='default', 5px, 2px);
 $_sel_menu_pad: if($_sizevariant=='default', 6px 10px, 4px 10px);
-$_circ_btn_pad: if($_sizevariant=='default', 4px, 2px 6px);
+$_circ_btn_pad: if($_sizevariant=='default', 4px, 2px);
 $_switch_margin: if($_sizevariant=='default', 10px, 7px);
 
 * {

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -199,7 +199,7 @@
     $button_fill: if($c == $bg_color, if($variant == 'light', image(lighten($c, 2%)), image(lighten($c, 4%))), image(lighten($c, 2%))) !global;
     background-image: $button_fill;
     @include _button_text_shadow($tc, $c);
-    @include _shadows(0 1px transparentize(black, 0.9));
+    @include _shadows(0 1px transparentize(black, 0.95));
   }
 
   @else if $t==hover {
@@ -220,7 +220,7 @@
       @include _button_text_shadow($tc,lighten($c, 6%));
       @include _shadows(inset 0 1px _button_hilight_color(darken($c, 2%)), $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85));
+    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.85, 0.9));
     background-image: if($c == $bg_color, if($variant == 'light', image(lighten($c, 4%)), image(lighten($c, 6%))), image(lighten($c, 4%)));
   }
 
@@ -242,7 +242,7 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.8, 0.85));
+    box-shadow: 0 1px transparentize(black, 0.95);
     background-image: image(lighten($c, 10%));
   }
 
@@ -264,7 +264,7 @@
                         $_button_edge, $_button_shadow);
     }
     background-image: image(lighten($c, 6%));
-    box-shadow: 0 1px transparentize(black, 0.8);
+    box-shadow: 0 1px transparentize(black, 0.85);
   }
 
   @else if $t==active {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -337,10 +337,6 @@ treeview.view radio {
 
 treeview:hover { background: $popover_hover_color; }
 
-// Fix for slimed down circular buttons, could need a change upstream since this happens for
-// Some of the circular buttons there too
-* { & button.circular { min-width: 0; } }
-
 scale {
   slider {
     .osd & {


### PR DESCRIPTION
I've sadly missed to also sync the corresponding button shadows for this SRU https://bugs.launchpad.net/ubuntu/+source/yaru-theme/+bug/1899731 in https://github.com/ubuntu/yaru/pull/2456

@3v1n0  is it possible to yet include it in the SRU? 

It looks like the .deb is not yet in focal

Pictures are here:

https://github.com/ubuntu/yaru/issues/2373#issuecomment-701519737
(the sidebar change is **_NOT_** included, only the button shadow)

