### PR TITLE
metacity: dialog and modal fixes. Shade support added.

### DIFF
--- a/metacity/src/dark/metacity-1/minimize_focused_prelight.svg
+++ b/metacity/src/dark/metacity-1/minimize_focused_prelight.svg
@@ -42,7 +42,7 @@
      id="namedview4581"
      showgrid="true"
      inkscape:zoom="25.416667"
-     inkscape:cx="5.8032788"
+     inkscape:cx="-0.39344243"
      inkscape:cy="11.881967"
      inkscape:window-x="333"
      inkscape:window-y="283"
@@ -63,7 +63,7 @@
        id="circle4571"
        style="fill:#4A4A4A;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
        id="g4575">
       <rect
          transform="rotate(-45)"
@@ -72,7 +72,7 @@
          width="0.26458001"
          height="2.6458001"
          id="rect4573"
-         style="fill:#F7F7F7;stroke-width:0.19721" />
+         style="fill:#f7f7f7;stroke-width:0.19721" />
     </g>
   </g>
 </svg>

--- a/metacity/src/default/metacity-1/minimize_focused_prelight.svg
+++ b/metacity/src/default/metacity-1/minimize_focused_prelight.svg
@@ -47,7 +47,7 @@
      inkscape:window-x="333"
      inkscape:window-y="283"
      inkscape:window-maximized="0"
-     inkscape:current-layer="g4577"
+     inkscape:current-layer="g4575"
      inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
@@ -67,12 +67,12 @@
        id="g4575">
       <rect
          transform="rotate(-45)"
-         x="-206.78"
+         x="-206.51541"
          y="208.69"
          width="0.26458001"
          height="2.6458001"
          id="rect4573"
-         style="fill:#F7F7F7;stroke-width:0.19721" />
+         style="fill:#f7f7f7;stroke-width:0.19721" />
     </g>
   </g>
 </svg>

--- a/metacity/src/light/metacity-1/minimize_focused_prelight.svg
+++ b/metacity/src/light/metacity-1/minimize_focused_prelight.svg
@@ -63,7 +63,7 @@
        id="circle4571"
        style="fill:#C6C6C6;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
        id="g4575">
       <rect
          transform="rotate(-45)"
@@ -72,7 +72,7 @@
          width="0.26458001"
          height="2.6458001"
          id="rect4573"
-         style="fill:#3D3D3D;stroke-width:0.19721" />
+         style="fill:#3d3d3d;stroke-width:0.19721" />
     </g>
   </g>
 </svg>

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -604,7 +604,7 @@
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
-		<piece position="overlay" draw_ops="border_focused" />
+		<piece position="overlay" draw_ops="rounded_border_focused" />
 		<button function="close" state="normal" draw_ops="close_focused" />
 		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
 		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
@@ -637,7 +637,7 @@
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
-		<piece position="overlay" draw_ops="border_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_unfocused" />
 		<button function="close" state="normal" draw_ops="close_unfocused" />
 		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
 		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
@@ -670,7 +670,7 @@
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
-		<piece position="overlay" draw_ops="border_focused" />
+		<piece position="overlay" draw_ops="rounded_border_focused" />
 		<button function="close" state="normal" draw_ops="close_focused" />
 		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
 		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
@@ -703,7 +703,7 @@
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
-		<piece position="overlay" draw_ops="border_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_unfocused" />
 		<button function="close" state="normal" draw_ops="close_unfocused" />
 		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
 		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
@@ -815,7 +815,7 @@
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
-		<piece position="overlay" draw_ops="border_focused" />
+		<piece position="overlay" draw_ops="rounded_border_focused" />
 		<button function="close" state="normal"><draw_ops></draw_ops></button>
 		<button function="close" state="pressed"><draw_ops></draw_ops></button>
 		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
@@ -844,7 +844,7 @@
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
-		<piece position="overlay" draw_ops="border_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_unfocused" />
 		<button function="close" state="normal"><draw_ops></draw_ops></button>
 		<button function="close" state="pressed"><draw_ops></draw_ops></button>
 		<button function="maximize" state="normal"><draw_ops></draw_ops></button>

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -28,7 +28,7 @@
 		<distance name="bottom_height" value="1" />
 		<distance name="left_titlebar_edge" value="8" />
 		<distance name="right_titlebar_edge" value="0" />
-		<distance name="title_vertical_pad" value="0" />
+		<distance name="title_vertical_pad" value="1" />
 		<aspect_ratio name="button" value="1" />
 		<border name="title_border" left="0" right="0" top="8" bottom="8" />
 		<border name="button_border" left="4" right="8" top="3" bottom="3" />

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -1412,8 +1412,8 @@
 		<frame focus="no" state="tiled_left" style="tiled_left_unfocused" />
 		<frame focus="yes" state="tiled_right" style="tiled_right_focused" />
 		<frame focus="no" state="tiled_right" style="tiled_right_unfocused" />
-		<frame focus="yes" state="shaded" style="normal_focused" />
-		<frame focus="no" state="shaded" style="normal_unfocused" />
+		<frame focus="yes" state="shaded" style="normal_shaded_focused" />
+		<frame focus="no" state="shaded" style="normal_shaded_unfocused" />
 		<frame focus="yes" state="maximized_and_shaded" style="normal_max_shaded_focused" />
 		<frame focus="no" state="maximized_and_shaded" style="normal_max_shaded_unfocused" />
 	</frame_style_set>
@@ -1423,8 +1423,8 @@
 		<frame focus="no" state="normal" resize="both" style="dialog_unfocused" />
 		<frame focus="yes" state="maximized" style="blank" />
 		<frame focus="no" state="maximized" style="blank" />
-		<frame focus="yes" state="shaded" style="dialog_focused" />
-		<frame focus="no" state="shaded" style="dialog_unfocused" />
+		<frame focus="yes" state="shaded" style="dialog_shaded_focused" />
+		<frame focus="no" state="shaded" style="dialog_shaded_unfocused" />
 		<frame focus="yes" state="maximized_and_shaded" style="blank" />
 		<frame focus="no" state="maximized_and_shaded" style="blank" />
 	</frame_style_set>
@@ -1434,8 +1434,8 @@
 		<frame focus="no" state="normal" resize="both" style="modal_dialog_unfocused" />
 		<frame focus="yes" state="maximized" style="blank" />
 		<frame focus="no" state="maximized" style="blank" />
-		<frame focus="yes" state="shaded" style="modal_dialog_focused" />
-		<frame focus="no" state="shaded" style="modal_dialog_unfocused" />
+		<frame focus="yes" state="shaded" style="modal_dialog_shaded_focused" />
+		<frame focus="no" state="shaded" style="modal_dialog_shaded_unfocused" />
 		<frame focus="yes" state="maximized_and_shaded" style="blank" />
 		<frame focus="no" state="maximized_and_shaded" style="blank" />
 	</frame_style_set>
@@ -1445,8 +1445,8 @@
 		<frame focus="no" state="normal" resize="both" style="utility_unfocused" />
 		<frame focus="yes" state="maximized" style="blank" />
 		<frame focus="no" state="maximized" style="blank" />
-		<frame focus="yes" state="shaded" style="utility_focused" />
-		<frame focus="no" state="shaded" style="utility_unfocused" />
+		<frame focus="yes" state="shaded" style="utility_shaded_focused" />
+		<frame focus="no" state="shaded" style="utility_shaded_unfocused" />
 		<frame focus="yes" state="maximized_and_shaded" style="blank" />
 		<frame focus="no" state="maximized_and_shaded" style="blank" />
 	</frame_style_set>

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -197,6 +197,60 @@
 		<line color="C_titlebar_highlight_unfocused" x1="width-3" x2="width-3" y1="3" y2="3" />
 	</draw_ops>
 
+	<draw_ops name="rounded_border_shaded_focused">
+		<line color="C_titlebar_border_focused" x1="2" y1="0" x2="width-3" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="1" y1="top_height-1" x2="width-1" y2="top_height-1" />
+		<line color="C_titlebar_border_focused" x1="0" y1="height-1" x2="width-1" y2="height-1" />
+		<line color="C_titlebar_border_focused" x1="0" y1="2" x2="0" y2="height-2" />
+		<line color="C_titlebar_border_focused" x1="width-1" y1="2" x2="width-1" y2="height-2" />
+
+		<!-- left arch -->
+		<line color="C_titlebar_border_focused" x1="0" x2="4" y1="1" y2="1" />
+		<line color="C_titlebar_border_focused" x1="0" x2="2" y1="2" y2="2" />
+		<line color="C_titlebar_border_focused" x1="0" x2="1" y1="3" y2="3" />
+		<line color="C_titlebar_border_focused" x1="0" x2="1" y1="4" y2="4" />
+
+		<!-- right arch -->
+		<line color="C_titlebar_border_focused" x1="width-5" x2="width" y1="1" y2="1" />
+		<line color="C_titlebar_border_focused" x1="width-3" x2="width" y1="2" y2="2" />
+		<line color="C_titlebar_border_focused" x1="width-2" x2="width" y1="3" y2="3" />
+		<line color="C_titlebar_border_focused" x1="width-2" x2="width" y1="4" y2="4" />
+
+		<!-- title bar top highlight -->
+		<line color="C_titlebar_highlight_focused" x1="5" y1="1" x2="width-6" y2="1" />
+		<line color="C_titlebar_highlight_focused" x1="3" x2="4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_focused" x1="2" x2="2" y1="3" y2="3" />
+		<line color="C_titlebar_highlight_focused" x1="width-5" x2="width-4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_focused" x1="width-3" x2="width-3" y1="3" y2="3" />
+	</draw_ops>
+
+	<draw_ops name="rounded_border_shaded_unfocused">
+		<line color="C_titlebar_border_unfocused" x1="2" y1="0" x2="width-3" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="1" y1="top_height-1" x2="width-1" y2="top_height-1" />
+		<line color="C_titlebar_border_unfocused" x1="0" y1="height-1" x2="width-1" y2="height-1" />
+		<line color="C_titlebar_border_unfocused" x1="0" y1="2" x2="0" y2="height-2" />
+		<line color="C_titlebar_border_unfocused" x1="width-1" y1="2" x2="width-1" y2="height-2" />
+
+		<!-- left arch -->
+		<line color="C_titlebar_border_unfocused" x1="0" x2="4" y1="1" y2="1" />
+		<line color="C_titlebar_border_unfocused" x1="0" x2="2" y1="2" y2="2" />
+		<line color="C_titlebar_border_unfocused" x1="0" x2="1" y1="3" y2="3" />
+		<line color="C_titlebar_border_unfocused" x1="0" x2="1" y1="4" y2="4" />
+
+		<!-- right arch -->
+		<line color="C_titlebar_border_unfocused" x1="width-5" x2="width" y1="1" y2="1" />
+		<line color="C_titlebar_border_unfocused" x1="width-3" x2="width" y1="2" y2="2" />
+		<line color="C_titlebar_border_unfocused" x1="width-2" x2="width" y1="3" y2="3" />
+		<line color="C_titlebar_border_unfocused" x1="width-2" x2="width" y1="4" y2="4" />
+
+		<!-- title bar top highlight -->
+		<line color="C_titlebar_highlight_unfocused" x1="5" y1="1" x2="width-6" y2="1" />
+		<line color="C_titlebar_highlight_unfocused" x1="3" x2="4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_unfocused" x1="2" x2="2" y1="3" y2="3" />
+		<line color="C_titlebar_highlight_unfocused" x1="width-5" x2="width-4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_unfocused" x1="width-3" x2="width-3" y1="3" y2="3" />
+	</draw_ops>
+
 	<!-- maximized -->
 	<draw_ops name="max_border_focused">
 		<line color="C_titlebar_highlight_focused" x1="0" y1="0" x2="width" y2="0" />

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -26,12 +26,12 @@
 		<distance name="left_width" value="1" />
 		<distance name="right_width" value="1" />
 		<distance name="bottom_height" value="1" />
-		<distance name="left_titlebar_edge" value="8" />
-		<distance name="right_titlebar_edge" value="0" />
+		<distance name="left_titlebar_edge" value="7" />
+		<distance name="right_titlebar_edge" value="7" />
 		<distance name="title_vertical_pad" value="1" />
 		<aspect_ratio name="button" value="1" />
 		<border name="title_border" left="0" right="0" top="8" bottom="8" />
-		<border name="button_border" left="4" right="8" top="3" bottom="3" />
+		<border name="button_border" left="11" right="0" top="3" bottom="3" />
 	</frame_geometry>
 	<frame_geometry name="normal_shaded" rounded_bottom_left="true" rounded_bottom_right="true" parent="normal" />
 

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -60,10 +60,6 @@
 		<distance name="left_width" value="1" />
 	</frame_geometry>
 
-	<!-- small window -->
-	<frame_geometry name="small" parent="normal">
-	</frame_geometry>
-
 	<!-- no buttons -->
 	<frame_geometry name="nobuttons" hide_buttons="true" parent="normal">
 	</frame_geometry>
@@ -84,14 +80,6 @@
 		<distance name="bottom_height" value="0" />
 		<border name="title_border" left="0" right="0" top="0" bottom="0" />
 		<border name="button_border" left="0" right="0" top="0" bottom="0" />
-	</frame_geometry>
-
-	<!-- modal -->
-	<frame_geometry name="modal" title_scale="medium" hide_buttons="true" rounded_top_left="true" rounded_top_right="true" parent="small">
-	</frame_geometry>
-
-	<!-- attached -->
-	<frame_geometry name="attached" hide_buttons="true" parent="normal">
 	</frame_geometry>
 
 	<!-- title -->
@@ -617,7 +605,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="modal_dialog_focused" geometry="modal">
+	<frame_style name="modal_dialog_focused" geometry="nobuttons">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_attached_focused" />
 		<piece position="title" draw_ops="title_focused" />
@@ -650,7 +638,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="modal_dialog_unfocused" geometry="modal">
+	<frame_style name="modal_dialog_unfocused" geometry="nobuttons">
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
@@ -683,7 +671,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="utility_focused" geometry="small">
+	<frame_style name="utility_focused" geometry="normal">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
@@ -716,7 +704,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="utility_unfocused" geometry="small">
+	<frame_style name="utility_unfocused" geometry="normal">
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
@@ -828,7 +816,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="attached_focused" geometry="attached">
+	<frame_style name="attached_focused" geometry="nobuttons">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_attached_focused" />
 		<piece position="title" draw_ops="title_focused" />
@@ -857,7 +845,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="attached_unfocused" geometry="attached">
+	<frame_style name="attached_unfocused" geometry="nobuttons">
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_attached_focused" />
 		<piece position="title" draw_ops="title_unfocused" />

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -455,6 +455,72 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
+	<frame_style name="normal_shaded_focused" geometry="normal_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="normal_shaded_unfocused" geometry="normal_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
 	<frame_style name="normal_max_focused" geometry="max">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
@@ -653,6 +719,72 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
+	<frame_style name="dialog_shaded_focused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="dialog_shaded_unfocused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
 	<frame_style name="modal_dialog_focused" geometry="nobuttons">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
@@ -719,6 +851,72 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
+	<frame_style name="modal_dialog_shaded_focused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="modal_dialog_shaded_unfocused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
 	<frame_style name="utility_focused" geometry="normal">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
@@ -757,6 +955,72 @@
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
 		<piece position="overlay" draw_ops="rounded_border_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="utility_shaded_focused" geometry="normal_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="utility_shaded_unfocused" geometry="normal_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
 		<button function="close" state="normal" draw_ops="close_unfocused" />
 		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
 		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
@@ -898,6 +1162,64 @@
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
 		<piece position="overlay" draw_ops="rounded_border_unfocused" />
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="attached_shaded_focused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="attached_shaded_unfocused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
 		<button function="close" state="normal"><draw_ops></draw_ops></button>
 		<button function="close" state="pressed"><draw_ops></draw_ops></button>
 		<button function="maximize" state="normal"><draw_ops></draw_ops></button>

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -42,11 +42,9 @@
 	</frame_geometry>
 
 	<!-- tiled -->
-	<frame_geometry name="tiled_left_active" parent="max">
-	</frame_geometry>
+	<frame_geometry name="tiled_left_active" parent="max" />
 
-	<frame_geometry name="tiled_left_inactive" parent="max">
-	</frame_geometry>
+	<frame_geometry name="tiled_left_inactive" parent="max" />
 
 	<!-- tiled_right have a left_width so a border is always rendered so when
 		 two windows are tiled next to each other a single pixel line
@@ -61,8 +59,7 @@
 	</frame_geometry>
 
 	<!-- no buttons -->
-	<frame_geometry name="nobuttons" hide_buttons="true" parent="normal">
-	</frame_geometry>
+	<frame_geometry name="nobuttons" hide_buttons="true" parent="normal" />
 
 	<!-- border -->
 	<frame_geometry name="border" has_title="false" rounded_top_left="false" rounded_top_right="false" parent="normal">

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -26,8 +26,8 @@
 		<distance name="left_width" value="1" />
 		<distance name="right_width" value="1" />
 		<distance name="bottom_height" value="1" />
-		<distance name="left_titlebar_edge" value="7" />
-		<distance name="right_titlebar_edge" value="7" />
+		<distance name="left_titlebar_edge" value="6" />
+		<distance name="right_titlebar_edge" value="6" />
 		<distance name="title_vertical_pad" value="1" />
 		<aspect_ratio name="button" value="1" />
 		<border name="title_border" left="0" right="0" top="8" bottom="8" />

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -33,6 +33,11 @@
 		<border name="title_border" left="0" right="0" top="8" bottom="8" />
 		<border name="button_border" left="4" right="8" top="3" bottom="3" />
 	</frame_geometry>
+	<frame_geometry name="normal_shaded" rounded_bottom_left="true" rounded_bottom_right="true" parent="normal" />
+
+	<!-- no buttons -->
+	<frame_geometry name="nobuttons" hide_buttons="true" parent="normal" />
+	<frame_geometry name="nobuttons_shaded" rounded_bottom_left="true" rounded_bottom_right="true" parent="nobuttons" />
 
 	<!-- maximized window -->
 	<frame_geometry name="max" title_scale="medium" rounded_top_left="false" rounded_top_right="false" parent="normal">
@@ -57,9 +62,6 @@
 	<frame_geometry name="tiled_right_inactive" parent="max">
 		<distance name="left_width" value="1" />
 	</frame_geometry>
-
-	<!-- no buttons -->
-	<frame_geometry name="nobuttons" hide_buttons="true" parent="normal" />
 
 	<!-- border -->
 	<frame_geometry name="border" has_title="false" rounded_top_left="false" rounded_top_right="false" parent="normal">

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -97,7 +97,7 @@
 	</draw_ops>
 
 	<draw_ops name="entire_background_unfocused">
-		<include name="entire_background_focused" />
+		<rectangle color="C_titlebar_unfocused" x="0" y="0" width="width" height="height" filled="true" />
 	</draw_ops>
 
 	<draw_ops name="titlebar_fill_focused">
@@ -114,11 +114,6 @@
 
 	<draw_ops name="titlebar_tiled_unfocused">
 		<rectangle color="C_titlebar_unfocused" x="0" y="0" width="width" height="height" filled="true" />
-	</draw_ops>
-
- 	<!-- titlebar for attached and modal dialogs -->
-	<draw_ops name="titlebar_fill_attached_focused">
-		<include name="entire_background_focused" />
 	</draw_ops>
 
 	<draw_ops name="border_focused">
@@ -607,7 +602,7 @@
 
 	<frame_style name="modal_dialog_focused" geometry="nobuttons">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
-		<piece position="titlebar" draw_ops="titlebar_fill_attached_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
 		<piece position="overlay" draw_ops="border_focused" />
 		<button function="close" state="normal" draw_ops="close_focused" />
@@ -818,7 +813,7 @@
 
 	<frame_style name="attached_focused" geometry="nobuttons">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
-		<piece position="titlebar" draw_ops="titlebar_fill_attached_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
 		<piece position="overlay" draw_ops="border_focused" />
 		<button function="close" state="normal"><draw_ops></draw_ops></button>
@@ -847,7 +842,7 @@
 
 	<frame_style name="attached_unfocused" geometry="nobuttons">
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
-		<piece position="titlebar" draw_ops="titlebar_fill_attached_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
 		<piece position="overlay" draw_ops="border_unfocused" />
 		<button function="close" state="normal"><draw_ops></draw_ops></button>


### PR DESCRIPTION
This pull request refactors/consolidates frame geometry to simplify the Metacity (Marco) theme maintenance. 

Dialog, modal and utility windows now correctly render the title bar and borders in all three variants of the theme.

Shaded windows are now styled. Title bar text clipping is fixed. Focused minimise button pre-light offset has been corrected. Buttons are placed at predictable offsets. 