### PR TITLE
Making network-server-symbolic more like the Yaru style

### DIFF
--- a/icons/Suru/scalable/places/network-server-symbolic.svg
+++ b/icons/Suru/scalable/places/network-server-symbolic.svg
@@ -21,7 +21,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,12 +41,13 @@
      id="namedview1201"
      showgrid="false"
      inkscape:zoom="1"
-     inkscape:cx="8"
+     inkscape:cx="12.970745"
      inkscape:cy="8"
      inkscape:window-x="72"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg1199">
+     inkscape:current-layer="svg1199"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid2431" />
@@ -54,60 +55,40 @@
   <path
      id="path1197"
      style="line-height:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#808080;marker:none"
-     d="M 4,0 C 3.342,0 2.8208125,0.05960938 2.3828125,0.22460938 1.9608757,0.37598639 1.6069147,0.67314739 1.3847656,1.0625 0.9687656,1.8145 1.015,2.7361406 1,3.9941406 V 6 v 4 2.005859 c 0.015,1.258 -0.031234,2.179641 0.3847656,2.931641 0.2221491,0.389353 0.5761101,0.686514 0.9980469,0.837891 C 2.8208125,15.940391 3.342,16 4,16 h 7 c 0.657,0 1.179187,-0.06061 1.617188,-0.224609 0.421935,-0.151378 0.775897,-0.448539 0.998046,-0.837891 C 14.03023,14.1845 13.985,13.263859 14,12.005859 V 10 6 3.9941406 C 13.985,2.7361406 14.030234,1.8155 13.615234,1.0625 13.393085,0.67314755 13.039123,0.37598658 12.617188,0.22460938 12.179187,0.06060938 11.657,0 11,0 Z m 0,1 h 7 c 0.592,0 1.005625,0.063156 1.265625,0.1601562 0.26,0.098 0.373609,0.2037188 0.474609,0.3867188 C 12.942234,1.912875 12.985,2.74 13,4 v 2 4 2 c -0.015,1.26 -0.05777,2.087125 -0.259766,2.453125 -0.101,0.183 -0.214609,0.288719 -0.474609,0.386719 C 12.005625,14.93684 11.592,15 11,15 H 4 C 3.408,15 2.994375,14.93684 2.734375,14.839844 2.474375,14.742844 2.3597656,14.637125 2.2597656,14.453125 2.057766,14.087125 2.015,13.26 2,12 V 10 6 4 C 2.015,2.74 2.0577656,1.912875 2.2597656,1.546875 2.3597656,1.362875 2.474375,1.2571563 2.734375,1.1601562 2.994375,1.0631563 3.408,1 4,1 Z"
-     sodipodi:nodetypes="sccccccccssccccccccsssscsccccscsssccccccss" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3057"
-     cx="4"
-     cy="4"
-     r="1" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3057-6"
-     cx="4"
-     cy="8"
-     r="1" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3057-7"
-     cx="4"
-     cy="12"
-     r="1" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3080"
-     cx="6.5"
-     cy="4.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3082"
-     cx="8.5"
-     cy="4.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3080-5"
-     cx="6.5"
-     cy="8.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3082-3"
-     cx="8.5"
-     cy="8.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3080-56"
-     cx="6.5"
-     cy="12.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3082-2"
-     cx="8.5"
-     cy="12.5"
-     r="0.5" />
+     d="M 4,0 C 3.3420002,-4.8193552e-4 2.8208125,0.05960938 2.3828125,0.22460938 1.9608757,0.37598639 1.6069147,0.67314739 1.3847656,1.0625 0.96876563,1.8145 1.015,2.7361406 1,3.9941406 V 4.9335938 C 1.2863297,4.6578872 1.6220223,4.4362916 2,4.296875 V 4 C 2.015,2.74 2.0577656,1.912875 2.2597656,1.546875 2.3597656,1.362875 2.474375,1.2571563 2.734375,1.1601562 2.994375,1.0631563 3.4080002,0.9995664 4,1 l 8,0.00586 c 0.592,4.336e-4 1.005625,0.063156 1.265625,0.1601562 0.26,0.098 0.373609,0.2037188 0.474609,0.3867188 0.202,0.366 0.244766,1.193125 0.259766,2.453125 V 4.3007812 C 14.377993,4.440068 14.713803,4.661669 15,4.9375 V 4 C 14.985,2.742 15.030234,1.8213594 14.615234,1.0683594 14.393085,0.67900692 14.039122,0.38184595 13.617188,0.23046875 13.179187,0.06646875 12.657,0.00634058 12,0.00585938 Z"
+     sodipodi:nodetypes="scccccccssscsccccccss" />
+  <path
+     id="path869"
+     style="line-height:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#808080;stroke-width:1.00182;marker:none"
+     d="M 3.985438,10 C 3.3250426,9.9995181 2.8019582,10.05961 2.3623627,10.224609 1.9388916,10.375986 1.583641,10.673147 1.3606833,11.0625 1.0684704,11.588814 1.0178367,12.250337 1,13 c 0.017835,0.749663 0.068478,1.411186 0.3606833,1.9375 0.2229577,0.389353 0.5782073,0.686514 1.0016794,0.837891 0.4395955,0.165 0.9626799,0.224127 1.6230753,0.224609 l 8.029124,0.0059 c 0.659392,4.82e-4 1.183479,-0.06061 1.623075,-0.224609 0.423469,-0.151378 0.778722,-0.448539 1.00168,-0.837891 C 14.931413,14.41521 14.982084,13.75152 15,13 c -0.01831,-0.74631 -0.07006,-1.406226 -0.360683,-1.931641 -0.222958,-0.389352 -0.57821,-0.686513 -1.00168,-0.83789 -0.439595,-0.16404 -0.963683,-0.224128 -1.623075,-0.22461 z m 0,1 8.029124,0.0059 c 0.594155,4.34e-4 1.009286,0.06316 1.270232,0.160157 0.260947,0.098 0.37497,0.203718 0.476337,0.386718 0.13748,0.248193 0.189862,0.783783 0.221508,1.447266 -0.03146,0.669403 -0.08327,1.209421 -0.221508,1.458984 -0.101367,0.183 -0.21539,0.288719 -0.476337,0.386719 -0.260946,0.097 -0.676077,0.16059 -1.270232,0.160156 L 3.985438,15 C 3.3912829,14.999566 2.9761521,14.93684 2.7152055,14.839844 2.454259,14.742844 2.3392328,14.637125 2.2388687,14.453125 2.1010087,14.204274 2.0489157,13.666437 2.0173613,13 2.0489157,12.33356 2.1010147,11.795754 2.2388687,11.546875 2.3392328,11.362875 2.454259,11.257156 2.7152055,11.160156 2.9761521,11.063156 3.3912829,10.999566 3.985438,11 Z" />
+  <g
+     id="g1012"
+     style="opacity:0.503452"
+     transform="translate(0,-4.9999967)" />
+  <path
+     id="path1197-27"
+     style="line-height:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#808080;marker:none"
+     d="M 4,5.0000029 C 3.3420002,4.9995209 2.8208125,5.0596123 2.3828125,5.2246123 1.9608757,5.3759893 1.6069147,5.6731503 1.3847656,6.0625029 0.96876563,6.8145029 1.015,7.7361435 1,8.9941435 v 0.9394534 c 0.2863297,-0.275707 0.6220223,-0.497302 1,-0.636719 v -0.296875 c 0.015,-1.26 0.057766,-2.087125 0.2597656,-2.453125 0.1,-0.184 0.2146094,-0.2897187 0.4746094,-0.3867188 0.26,-0.097 0.6736252,-0.1605898 1.265625,-0.1601562 l 8,0.00586 c 0.592,4.336e-4 1.005625,0.063156 1.265625,0.1601562 0.26,0.098 0.373609,0.2037188 0.474609,0.3867188 0.202,0.366 0.244766,1.193125 0.259766,2.453125 v 0.294921 c 0.377993,0.139287 0.713803,0.360888 1,0.636719 v -0.9375 C 14.985,7.7420029 15.03023,6.8213623 14.615234,6.0683623 14.393085,5.6790098 14.039122,5.3818488 13.617188,5.2304716 13.179187,5.0664716 12.657,5.0063435 12,5.0058623 Z"
+     sodipodi:nodetypes="scccccccssscsccccccss" />
+  <rect
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1035"
+     width="2"
+     height="1"
+     x="11"
+     y="3" />
+  <rect
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1035-0"
+     width="2"
+     height="1"
+     x="11"
+     y="8" />
+  <rect
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1035-9"
+     width="2"
+     height="1"
+     x="11"
+     y="13" />
 </svg>

--- a/icons/Suru/scalable/places/network-server-symbolic.svg
+++ b/icons/Suru/scalable/places/network-server-symbolic.svg
@@ -1,10 +1,113 @@
-<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg">
-    <g fill="gray">
-        <path d="M10 3h3v1h-3z"/>
-        <path color="#000" d="M1 0v4h1V1h12v3h1V0z" fill-rule="evenodd" font-family="sans-serif" font-weight="400" overflow="visible" style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal"/>
-        <path d="M10 8h3v1h-3z"/>
-        <path color="#000" d="M1 5v4h1V6h12v3h1V5z" fill-rule="evenodd" font-family="sans-serif" font-weight="400" overflow="visible" style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal"/>
-        <path d="M10 13h3v1h-3z"/>
-        <path color="#000" d="M1 10v6h14v-6zm1 1h12v4H2z" fill-rule="evenodd" font-family="sans-serif" font-weight="400" overflow="visible" style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal"/>
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg1199"
+   sodipodi:docname="network-server-symbolic.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata1205">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1203" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview1201"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1199">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2431" />
+  </sodipodi:namedview>
+  <path
+     id="path1197"
+     style="line-height:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#808080;marker:none"
+     d="M 4,0 C 3.342,0 2.8208125,0.05960938 2.3828125,0.22460938 1.9608757,0.37598639 1.6069147,0.67314739 1.3847656,1.0625 0.9687656,1.8145 1.015,2.7361406 1,3.9941406 V 6 v 4 2.005859 c 0.015,1.258 -0.031234,2.179641 0.3847656,2.931641 0.2221491,0.389353 0.5761101,0.686514 0.9980469,0.837891 C 2.8208125,15.940391 3.342,16 4,16 h 7 c 0.657,0 1.179187,-0.06061 1.617188,-0.224609 0.421935,-0.151378 0.775897,-0.448539 0.998046,-0.837891 C 14.03023,14.1845 13.985,13.263859 14,12.005859 V 10 6 3.9941406 C 13.985,2.7361406 14.030234,1.8155 13.615234,1.0625 13.393085,0.67314755 13.039123,0.37598658 12.617188,0.22460938 12.179187,0.06060938 11.657,0 11,0 Z m 0,1 h 7 c 0.592,0 1.005625,0.063156 1.265625,0.1601562 0.26,0.098 0.373609,0.2037188 0.474609,0.3867188 C 12.942234,1.912875 12.985,2.74 13,4 v 2 4 2 c -0.015,1.26 -0.05777,2.087125 -0.259766,2.453125 -0.101,0.183 -0.214609,0.288719 -0.474609,0.386719 C 12.005625,14.93684 11.592,15 11,15 H 4 C 3.408,15 2.994375,14.93684 2.734375,14.839844 2.474375,14.742844 2.3597656,14.637125 2.2597656,14.453125 2.057766,14.087125 2.015,13.26 2,12 V 10 6 4 C 2.015,2.74 2.0577656,1.912875 2.2597656,1.546875 2.3597656,1.362875 2.474375,1.2571563 2.734375,1.1601562 2.994375,1.0631563 3.408,1 4,1 Z"
+     sodipodi:nodetypes="sccccccccssccccccccsssscsccccscsssccccccss" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3057"
+     cx="4"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3057-6"
+     cx="4"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3057-7"
+     cx="4"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3080"
+     cx="6.5"
+     cy="4.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3082"
+     cx="8.5"
+     cy="4.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3080-5"
+     cx="6.5"
+     cy="8.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3082-3"
+     cx="8.5"
+     cy="8.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3080-56"
+     cx="6.5"
+     cy="12.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3082-2"
+     cx="8.5"
+     cy="12.5"
+     r="0.5" />
 </svg>

--- a/icons/src/scalable/places/network-server-symbolic.svg
+++ b/icons/src/scalable/places/network-server-symbolic.svg
@@ -1,10 +1,113 @@
-<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg">
-    <g fill="gray">
-        <path d="M10 3h3v1h-3z"/>
-        <path color="#000" d="M1 0v4h1V1h12v3h1V0z" fill-rule="evenodd" font-family="sans-serif" font-weight="400" overflow="visible" style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal" white-space="normal"/>
-        <path d="M10 8h3v1h-3z"/>
-        <path color="#000" d="M1 5v4h1V6h12v3h1V5z" fill-rule="evenodd" font-family="sans-serif" font-weight="400" overflow="visible" style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal" white-space="normal"/>
-        <path d="M10 13h3v1h-3z"/>
-        <path color="#000" d="M1 10v6h14v-6zm1 1h12v4H2z" fill-rule="evenodd" font-family="sans-serif" font-weight="400" overflow="visible" style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal" white-space="normal"/>
-    </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg1199"
+   sodipodi:docname="network-server-symbolic.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <metadata
+     id="metadata1205">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1203" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview1201"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1199">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2431" />
+  </sodipodi:namedview>
+  <path
+     id="path1197"
+     style="line-height:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#808080;marker:none"
+     d="M 4,0 C 3.342,0 2.8208125,0.05960938 2.3828125,0.22460938 1.9608757,0.37598639 1.6069147,0.67314739 1.3847656,1.0625 0.9687656,1.8145 1.015,2.7361406 1,3.9941406 V 6 v 4 2.005859 c 0.015,1.258 -0.031234,2.179641 0.3847656,2.931641 0.2221491,0.389353 0.5761101,0.686514 0.9980469,0.837891 C 2.8208125,15.940391 3.342,16 4,16 h 7 c 0.657,0 1.179187,-0.06061 1.617188,-0.224609 0.421935,-0.151378 0.775897,-0.448539 0.998046,-0.837891 C 14.03023,14.1845 13.985,13.263859 14,12.005859 V 10 6 3.9941406 C 13.985,2.7361406 14.030234,1.8155 13.615234,1.0625 13.393085,0.67314755 13.039123,0.37598658 12.617188,0.22460938 12.179187,0.06060938 11.657,0 11,0 Z m 0,1 h 7 c 0.592,0 1.005625,0.063156 1.265625,0.1601562 0.26,0.098 0.373609,0.2037188 0.474609,0.3867188 C 12.942234,1.912875 12.985,2.74 13,4 v 2 4 2 c -0.015,1.26 -0.05777,2.087125 -0.259766,2.453125 -0.101,0.183 -0.214609,0.288719 -0.474609,0.386719 C 12.005625,14.93684 11.592,15 11,15 H 4 C 3.408,15 2.994375,14.93684 2.734375,14.839844 2.474375,14.742844 2.3597656,14.637125 2.2597656,14.453125 2.057766,14.087125 2.015,13.26 2,12 V 10 6 4 C 2.015,2.74 2.0577656,1.912875 2.2597656,1.546875 2.3597656,1.362875 2.474375,1.2571563 2.734375,1.1601562 2.994375,1.0631563 3.408,1 4,1 Z"
+     sodipodi:nodetypes="sccccccccssccccccccsssscsccccscsssccccccss" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3057"
+     cx="4"
+     cy="4"
+     r="1" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3057-6"
+     cx="4"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3057-7"
+     cx="4"
+     cy="12"
+     r="1" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3080"
+     cx="6.5"
+     cy="4.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3082"
+     cx="8.5"
+     cy="4.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3080-5"
+     cx="6.5"
+     cy="8.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3082-3"
+     cx="8.5"
+     cy="8.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3080-56"
+     cx="6.5"
+     cy="12.5"
+     r="0.5" />
+  <circle
+     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
+     id="path3082-2"
+     cx="8.5"
+     cy="12.5"
+     r="0.5" />
 </svg>

--- a/icons/src/scalable/places/network-server-symbolic.svg
+++ b/icons/src/scalable/places/network-server-symbolic.svg
@@ -41,12 +41,13 @@
      id="namedview1201"
      showgrid="false"
      inkscape:zoom="1"
-     inkscape:cx="8"
+     inkscape:cx="12.970745"
      inkscape:cy="8"
      inkscape:window-x="72"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg1199">
+     inkscape:current-layer="svg1199"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid2431" />
@@ -54,60 +55,40 @@
   <path
      id="path1197"
      style="line-height:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#808080;marker:none"
-     d="M 4,0 C 3.342,0 2.8208125,0.05960938 2.3828125,0.22460938 1.9608757,0.37598639 1.6069147,0.67314739 1.3847656,1.0625 0.9687656,1.8145 1.015,2.7361406 1,3.9941406 V 6 v 4 2.005859 c 0.015,1.258 -0.031234,2.179641 0.3847656,2.931641 0.2221491,0.389353 0.5761101,0.686514 0.9980469,0.837891 C 2.8208125,15.940391 3.342,16 4,16 h 7 c 0.657,0 1.179187,-0.06061 1.617188,-0.224609 0.421935,-0.151378 0.775897,-0.448539 0.998046,-0.837891 C 14.03023,14.1845 13.985,13.263859 14,12.005859 V 10 6 3.9941406 C 13.985,2.7361406 14.030234,1.8155 13.615234,1.0625 13.393085,0.67314755 13.039123,0.37598658 12.617188,0.22460938 12.179187,0.06060938 11.657,0 11,0 Z m 0,1 h 7 c 0.592,0 1.005625,0.063156 1.265625,0.1601562 0.26,0.098 0.373609,0.2037188 0.474609,0.3867188 C 12.942234,1.912875 12.985,2.74 13,4 v 2 4 2 c -0.015,1.26 -0.05777,2.087125 -0.259766,2.453125 -0.101,0.183 -0.214609,0.288719 -0.474609,0.386719 C 12.005625,14.93684 11.592,15 11,15 H 4 C 3.408,15 2.994375,14.93684 2.734375,14.839844 2.474375,14.742844 2.3597656,14.637125 2.2597656,14.453125 2.057766,14.087125 2.015,13.26 2,12 V 10 6 4 C 2.015,2.74 2.0577656,1.912875 2.2597656,1.546875 2.3597656,1.362875 2.474375,1.2571563 2.734375,1.1601562 2.994375,1.0631563 3.408,1 4,1 Z"
-     sodipodi:nodetypes="sccccccccssccccccccsssscsccccscsssccccccss" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3057"
-     cx="4"
-     cy="4"
-     r="1" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3057-6"
-     cx="4"
-     cy="8"
-     r="1" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3057-7"
-     cx="4"
-     cy="12"
-     r="1" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3080"
-     cx="6.5"
-     cy="4.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3082"
-     cx="8.5"
-     cy="4.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3080-5"
-     cx="6.5"
-     cy="8.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3082-3"
-     cx="8.5"
-     cy="8.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3080-56"
-     cx="6.5"
-     cy="12.5"
-     r="0.5" />
-  <circle
-     style="fill:#808080;stroke-width:8;stroke-linecap:round;stroke-linejoin:round"
-     id="path3082-2"
-     cx="8.5"
-     cy="12.5"
-     r="0.5" />
+     d="M 4,0 C 3.3420002,-4.8193552e-4 2.8208125,0.05960938 2.3828125,0.22460938 1.9608757,0.37598639 1.6069147,0.67314739 1.3847656,1.0625 0.96876563,1.8145 1.015,2.7361406 1,3.9941406 V 4.9335938 C 1.2863297,4.6578872 1.6220223,4.4362916 2,4.296875 V 4 C 2.015,2.74 2.0577656,1.912875 2.2597656,1.546875 2.3597656,1.362875 2.474375,1.2571563 2.734375,1.1601562 2.994375,1.0631563 3.4080002,0.9995664 4,1 l 8,0.00586 c 0.592,4.336e-4 1.005625,0.063156 1.265625,0.1601562 0.26,0.098 0.373609,0.2037188 0.474609,0.3867188 0.202,0.366 0.244766,1.193125 0.259766,2.453125 V 4.3007812 C 14.377993,4.440068 14.713803,4.661669 15,4.9375 V 4 C 14.985,2.742 15.030234,1.8213594 14.615234,1.0683594 14.393085,0.67900692 14.039122,0.38184595 13.617188,0.23046875 13.179187,0.06646875 12.657,0.00634058 12,0.00585938 Z"
+     sodipodi:nodetypes="scccccccssscsccccccss" />
+  <path
+     id="path869"
+     style="line-height:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#808080;stroke-width:1.00182;marker:none"
+     d="M 3.985438,10 C 3.3250426,9.9995181 2.8019582,10.05961 2.3623627,10.224609 1.9388916,10.375986 1.583641,10.673147 1.3606833,11.0625 1.0684704,11.588814 1.0178367,12.250337 1,13 c 0.017835,0.749663 0.068478,1.411186 0.3606833,1.9375 0.2229577,0.389353 0.5782073,0.686514 1.0016794,0.837891 0.4395955,0.165 0.9626799,0.224127 1.6230753,0.224609 l 8.029124,0.0059 c 0.659392,4.82e-4 1.183479,-0.06061 1.623075,-0.224609 0.423469,-0.151378 0.778722,-0.448539 1.00168,-0.837891 C 14.931413,14.41521 14.982084,13.75152 15,13 c -0.01831,-0.74631 -0.07006,-1.406226 -0.360683,-1.931641 -0.222958,-0.389352 -0.57821,-0.686513 -1.00168,-0.83789 -0.439595,-0.16404 -0.963683,-0.224128 -1.623075,-0.22461 z m 0,1 8.029124,0.0059 c 0.594155,4.34e-4 1.009286,0.06316 1.270232,0.160157 0.260947,0.098 0.37497,0.203718 0.476337,0.386718 0.13748,0.248193 0.189862,0.783783 0.221508,1.447266 -0.03146,0.669403 -0.08327,1.209421 -0.221508,1.458984 -0.101367,0.183 -0.21539,0.288719 -0.476337,0.386719 -0.260946,0.097 -0.676077,0.16059 -1.270232,0.160156 L 3.985438,15 C 3.3912829,14.999566 2.9761521,14.93684 2.7152055,14.839844 2.454259,14.742844 2.3392328,14.637125 2.2388687,14.453125 2.1010087,14.204274 2.0489157,13.666437 2.0173613,13 2.0489157,12.33356 2.1010147,11.795754 2.2388687,11.546875 2.3392328,11.362875 2.454259,11.257156 2.7152055,11.160156 2.9761521,11.063156 3.3912829,10.999566 3.985438,11 Z" />
+  <g
+     id="g1012"
+     style="opacity:0.503452"
+     transform="translate(0,-4.9999967)" />
+  <path
+     id="path1197-27"
+     style="line-height:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;isolation:auto;mix-blend-mode:normal;solid-color:#000000;solid-opacity:1;fill:#808080;marker:none"
+     d="M 4,5.0000029 C 3.3420002,4.9995209 2.8208125,5.0596123 2.3828125,5.2246123 1.9608757,5.3759893 1.6069147,5.6731503 1.3847656,6.0625029 0.96876563,6.8145029 1.015,7.7361435 1,8.9941435 v 0.9394534 c 0.2863297,-0.275707 0.6220223,-0.497302 1,-0.636719 v -0.296875 c 0.015,-1.26 0.057766,-2.087125 0.2597656,-2.453125 0.1,-0.184 0.2146094,-0.2897187 0.4746094,-0.3867188 0.26,-0.097 0.6736252,-0.1605898 1.265625,-0.1601562 l 8,0.00586 c 0.592,4.336e-4 1.005625,0.063156 1.265625,0.1601562 0.26,0.098 0.373609,0.2037188 0.474609,0.3867188 0.202,0.366 0.244766,1.193125 0.259766,2.453125 v 0.294921 c 0.377993,0.139287 0.713803,0.360888 1,0.636719 v -0.9375 C 14.985,7.7420029 15.03023,6.8213623 14.615234,6.0683623 14.393085,5.6790098 14.039122,5.3818488 13.617188,5.2304716 13.179187,5.0664716 12.657,5.0063435 12,5.0058623 Z"
+     sodipodi:nodetypes="scccccccssscsccccccss" />
+  <rect
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1035"
+     width="2"
+     height="1"
+     x="11"
+     y="3" />
+  <rect
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1035-0"
+     width="2"
+     height="1"
+     x="11"
+     y="8" />
+  <rect
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1035-9"
+     width="2"
+     height="1"
+     x="11"
+     y="13" />
 </svg>


### PR DESCRIPTION
The current server symbol is very angular and not really in keeping with the current Yaru style:

![image](https://user-images.githubusercontent.com/38893390/104198061-b1e08c00-541d-11eb-854e-4c377f1555ac.png)

This suggested change makes it a) more like the other symbols and b) more like the full colour server icon:

![image](https://user-images.githubusercontent.com/38893390/104198235-e3595780-541d-11eb-8b42-8c919bbeeb8e.png)

Just an idea so don't worry if you don't like it :+1: 