### PR TITLE
Improving Inkscape tweak tool icon

### DIFF
--- a/icons/Suru/24x24/legacy/tool-tweak.svg
+++ b/icons/Suru/24x24/legacy/tool-tweak.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -15,62 +13,77 @@
    viewBox="0 0 6.3499999 6.3500002"
    version="1.1"
    id="svg3971"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
    sodipodi:docname="tool-tweak.svg">
   <defs
      id="defs3965">
-    <linearGradient
+    <filter
        inkscape:collect="always"
-       id="linearGradient8992">
-      <stop
-         style="stop-color:#46a926;stop-opacity:1"
-         offset="0"
-         id="stop8988" />
-      <stop
-         style="stop-color:#cbe667;stop-opacity:1"
-         offset="1"
-         id="stop8990" />
-    </linearGradient>
+       style="color-interpolation-filters:sRGB"
+       id="filter2728"
+       x="-0.1055282"
+       width="1.2110564"
+       y="-0.11059038"
+       height="1.2211808">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.7400156"
+         id="feGaussianBlur2730" />
+    </filter>
     <linearGradient
+       gradientTransform="translate(-22.51124,319.64467)"
        inkscape:collect="always"
-       xlink:href="#linearGradient8992"
-       id="linearGradient8994"
-       x1="5.2921982"
-       y1="291.17914"
-       x2="1.5880314"
-       y2="295.94165"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,6.3505315,0)" />
-    <linearGradient
-       gradientTransform="matrix(-1,0,0,1,6.3505315,-4.8234639e-6)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient927"
-       id="linearGradient8994-8"
-       x1="2.7607429"
-       y1="292.11154"
-       x2="1.6650393"
-       y2="294.83585"
+       xlink:href="#linearGradient5796"
+       id="linearGradient2599-1-3-0"
+       x1="37.088387"
+       y1="-296.96707"
+       x2="37.169743"
+       y2="-318.5672"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient927">
+       id="linearGradient5796">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop5794"
          offset="0"
-         id="stop923" />
+         style="stop-color:#4d4d4d;stop-opacity:1" />
       <stop
-         id="stop933"
-         offset="0.39608327"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         id="stop931"
-         offset="0.92500001"
-         style="stop-color:#ffffff;stop-opacity:0.09803922" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         id="stop5792"
          offset="1"
-         id="stop925" />
+         style="stop-color:#151515;stop-opacity:1;" />
     </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter2766"
+       x="-0.20519365"
+       width="1.4103873"
+       y="-0.2150369"
+       height="1.4300739">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.524429"
+         id="feGaussianBlur2768" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5796"
+       id="linearGradient2964"
+       x1="132"
+       y1="-298"
+       x2="132"
+       y2="-319"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5796"
+       id="linearGradient10921"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26458334,0,0,0.26458334,-6.3592506,375.84016)"
+       x1="37.088387"
+       y1="-296.96707"
+       x2="37.169743"
+       y2="-318.5672" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -80,8 +93,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="0.99999999"
-     inkscape:cx="15.243976"
-     inkscape:cy="14.786647"
+     inkscape:cx="11.928737"
+     inkscape:cy="-3.9049411"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -90,7 +103,9 @@
      inkscape:window-height="704"
      inkscape:window-x="72"
      inkscape:window-y="27"
-     inkscape:window-maximized="1">
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:snap-global="true">
     <inkscape:grid
        type="xygrid"
        id="grid4605" />
@@ -117,19 +132,46 @@
        id="g982"
        style="display:inline;enable-background:new" />
     <path
-       style="opacity:1;vector-effect:none;fill:url(#linearGradient8994);fill-opacity:1;stroke:none;stroke-width:0.5291667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 1.8017119,291.31505 c 1.3911715,0.79777 4.0159989,0.95546 3.882454,3.04672 -0.091662,1.84844 -2.9898498,2.83062 -3.9077335,1.00528 -0.6119394,-1.11994 -2.04294169,-3.37312 -0.2228587,-4.05561 z"
-       id="path8951"
-       inkscape:connector-curvature="0" />
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter2728);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+       d="m 10.60585,5.1130296 c -1.0295105,0 -1.8878005,0.85829 -1.8878005,1.88781 v 3.7627304 0.95681 0.93101 0.95681 1.10615 l -0.54386,-0.54386 c -0.35515,-0.36509 -0.84391,-0.57147 -1.35319,-0.57151 h -0.002 c -0.60177,0.002 -1.169,0.2912 -1.52279,0.77799 l 0.0959,-0.11246 -1.23335,1.23335 1.29049,1.28681 -0.035,-0.0387 c 0.0286,0.0319 0.0581,0.0628 0.0903,0.094 l 2.82251,2.82251 0.66737,0.66737 0.26364,0.26364 c 0.43163,0.44877 1.0598905,0.65639 1.6739505,0.55306 l -0.15666,0.0129 h 6.43775 c 0.16076,0 0.31439,-0.0135 0.46273,-0.0369 0.62503,-0.0328 1.2267,-0.12904 1.82145,-0.45721 0.56617,-0.31236 0.99034,-0.82807 1.2186,-1.43613 0.21454,-0.57291 0.27285,-1.17991 0.27285,-1.85832 v -0.94422 -0.94391 -2.83172 c 0,-1.02952 -0.85847,-1.90612 -1.88782,-1.88782 -0.7431,0.0132 -0.81822,0.25132 -1.10982,0.43693 -0.031,-1.00508 -1.05793,-1.3672604 -1.7219,-1.3808404 -0.94391,0.0132 -1.09821,0.2180504 -1.42247,0.4793304 -0.46534,-0.4660704 -0.9373,-0.4660704 -1.40925,-0.4660704 -0.27678,-0.0196 -0.62201,0.0799 -0.94391,0.2414204 V 7.0008396 c 0,-1.02952 -0.8583,-1.88781 -1.88782,-1.88781 z"
+       id="path5658-9-5-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sscccccccccccccccccccscccsccsscccccss"
+       transform="matrix(0.26458334,0,0,0.26458334,-0.40315146,291.26751)" />
     <path
-       style="opacity:0.8;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.26458335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 1.8017119,291.31505 c 1.3911716,0.79777 4.0159989,0.95546 3.882454,3.04672 -0.091662,1.84844 -2.9898498,2.83062 -3.9077333,1.00528 -0.6119395,-1.11994 -2.04294189,-3.37312 -0.2228588,-4.05561 z"
-       id="path8951-5"
-       inkscape:connector-curvature="0" />
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient2599-1-3-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter2766);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+       d="m 10.48876,3.6586296 c -1.0907005,0 -2.0000005,0.9093 -2.0000005,2 v 3.98633 1.0136704 0.98633 1.01367 1.17188 l -0.57617,-0.57618 c -0.37625,-0.38678 -0.89406,-0.60543 -1.4336,-0.60547 h -0.002 c -0.63753,0.002 -1.23846,0.30851 -1.61328,0.82422 l 0.10156,-0.11914 -1.30664,1.30664 1.36719,1.36328 -0.0371,-0.041 c 0.0303,0.0338 0.0616,0.0665 0.0957,0.0996 l 2.99024,2.99024 0.70703,0.70703 0.2793,0.2793 c 0.45729,0.47544 1.1228805,0.6954 1.7734305,0.58593 l -0.16597,0.01367 h 6.82031 c 0.17031,0 0.33307,-0.0143 0.49023,-0.0391 0.66217,-0.0347 1.2996,-0.13671 1.92969,-0.48438 0.59982,-0.33093 1.04919,-0.87728 1.29102,-1.52148 0.22728,-0.60695 0.28906,-1.25002 0.28906,-1.96875 v -1.00033 -1 -3 c 0,-1.0907 -0.90948,-2.0193904 -2,-2.0000004 -0.78726,0.014 -0.86685,0.26625 -1.17578,0.4628904 -0.0328,-1.0648004 -1.12079,-1.4485104 -1.82422,-1.4628904 -1,0.014 -1.16347,0.231 -1.507,0.50781 -0.493,-0.49377 -0.993,-0.49377 -1.493,-0.49377 -0.29323,-0.0208 -0.65897,0.0847 -1,0.25577 v -3.25577 c 0,-1.0907 -0.9093,-2 -2,-2 z"
+       id="path5658-9-5-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sscccccccccccccccccccscccsccsscccccss"
+       transform="matrix(0.26458334,0,0,0.26458334,-0.48251951,291.26751)" />
     <path
-       style="opacity:0.6;vector-effect:none;fill:url(#linearGradient8994-8);fill-opacity:1;stroke:none;stroke-width:0.5291667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 1.5906153,291.44321 0.1855184,0.004 c 0.7205184,0.40244 1.700038,0.64095 2.4804687,1.02526 0.3967023,0.19535 0.7380192,0.42655 0.9689332,0.7245 0.2309138,0.29795 0.3577012,0.66131 0.3260783,1.15652 a 0.1323049,0.1323049 0 0 0 0,0.002 c -0.042473,0.85649 -0.7428753,1.52426 -1.5487428,1.75958 -0.4029337,0.11767 -0.8273492,0.12556 -1.19941,0 -0.3720608,-0.12555 -0.6931763,-0.37955 -0.907955,-0.80667 a 0.1323049,0.1323049 0 0 0 -0.00207,-0.006 c -0.3088756,-0.56528 -0.8127785,-1.40132 -1.01182459,-2.1606 -0.099523,-0.37964 -0.12082225,-0.73492 -0.0211873,-1.02319 0.0984015,-0.2847 0.31341089,-0.51587 0.73018809,-0.67593 z m 0.095085,0.2651 c -0.1315905,0.0306 -0.2525921,0.11577 -0.3545004,0.20257 -0.33516011,0.3116 -0.2589921,0.81702 -0.1477946,1.21182 0.2080307,0.69471 0.5831554,1.33184 0.9250082,1.96112 0.1536311,0.29972 0.3820533,0.59544 0.7110677,0.7245 0.4999512,0.19812 1.0757511,0.10835 1.5384074,-0.14728 0.548966,-0.27468 0.9694029,-0.85217 0.9322429,-1.48311 0.028444,-0.49221 -0.2863784,-0.92826 -0.6748942,-1.19889 -0.6416455,-0.41686 -1.3751561,-0.62968 -2.0789431,-0.91054 -0.2920285,-0.0994 -0.5641057,-0.25126 -0.8505939,-0.36019 z"
-       id="path8951-0"
-       inkscape:connector-curvature="0" />
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient10921);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+       d="m 2.3719995,292.23552 c -0.2885807,0 -0.5291667,0.24059 -0.5291667,0.52917 v 1.05472 0.2682 0.26096 0.2682 0.31006 l -0.152445,-0.15244 c -0.09955,-0.10234 -0.2365535,-0.16019 -0.3793067,-0.1602 h -5.292e-4 c -0.1686798,5.3e-4 -0.32767582,0.0816 -0.42684692,0.21807 l 0.026871,-0.0315 -0.3457152,0.34572 0.3617357,0.3607 -0.00982,-0.0109 c 0.00802,0.009 0.016298,0.0176 0.025321,0.0264 l 0.79116732,0.79117 0.187069,0.18706 0.0739,0.0739 c 0.120991,0.1258 0.2970947,0.18399 0.4692197,0.15503 l -0.04391,0.004 h 1.8045391 c 0.04506,0 0.08812,-0.004 0.1297067,-0.0103 0.175199,-0.009 0.343852,-0.0362 0.5105637,-0.12816 0.158702,-0.0876 0.277598,-0.23212 0.341582,-0.40256 0.06014,-0.16059 0.07648,-0.33074 0.07648,-0.5209 v -0.26467 -0.26458 -0.79375 c 0,-0.28858 -0.240633,-0.5343 -0.5291667,-0.52917 -0.208296,0.004 -0.229354,0.0704 -0.311091,0.12247 -0.0087,-0.28172 -0.2965427,-0.38325 -0.4826587,-0.38705 -0.2645827,0.004 -0.3078337,0.0611 -0.3987267,0.13435 -0.130439,-0.13065 -0.262731,-0.13065 -0.3950227,-0.13065 -0.07758,-0.005 -0.174352,0.0224 -0.264583,0.0677 v -0.86142 c 0,-0.28858 -0.2405857,-0.52917 -0.5291667,-0.52917 z"
+       id="path5658-9-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sscccccccccccccccccccscccsccsscccccss" />
+    <g
+       id="g12279"
+       style="display:inline;fill:url(#linearGradient2964);fill-opacity:1"
+       transform="matrix(0.26458334,0,0,0.26458334,-31.759256,376.10844)">
+      <path
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 129,76 c -0.554,0 -1,0.446 -1,1 V 80.986328 82 84 85.986328 87 87.585938 l -2.29297,-2.292969 c -0.18827,-0.19354 -0.4468,-0.302715 -0.7168,-0.302735 -0.31924,7.5e-4 -0.61895,0.15387 -0.80664,0.41211 L 123.58594,86 l 0.6582,0.65625 c 0.0157,0.0175 0.0319,0.03438 0.0488,0.05078 l 3,3 0.70703,0.707031 0.29297,0.292969 c 0.0443,0.04601 0.0953,0.08298 0.14648,0.119141 l 0.0606,0.06055 0.004,-0.01563 c 0.20114,0.119575 0.43943,0.168677 0.67578,0.128906 H 136 c 0.14347,0 0.25528,-0.02972 0.37891,-0.04883 0.58991,-0.03188 1.11786,-0.106411 1.55859,-0.34961 0.37637,-0.207659 0.67322,-0.559386 0.83789,-0.998046 C 138.93971,89.164856 139,88.643938 139,87.986328 v -1 -3.000328 -1 c 0,-0.554 -0.44605,-1.007755 -1,-1 -1,0.014 -1,1 -1,1 L 136,83 v -1.014 c 0,-0.554 -0.446,-1 -1,-1 -0.554,0 -1,0.446 -1,1 v 1 h -1 V 82.665688 81.986 c 0,-0.554 -0.37893,-0.98038 -1,-1 -0.554,0 -1,0.446 -1,1 v 1 h -1 V 81.999672 81.986 80.999672 77 c 0,-0.554 -0.446,-1 -1,-1 z"
+         transform="translate(0,-392)"
+         id="rect6325"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sscccccccccccccccccccscccsccssccssscccscccccccss" />
+    </g>
+    <path
+       style="opacity:1;fill:none;stroke:#aea795;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 0,292.76664 c 0,0 0.54051935,0.0767 0.79375001,0 0.60869019,-0.1843 0.95152149,-1.05833 1.58750009,-1.05833 0.6359786,0 0.9788098,0.87403 1.5875,1.05833 0.759692,0.23002 2.3812501,0 2.3812501,0"
+       id="path898"
+       sodipodi:nodetypes="caaac" />
+    <path
+       style="opacity:1;fill:none;stroke:#aea795;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 0,291.44372 c 0,0 0.53258303,0.0424 0.79375001,0 0.55058769,-0.0894 1.02971009,-0.52916 1.58750009,-0.52916 0.5577899,0 1.0369123,0.43981 1.5874999,0.52916 0.7835009,0.12714 2.38125,0 2.38125,0"
+       id="path898-7"
+       sodipodi:nodetypes="caaac" />
   </g>
 </svg>


### PR DESCRIPTION
Current one looks nice but metaphor isn't very clear at all... this is the tool that you use to push lines and shapes around like putty:

![image](https://user-images.githubusercontent.com/38893390/99183086-5b164900-2731-11eb-8cd2-6bd356b530f6.png)

(The icon is meant to be a blob of putty btw, lol).

This new version makes the function of the tool a lot clearer IMO, even if it's a bit drab:

![image](https://user-images.githubusercontent.com/38893390/99183109-75e8bd80-2731-11eb-8e8d-29501ad91685.png)
