### PR TITLE
symlink shotwell with org.gnome.Shotwell

### DIFF
--- a/icons/Suru/16x16/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/16x16/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/16x16@2x/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/16x16@2x/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/24x24/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/24x24/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/24x24@2x/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/24x24@2x/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/256x256/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/256x256/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/256x256@2x/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/256x256@2x/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/32x32/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/32x32/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/32x32@2x/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/32x32@2x/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/48x48/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/48x48/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/48x48@2x/apps/org.gnome.Shotwell.png
+++ b/icons/Suru/48x48@2x/apps/org.gnome.Shotwell.png
@@ -1,0 +1,1 @@
+shotwell.png

--- a/icons/Suru/scalable/apps/og.gnome.Shotwell-symbolic.svg
+++ b/icons/Suru/scalable/apps/og.gnome.Shotwell-symbolic.svg
@@ -1,0 +1,1 @@
+gallery-app-symbolic.svg

--- a/icons/src/symlinks/fullcolor/apps.list
+++ b/icons/src/symlinks/fullcolor/apps.list
@@ -73,6 +73,7 @@ root-terminal-app.png gksu-root-terminal.png
 screenshot-app.png applets-screenshooter.png
 screenshot-app.png gnome-screenshot.png
 scanner.png org.gnome.SimpleScan.png
+shotwell.png org.gnome.Shotwell.png
 software-properties.png software-properties-gtk.png
 software-store.png software-center.png
 software-store.png softwarecenter.png

--- a/icons/src/symlinks/symbolic/apps.list
+++ b/icons/src/symlinks/symbolic/apps.list
@@ -40,6 +40,7 @@ gallery-app-symbolic.svg gnome-photos-symbolic.svg
 gallery-app-symbolic.svg multimedia-photo-manager-symbolic.svg
 gallery-app-symbolic.svg org.gnome.Photos-symbolic.svg
 gallery-app-symbolic.svg shotwell-symbolic.svg
+gallery-app-symbolic.svg og.gnome.Shotwell-symbolic.svg
 gnome-mines-symbolic.svg org.gnome.Mines-symbolic.svg
 gnome-mahjongg-symbolic.svg org.gnome.Mahjongg-symbolic.svg
 help-app-symbolic.svg gnome-help-symbolic.svg


### PR DESCRIPTION
hi, 

This will symlink **shotwell** with **org.gnome.Shotwell** 

**modified files:**
/icons/src/symlinks/fullcolor/apps.list 
/icons/src/symlinks/symbolic/apps.list

thanks!
