### PR TITLE
darker mate panel colors for default+dark

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -682,13 +682,14 @@ SheetStyleDialog.unity-force-quit { background-color: $bg_color; }
 /***********
 * Mate *
 ***********/
-
-$_base_bg_color: if($ambiance==true, $headerbar_bg_color, if($variant=='light', $bg_color, $headerbar_bg_color));
-$_base_fg_color:  if($ambiance==true, $headerbar_fg_color, if($variant=='light', $fg_color, $headerbar_fg_color));
-$_base_insensitive_fg_color: if($ambiance==true, lighten($headerbar_fg_color, 10%), if($variant=='light', $insensitive_fg_color, lighten($headerbar_fg_color, 10%)));
+$_panel_bg_color: lighten($jet, 2%);
+$_panel_fg_color: darken($porcelain, 2%);
+$_base_bg_color: if($ambiance==true, $_panel_bg_color, if($variant=='light', $bg_color, $_panel_bg_color));
+$_base_fg_color:  if($ambiance==true, $_panel_fg_color, if($variant=='light', $fg_color, $_panel_fg_color));
+$_base_insensitive_fg_color: if($ambiance==true, lighten($_panel_fg_color, 10%), if($variant=='light', $insensitive_fg_color, lighten($_panel_fg_color, 10%)));
 $_base_border_color: if($ambiance==true, $headerbar_border_color, if($variant=='light', $borders_color, $headerbar_border_color));
-$_base_hover_color: if($ambiance==true, lighten($headerbar_bg_color, 4%), if($variant=='light', darken($bg_color, 4%), lighten($headerbar_bg_color, 4%)));
-$_base_active_color: if($ambiance==true, darken($headerbar_bg_color, 4%), if($variant=='light', darken($bg_color, 4%), darken($headerbar_bg_color, 4%)));
+$_base_hover_color: if($ambiance==true, lighten($_panel_bg_color, 4%), if($variant=='light', darken($bg_color, 4%), lighten($_panel_bg_color, 4%)));
+$_base_active_color: if($ambiance==true, darken($_panel_bg_color, 4%), if($variant=='light', darken($bg_color, 4%), darken($_panel_bg_color, 4%)));
 $_wm_border: if($variant=='light', transparentize(black, 0.77), transparentize($borders_color, 0.1));
 $_wm_border_backdrop: if($variant=='light', transparentize(black, 0.82), transparentize($borders_color, 0.1));
 $_wm_shadow: 0 3px 9px 1px transparentize(black, 0.5), 0 0 0 1px $_wm_border; //doing borders with box-shadow;


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/15329494/105332724-34fba200-5bd5-11eb-9e79-e7e8210f1590.png)

After:
![grafik](https://user-images.githubusercontent.com/15329494/105332812-4cd32600-5bd5-11eb-8b7a-c95008fcf1f0.png)
@flexiondotorg could you double check?