### PR TITLE
icons: Use Ambiant-MATE icons with Yaru-MATE

### DIFF
--- a/gtk/src/meson.build
+++ b/gtk/src/meson.build
@@ -24,7 +24,7 @@ foreach flavour: flavours
   elif flavour == 'light'
     conf_data.set('IconTheme', 'Radiant-MATE')
   else
-    conf_data.set('IconTheme', 'Radiant-MATE')
+    conf_data.set('IconTheme', 'Ambiant-MATE')
   endif
 
   configure_file(input: 'index.theme.in',

--- a/icons/meson.build
+++ b/icons/meson.build
@@ -26,7 +26,7 @@ foreach flavour: ['default', 'dark', 'light']
   elif flavour == 'light'
     conf_data.set('InheritThemes', 'Radiant-MATE,ubuntu-mono-light,Humanity,gnome,hicolor,mate')
   else
-    conf_data.set('InheritThemes', 'Radiant-MATE,ubuntu-mono-light,Humanity,gnome,hicolor,mate')
+    conf_data.set('InheritThemes', 'Ambiant,ubuntu-mono-light,Humanity,gnome,hicolor,mate')
   endif
 
   foreach theme: themes_f

--- a/icons/meson.build
+++ b/icons/meson.build
@@ -26,7 +26,7 @@ foreach flavour: ['default', 'dark', 'light']
   elif flavour == 'light'
     conf_data.set('InheritThemes', 'Radiant-MATE,ubuntu-mono-light,Humanity,gnome,hicolor,mate')
   else
-    conf_data.set('InheritThemes', 'Ambiant,ubuntu-mono-light,Humanity,gnome,hicolor,mate')
+    conf_data.set('InheritThemes', 'Ambiant-MATE,ubuntu-mono-light,Humanity,gnome,hicolor,mate')
   endif
 
   foreach theme: themes_f


### PR DESCRIPTION
Upstream has merged dark panels for the Yaru-MATE theme and Ambiant-MATE icons match a dark panel.
