### PR TITLE
metacity: Fix theme previews and loading

### DIFF
--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -316,7 +316,7 @@
 		<image filename="maximize_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
 	</draw_ops>
 	<draw_ops name="maximize_focused_pressed">
-		<image filename="maximize_focused_pressed.png" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="maximize_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
 	</draw_ops>
 	<draw_ops name="maximize_unfocused">
 		<image filename="maximize_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
@@ -336,7 +336,7 @@
 		<image filename="unmaximize_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
 	</draw_ops>
 	<draw_ops name="unmaximize_focused_pressed">
-		<image filename="unmaximize_focused_pressed.png" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="unmaximize_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
 	</draw_ops>
 	<draw_ops name="unmaximize_unfocused">
 		<image filename="unmaximize_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />


### PR DESCRIPTION
Some assets still referenced non-existent .png file which prevented the Metacity (Marco) theme preview from rendering and loading.
