### PR TITLE
Add .ini file mimetype

### DIFF
--- a/icons/Suru/16x16/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/16x16/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/Suru/16x16@2x/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/16x16@2x/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/Suru/24x24/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/24x24/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/Suru/24x24@2x/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/24x24@2x/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/Suru/256x256/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/256x256/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/Suru/256x256@2x/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/256x256@2x/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/Suru/32x32/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/32x32/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/Suru/32x32@2x/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/32x32@2x/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/Suru/48x48/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/48x48/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/Suru/48x48@2x/mimetypes/application-x-wine-extension-ini.png
+++ b/icons/Suru/48x48@2x/mimetypes/application-x-wine-extension-ini.png
@@ -1,0 +1,1 @@
+text-x-generic.png

--- a/icons/src/symlinks/fullcolor/mimetypes.list
+++ b/icons/src/symlinks/fullcolor/mimetypes.list
@@ -107,6 +107,7 @@ text-x-c.png text-x-csrc.png
 text-x-cpp.png text-x-c++.png
 text-x-cpp.png text-x-c++src.png
 text-x-cpp.png text-x-cppsrc.png
+text-x-generic.png application-x-wine-extension-ini.png
 text-x-generic.png text-plain.png
 text-x-generic.png text-x-plain.png
 text-x-generic.png text.png


### PR DESCRIPTION
Link **text-x-generic** to **application-x-wine-extension-ini**

![Capture d’écran du 2021-01-12 15-24-13](https://user-images.githubusercontent.com/36476595/104327102-b6bf4180-54ea-11eb-98c3-5b3929836c61.png)

.ini file (like **php.ini**) are using **text-x-generic** in normal install of Ubuntu. When installing Wine, they get the **application/x-wine-extension-ini** one. As these files are just plain text, link them to **text-x-generic** restore the default behavior.

Closes #2533 
Related to #2334