### PR TITLE
Added missing GTK2 dark assets

### DIFF
--- a/gtk/src/dark/gtk-2.0/assets.txt
+++ b/gtk/src/dark/gtk-2.0/assets.txt
@@ -1,6 +1,10 @@
 menu-checkbox
+menu-checkbox-hover
+menu-checkbox-insensitive
 menu-checkbox-checked
+menu-checkbox-checked-insensitive
 menu-checkbox-mixed
+menu-checkbox-mixed-insensitive
 menu-radio
 menu-radio-hover
 menu-radio-insensitive


### PR DESCRIPTION
Some assets of gtk2.0 dark theme were missing in assets.txt. I just copied them from default variant.