### PR TITLE
fix file-lables not dim in nautilus

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -16,6 +16,10 @@ $ambiance: null !default;
    * Nautilus *
    ***********/
   .nautilus-window {
+    .nautilus-canvas-item.dim-label,
+    .nautilus-list-dim-label {
+        color: mix($text_color, $base_color);
+    }
     // keep details box visible
     // details box looks ugly when many items are selected and it floats above the orange
     background-image: none;
@@ -129,6 +133,7 @@ $ambiance: null !default;
       &:selected:not(:backdrop) {
         &:dir(ltr) { background-color: $selected_bg_color; }
         &:not(:dir(ltr)) { background-color: rgba(175, 175, 175, 0.5); }
+        color: $backdrop_selected_fg_color;
       }
 
       &:backdrop:selected {

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -133,7 +133,7 @@ $ambiance: null !default;
       &:selected:not(:backdrop) {
         &:dir(ltr) { background-color: $selected_bg_color; }
         &:not(:dir(ltr)) { background-color: rgba(175, 175, 175, 0.5); }
-        color: $backdrop_selected_fg_color;
+        color: $selected_fg_color;
       }
 
       &:backdrop:selected {


### PR DESCRIPTION
hi,

This will fix #2469, by reapplying #2102 and adding color in **.nautilus-canvas-item** to counter unreadable label when selected

**modified file:**
gtk/src/default/gtk-3.20/_apps.scss

### before:
![before](https://user-images.githubusercontent.com/54065734/99539359-283faf80-29d4-11eb-909d-aad1b7aba4ff.png)

### after:
![after](https://user-images.githubusercontent.com/54065734/99539387-3097ea80-29d4-11eb-8115-a163b14084fc.png)

thanks!
