### PR TITLE
Mate: axe border-radii of classic dialog buttons

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -1143,3 +1143,16 @@ scrollbar {
   background-image: none;
   background-color: transparent;
 }
+
+// Axing the border-radii for classic (not csd) dialog buttons
+// So we don't end up with rounded buttons in a squared dialog frame
+messagedialog.background:not(.csd)  {
+  box.dialog-vbox.vertical {
+    button {
+      &, &:hover, &:active, &:checked, &:backdrop {
+        border-radius: 0;
+        -gtk-outline-radius: 0;
+      }
+    }
+  }  
+}


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/15329494/105575951-c272f980-5d6f-11eb-812a-1498505dbbed.png)
