### PR TITLE
Add symbolic link for 'htop'

### DIFF
--- a/icons/Suru/16x16/apps/htop.png
+++ b/icons/Suru/16x16/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/16x16@2x/apps/htop.png
+++ b/icons/Suru/16x16@2x/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/24x24/apps/htop.png
+++ b/icons/Suru/24x24/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/24x24@2x/apps/htop.png
+++ b/icons/Suru/24x24@2x/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/256x256/apps/htop.png
+++ b/icons/Suru/256x256/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/256x256@2x/apps/htop.png
+++ b/icons/Suru/256x256@2x/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/32x32/apps/htop.png
+++ b/icons/Suru/32x32/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/32x32@2x/apps/htop.png
+++ b/icons/Suru/32x32@2x/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/48x48/apps/htop.png
+++ b/icons/Suru/48x48/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/48x48@2x/apps/htop.png
+++ b/icons/Suru/48x48@2x/apps/htop.png
@@ -1,0 +1,1 @@
+system-monitor-app.png

--- a/icons/Suru/scalable/apps/htop-symbolic.svg
+++ b/icons/Suru/scalable/apps/htop-symbolic.svg
@@ -1,0 +1,1 @@
+system-monitor-app-symbolic.svg

--- a/icons/src/symlinks/fullcolor/apps.list
+++ b/icons/src/symlinks/fullcolor/apps.list
@@ -87,6 +87,7 @@ system-file-manager.png nautilus.png
 system-file-manager.png org.gnome.Nautilus.png
 system-monitor-app.png utilities-system-monitor.png
 system-monitor-app.png gnome-system-monitor.png
+system-monitor-app.png htop.png
 system-monitor-app.png org.gnome.SystemMonitor.png
 system-settings.png gnome-control-center.png
 system-settings.png preferences-desktop.png

--- a/icons/src/symlinks/symbolic/apps.list
+++ b/icons/src/symlinks/symbolic/apps.list
@@ -89,6 +89,7 @@ system-file-manager-symbolic.svg nautilus-symbolic.svg
 system-file-manager-symbolic.svg org.gnome.Nautilus-symbolic.svg
 system-monitor-app-symbolic.svg utilities-system-monitor-symbolic.svg
 system-monitor-app-symbolic.svg gnome-system-monitor-symbolic.svg
+system-monitor-app-symbolic.svg htop-symbolic.svg
 system-monitor-app-symbolic.svg org.gnome.SystemMonitor-symbolic.svg
 system-settings-symbolic.svg gnome-control-center-symbolic.svg
 system-settings-symbolic.svg preferences-desktop-symbolic.svg


### PR DESCRIPTION
Supplemental pull request for https://github.com/ubuntu/yaru/issues/2517

/cc @Feichtmeier because he suggested symlink https://github.com/ubuntu/yaru/issues/2517#issuecomment-750221951 (and possibly cherry-pick to Focal?)