### PR TITLE
Update Unity window buttons and add Metacity themes

### DIFF
--- a/gtk/src/default/unity-to-metacity.sh
+++ b/gtk/src/default/unity-to-metacity.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+for FLAVOUR in default dark light; do
+    echo "${FLAVOUR}"
+    METACITY_DIR="../../../metacity/src/${FLAVOUR}/metacity-1"
+    mkdir -p "${METACITY_DIR}"
+
+    case ${FLAVOUR} in
+        default)
+            close_unfocused="636363"
+            close_unfocused_glyphs="F7F7F7"
+            focused_glyphs="F7F7F7"
+            focused_normal="323030"
+            focused_prelight="4F4F4F"
+            focused_pressed="5C5C5C"
+            unfocused_glyphs="A3A2A2"
+            unfocused_normal="3F3C3C"
+            unfocused_prelight="4F4F4F"
+            unfocused_pressed="5C5C5C"
+            ;;
+        dark)
+            close_unfocused="575757"
+            close_unfocused_glyphs="D2D2D2"
+            focused_glyphs="F7F7F7"
+            focused_normal="2C2C2C"
+            focused_prelight="4A4A4A"
+            focused_pressed="5E5E5E"
+            unfocused_glyphs="D2D2D2"
+            unfocused_normal="3E3E3E"
+            unfocused_prelight="5A5A5A"
+            unfocused_pressed="5E5E5E"
+            ;;
+        light)
+            close_unfocused="A3A3A3"
+            close_unfocused_glyphs="f9f9f9"
+            focused_glyphs="3D3D3D"
+            focused_normal="DEDEDE"
+            focused_prelight="C6C6C6"
+            focused_pressed="B5B5B5"
+            unfocused_glyphs="626262"
+            unfocused_normal="F7F7F7"
+            unfocused_prelight="dbdbdb"
+            unfocused_pressed="B5B5B5"
+            ;;
+    esac
+
+    for SVG_IN in unity/*.svg; do
+        # Skip the files we don't need for Metacity
+        SVG=$(basename "${SVG_IN}")
+
+        # If the SVG has a short name, ignore it.
+        if [[ $SVG != *"_"* ]]; then
+            continue
+        fi
+
+        # Launchers are Unity specific. Ignore.
+        if [[ $SVG == *"launcher"* ]]; then
+            continue
+        fi
+
+        # Copy the original SVG to the new location
+        cp "${SVG_IN}" "${METACITY_DIR}/"
+
+        if [[ $SVG == *"close_focused_normal"* ]]; then
+            continue
+        fi
+
+        if [[ $SVG == *"close_focused_prelight"* ]]; then
+            continue
+        fi
+
+        if [[ $SVG == *"close_focused_pressed"* ]]; then
+            continue
+        fi
+
+        if [[ $SVG == *"close_unfocused.svg"* ]]; then
+            sed -i "s/636363/${close_unfocused}/g" "${METACITY_DIR}/${SVG}"
+            sed -i "s/ffffff/${close_unfocused_glyphs}/g" "${METACITY_DIR}/${SVG}"
+            continue
+        fi
+
+        if [[ $SVG == *"focused_normal"* ]]; then
+            sed -i "s/323030/${focused_normal}/g" "${METACITY_DIR}/${SVG}"
+            sed -i "s/ffffff/${focused_glyphs}/g" "${METACITY_DIR}/${SVG}"
+            continue
+        fi
+
+        if [[ $SVG == *"_unfocused.svg"* ]]; then
+            sed -i "s/323030/${unfocused_normal}/g" "${METACITY_DIR}/${SVG}"
+            sed -i "s/ffffff/${unfocused_glyphs}/g" "${METACITY_DIR}/${SVG}"
+            continue
+        fi
+
+        # This is a special case
+        if [[ $SVG == *"close_unfocused_prelight"* ]]; then
+            if [ "${FLAVOUR}" == "dark" ]; then
+                sed -i "s/707070/636363/g" "${METACITY_DIR}/${SVG}"
+                sed -i "s/ffffff/f5f5f5/g" "${METACITY_DIR}/${SVG}"
+            elif [ "${FLAVOUR}" == "light" ]; then
+                sed -i "s/707070/b0b0b0/g" "${METACITY_DIR}/${SVG}"
+                sed -i "s/ffffff/f9f9f9/g" "${METACITY_DIR}/${SVG}"
+            fi
+            continue
+        fi
+
+        if [[ $SVG == *"unfocused_prelight"* ]]; then
+            sed -i "s/505050/${unfocused_prelight}/g" "${METACITY_DIR}/${SVG}"
+            sed -i "s/ffffff/${unfocused_glyphs}/g" "${METACITY_DIR}/${SVG}"
+            continue
+        fi
+
+        if [[ $SVG == *"focused_prelight"* ]]; then
+            sed -i "s/505050/${focused_prelight}/g" "${METACITY_DIR}/${SVG}"
+            sed -i "s/ffffff/${focused_glyphs}/g" "${METACITY_DIR}/${SVG}"
+            continue
+        fi
+
+        if [[ $SVG == *"unfocused_pressed"* ]]; then
+            sed -i "s/5c5c5c/${unfocused_pressed}/g" "${METACITY_DIR}/${SVG}"
+            if [[ $SVG == *"close_unfocused_pressed"* ]] && [ "${FLAVOUR}" == "light" ]; then
+                sed -i "s/ffffff/f9f9f9/g" "${METACITY_DIR}/${SVG}"
+            else
+                sed -i "s/ffffff/${unfocused_glyphs}/g" "${METACITY_DIR}/${SVG}"
+            fi
+            continue
+        fi
+
+        if [[ $SVG == *"focused_pressed"* ]]; then
+            sed -i "s/5c5c5c/${focused_pressed}/g" "${METACITY_DIR}/${SVG}"
+            sed -i "s/ffffff/${focused_glyphs}/g" "${METACITY_DIR}/${SVG}"
+            continue
+        fi
+    done
+done
+sync

--- a/gtk/src/default/unity/close.svg
+++ b/gtk/src/default/unity/close.svg
@@ -13,7 +13,7 @@
    viewBox="0 0 6.3499636 6.3499636"
    id="svg4636"
    sodipodi:docname="close.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4642">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
      id="namedview4638"
      showgrid="true"
      inkscape:zoom="30.341309"
      inkscape:cx="11.685857"
      inkscape:cy="9.8749984"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg4636">
+     inkscape:current-layer="g4634"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5187" />
@@ -62,9 +63,9 @@
        id="circle4626"
        style="fill:#e95420;stroke-width:0.66123003" />
     <g
-       transform="rotate(-45,2.9104,294.09)"
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
        id="g4632"
-       style="fill:#ffffff;stroke-width:0.28984001">
+       style="fill:#ffffff;stroke-width:0.28984">
       <rect
          x="1.3229001"
          y="293.95999"

--- a/gtk/src/default/unity/close_focused_normal.svg
+++ b/gtk/src/default/unity/close_focused_normal.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.3499636 6.3499636"
    id="svg4636"
-   sodipodi:docname="close.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="close_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4642">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
      id="namedview4638"
      showgrid="true"
      inkscape:zoom="30.341309"
      inkscape:cx="11.685857"
      inkscape:cy="9.8749984"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg4636">
+     inkscape:current-layer="g4634"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5187" />
@@ -62,9 +63,9 @@
        id="circle4626"
        style="fill:#e95420;stroke-width:0.66123003" />
     <g
-       transform="rotate(-45,2.9104,294.09)"
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
        id="g4632"
-       style="fill:#ffffff;stroke-width:0.28984001">
+       style="fill:#ffffff;stroke-width:0.28984">
       <rect
          x="1.3229001"
          y="293.95999"

--- a/gtk/src/default/unity/close_focused_prelight.svg
+++ b/gtk/src/default/unity/close_focused_prelight.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.3499636 6.3499636"
    id="svg4636"
-   sodipodi:docname="close.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="close_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4642">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
      id="namedview4638"
      showgrid="true"
      inkscape:zoom="30.341309"
      inkscape:cx="11.685857"
      inkscape:cy="9.8749984"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg4636">
+     inkscape:current-layer="g4634"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5187" />
@@ -62,9 +63,9 @@
        id="circle4626"
        style="fill:#fa6140;stroke-width:0.66123003" />
     <g
-       transform="rotate(-45,2.9104,294.09)"
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
        id="g4632"
-       style="fill:#ffffff;stroke-width:0.28984001">
+       style="fill:#ffffff;stroke-width:0.28984">
       <rect
          x="1.3229001"
          y="293.95999"

--- a/gtk/src/default/unity/close_focused_pressed.svg
+++ b/gtk/src/default/unity/close_focused_pressed.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.3499636 6.3499636"
    id="svg4636"
-   sodipodi:docname="close.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="close_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4642">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
      id="namedview4638"
      showgrid="true"
      inkscape:zoom="30.341309"
      inkscape:cx="11.685857"
      inkscape:cy="9.8749984"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg4636">
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5187" />
@@ -62,9 +63,9 @@
        id="circle4626"
        style="fill:#e84425;stroke-width:0.66123003" />
     <g
-       transform="rotate(-45,2.9104,294.09)"
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
        id="g4632"
-       style="fill:#ffffff;stroke-width:0.28984001">
+       style="fill:#ffffff;stroke-width:0.28984">
       <rect
          x="1.3229001"
          y="293.95999"
@@ -72,12 +73,13 @@
          height="0.26458001"
          id="rect4628" />
       <rect
-         transform="rotate(-90)"
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
          x="-295.67999"
-         y="2.7781"
-         width="3.175"
-         height="0.26458001"
-         id="rect4630" />
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/close_unfocused.svg
+++ b/gtk/src/default/unity/close_unfocused.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.3499636 6.3499636"
    id="svg4636"
-   sodipodi:docname="close.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="close_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4642">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
      id="namedview4638"
      showgrid="true"
      inkscape:zoom="30.341309"
      inkscape:cx="11.685857"
      inkscape:cy="9.8749984"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg4636">
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5187" />
@@ -62,9 +63,9 @@
        id="circle4626"
        style="fill:#636363;stroke-width:0.66123003" />
     <g
-       transform="rotate(-45,2.9104,294.09)"
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
        id="g4632"
-       style="fill:#ffffff;stroke-width:0.28984001">
+       style="fill:#ffffff;stroke-width:0.28984">
       <rect
          x="1.3229001"
          y="293.95999"
@@ -72,12 +73,13 @@
          height="0.26458001"
          id="rect4628" />
       <rect
-         transform="rotate(-90)"
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
          x="-295.67999"
-         y="2.7781"
-         width="3.175"
-         height="0.26458001"
-         id="rect4630" />
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/close_unfocused_prelight.svg
+++ b/gtk/src/default/unity/close_unfocused_prelight.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.3499636 6.3499636"
    id="svg4636"
-   sodipodi:docname="close.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="close_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4642">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
      id="namedview4638"
      showgrid="true"
      inkscape:zoom="30.341309"
      inkscape:cx="11.685857"
      inkscape:cy="9.8749984"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg4636">
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5187" />
@@ -62,9 +63,9 @@
        id="circle4626"
        style="fill:#707070;stroke-width:0.66123003" />
     <g
-       transform="rotate(-45,2.9104,294.09)"
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
        id="g4632"
-       style="fill:#ffffff;stroke-width:0.28984001">
+       style="fill:#ffffff;stroke-width:0.28984">
       <rect
          x="1.3229001"
          y="293.95999"
@@ -72,12 +73,13 @@
          height="0.26458001"
          id="rect4628" />
       <rect
-         transform="rotate(-90)"
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
          x="-295.67999"
-         y="2.7781"
-         width="3.175"
-         height="0.26458001"
-         id="rect4630" />
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/close_unfocused_pressed.svg
+++ b/gtk/src/default/unity/close_unfocused_pressed.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.3499636 6.3499636"
    id="svg4636"
-   sodipodi:docname="close.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="close_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4642">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
      id="namedview4638"
      showgrid="true"
      inkscape:zoom="30.341309"
      inkscape:cx="11.685857"
      inkscape:cy="9.8749984"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4636">
+     inkscape:window-x="785"
+     inkscape:window-y="32"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5187" />
@@ -62,9 +63,9 @@
        id="circle4626"
        style="fill:#636363;stroke-width:0.66123003" />
     <g
-       transform="rotate(-45,2.9104,294.09)"
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
        id="g4632"
-       style="fill:#ffffff;stroke-width:0.28984001">
+       style="fill:#ffffff;stroke-width:0.28984">
       <rect
          x="1.3229001"
          y="293.95999"
@@ -72,12 +73,13 @@
          height="0.26458001"
          id="rect4628" />
       <rect
-         transform="rotate(-90)"
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
          x="-295.67999"
-         y="2.7781"
-         width="3.175"
-         height="0.26458001"
-         id="rect4630" />
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/maximize.svg
+++ b/gtk/src/default/unity/maximize.svg
@@ -13,7 +13,7 @@
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
    sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="2486"
+     inkscape:window-height="1374"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
      inkscape:cx="14.9944"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-x="74"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,55 @@
        id="circle5255"
        style="fill:#323030;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5257"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/maximize_focused_normal.svg
+++ b/gtk/src/default/unity/maximize_focused_normal.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="maximize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
      inkscape:cx="14.9944"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="643"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,55 @@
        id="circle5255"
        style="fill:#323030;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5257"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/maximize_focused_prelight.svg
+++ b/gtk/src/default/unity/maximize_focused_prelight.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="maximize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
      inkscape:cx="14.9944"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="660"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,55 @@
        id="circle5255"
        style="fill:#505050;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5257"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/maximize_focused_pressed.svg
+++ b/gtk/src/default/unity/maximize_focused_pressed.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="maximize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
      inkscape:cx="14.9944"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="663"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,55 @@
        id="circle5255"
        style="fill:#5c5c5c;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5257"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/maximize_unfocused.svg
+++ b/gtk/src/default/unity/maximize_unfocused.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="maximize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
      inkscape:cx="14.9944"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="693"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,55 @@
        id="circle5255"
        style="fill:#323030;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5257"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/maximize_unfocused_prelight.svg
+++ b/gtk/src/default/unity/maximize_unfocused_prelight.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="maximize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
      inkscape:cx="14.9944"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="751"
+     inkscape:window-y="151"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,55 @@
        id="circle5255"
        style="fill:#505050;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5257"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/maximize_unfocused_pressed.svg
+++ b/gtk/src/default/unity/maximize_unfocused_pressed.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="maximize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
      inkscape:cx="14.9944"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="850"
+     inkscape:window-y="190"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,55 @@
        id="circle5255"
        style="fill:#5c5c5c;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5257"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/menu.svg
+++ b/gtk/src/default/unity/menu.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2488"
+     inkscape:window-height="1374"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="72"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#323030;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#ffffff;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/gtk/src/default/unity/menu_focused_normal.svg
+++ b/gtk/src/default/unity/menu_focused_normal.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="642"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#323030;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#ffffff;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/gtk/src/default/unity/menu_focused_prelight.svg
+++ b/gtk/src/default/unity/menu_focused_prelight.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="659"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#505050;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#ffffff;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/gtk/src/default/unity/menu_focused_pressed.svg
+++ b/gtk/src/default/unity/menu_focused_pressed.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="662"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5c5c5c;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#ffffff;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/gtk/src/default/unity/menu_unfocused.svg
+++ b/gtk/src/default/unity/menu_unfocused.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="692"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#323030;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#ffffff;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/gtk/src/default/unity/menu_unfocused_prelight.svg
+++ b/gtk/src/default/unity/menu_unfocused_prelight.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="750"
+     inkscape:window-y="117"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#505050;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#ffffff;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/gtk/src/default/unity/menu_unfocused_pressed.svg
+++ b/gtk/src/default/unity/menu_unfocused_pressed.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="849"
+     inkscape:window-y="156"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5c5c5c;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#ffffff;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/gtk/src/default/unity/minimize.svg
+++ b/gtk/src/default/unity/minimize.svg
@@ -13,7 +13,7 @@
    viewBox="0 0 6.35 6.35"
    id="svg4579"
    sodipodi:docname="minimize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4585">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,12 +42,13 @@
      id="namedview4581"
      showgrid="true"
      inkscape:zoom="25.416667"
-     inkscape:cx="12"
+     inkscape:cx="-0.39344243"
      inkscape:cy="11.881967"
      inkscape:window-x="75"
      inkscape:window-y="34"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4579">
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid4587" />
@@ -62,11 +63,11 @@
        id="circle4571"
        style="fill:#323030;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83667,88.367359)"
        id="g4575">
       <rect
          transform="rotate(-45)"
-         x="-206.78"
+         x="-206.51541"
          y="208.69"
          width="0.26458001"
          height="2.6458001"

--- a/gtk/src/default/unity/minimize_focused_normal.svg
+++ b/gtk/src/default/unity/minimize_focused_normal.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.35"
    id="svg4579"
-   sodipodi:docname="minimize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="minimize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4585">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,12 +42,13 @@
      id="namedview4581"
      showgrid="true"
      inkscape:zoom="25.416667"
-     inkscape:cx="12"
+     inkscape:cx="0.11803297"
      inkscape:cy="11.881967"
-     inkscape:window-x="75"
-     inkscape:window-y="34"
+     inkscape:window-x="363"
+     inkscape:window-y="274"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4579">
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid4587" />
@@ -62,11 +63,11 @@
        id="circle4571"
        style="fill:#323030;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
        id="g4575">
       <rect
          transform="rotate(-45)"
-         x="-206.78"
+         x="-206.51541"
          y="208.69"
          width="0.26458001"
          height="2.6458001"

--- a/gtk/src/default/unity/minimize_focused_prelight.svg
+++ b/gtk/src/default/unity/minimize_focused_prelight.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.35"
    id="svg4579"
-   sodipodi:docname="minimize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="minimize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4585">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,12 +42,13 @@
      id="namedview4581"
      showgrid="true"
      inkscape:zoom="25.416667"
-     inkscape:cx="12"
+     inkscape:cx="0.11803297"
      inkscape:cy="11.881967"
-     inkscape:window-x="75"
-     inkscape:window-y="34"
+     inkscape:window-x="333"
+     inkscape:window-y="283"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4579">
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid4587" />
@@ -62,7 +63,7 @@
        id="circle4571"
        style="fill:#505050;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
        id="g4575">
       <rect
          transform="rotate(-45)"

--- a/gtk/src/default/unity/minimize_focused_pressed.svg
+++ b/gtk/src/default/unity/minimize_focused_pressed.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.35"
    id="svg4579"
-   sodipodi:docname="minimize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="minimize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4585">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,12 +42,13 @@
      id="namedview4581"
      showgrid="true"
      inkscape:zoom="25.416667"
-     inkscape:cx="12"
+     inkscape:cx="-0.39344243"
      inkscape:cy="11.881967"
-     inkscape:window-x="75"
-     inkscape:window-y="34"
+     inkscape:window-x="398"
+     inkscape:window-y="283"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4579">
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid4587" />
@@ -62,7 +63,7 @@
        id="circle4571"
        style="fill:#5c5c5c;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
        id="g4575">
       <rect
          transform="rotate(-45)"

--- a/gtk/src/default/unity/minimize_unfocused.svg
+++ b/gtk/src/default/unity/minimize_unfocused.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.35"
    id="svg4579"
-   sodipodi:docname="minimize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="minimize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4585">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,12 +42,13 @@
      id="namedview4581"
      showgrid="true"
      inkscape:zoom="25.416667"
-     inkscape:cx="12"
+     inkscape:cx="-0.39344243"
      inkscape:cy="11.881967"
-     inkscape:window-x="75"
-     inkscape:window-y="34"
+     inkscape:window-x="503"
+     inkscape:window-y="307"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4579">
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid4587" />
@@ -62,11 +63,11 @@
        id="circle4571"
        style="fill:#323030;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
        id="g4575">
       <rect
          transform="rotate(-45)"
-         x="-206.78"
+         x="-206.51541"
          y="208.69"
          width="0.26458001"
          height="2.6458001"

--- a/gtk/src/default/unity/minimize_unfocused_prelight.svg
+++ b/gtk/src/default/unity/minimize_unfocused_prelight.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.35"
    id="svg4579"
-   sodipodi:docname="minimize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="minimize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4585">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,12 +42,13 @@
      id="namedview4581"
      showgrid="true"
      inkscape:zoom="25.416667"
-     inkscape:cx="12"
+     inkscape:cx="-0.39344243"
      inkscape:cy="11.881967"
-     inkscape:window-x="75"
-     inkscape:window-y="34"
+     inkscape:window-x="455"
+     inkscape:window-y="253"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4579">
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid4587" />
@@ -62,11 +63,11 @@
        id="circle4571"
        style="fill:#505050;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
        id="g4575">
       <rect
          transform="rotate(-45)"
-         x="-206.78"
+         x="-206.51541"
          y="208.69"
          width="0.26458001"
          height="2.6458001"

--- a/gtk/src/default/unity/minimize_unfocused_pressed.svg
+++ b/gtk/src/default/unity/minimize_unfocused_pressed.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.35"
    id="svg4579"
-   sodipodi:docname="minimize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="minimize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata4585">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -42,12 +42,13 @@
      id="namedview4581"
      showgrid="true"
      inkscape:zoom="25.416667"
-     inkscape:cx="12"
+     inkscape:cx="5.8032788"
      inkscape:cy="11.881967"
-     inkscape:window-x="75"
-     inkscape:window-y="34"
+     inkscape:window-x="425"
+     inkscape:window-y="283"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4579">
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid4587" />
@@ -62,7 +63,7 @@
        id="circle4571"
        style="fill:#5c5c5c;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
        id="g4575">
       <rect
          transform="rotate(-45)"

--- a/gtk/src/default/unity/unmaximize.svg
+++ b/gtk/src/default/unity/unmaximize.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="unmaximize.svg"
+   inkscape:version="1.0.1 (0767f8302a, 2020-10-17)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="2482"
+     inkscape:window-height="1374"
      id="namedview5277"
      showgrid="true"
-     inkscape:zoom="21.454545"
+     inkscape:zoom="32"
      inkscape:cx="14.9944"
-     inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:cy="12.552296"
+     inkscape:window-x="78"
+     inkscape:window-y="32"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,85 @@
        id="circle5255"
        style="fill:#323030;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
+       transform="matrix(0.4242659,-0.70711,0.4242659,0.70711,-123.09786,88.36736)"
+       id="bottom"
+       inkscape:label="bottom" />
+    <g
+       id="g303">
       <rect
-         transform="rotate(-45)"
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
          x="-206.78"
          y="208.69"
          width="0.26458001"
          height="2.6458001"
          id="rect5257"
          style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/unmaximize_focused_normal.svg
+++ b/gtk/src/default/unity/unmaximize_focused_normal.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="unmaximize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
-     inkscape:cx="14.9944"
+     inkscape:cx="7.6532981"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="416"
+     inkscape:window-y="101"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,81 @@
        id="circle5255"
        style="fill:#323030;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
+       id="g303">
       <rect
-         transform="rotate(-45)"
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
          x="-206.78"
          y="208.69"
          width="0.26458001"
          height="2.6458001"
          id="rect5257"
          style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/unmaximize_focused_prelight.svg
+++ b/gtk/src/default/unity/unmaximize_focused_prelight.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="unmaximize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
-     inkscape:cx="14.9944"
+     inkscape:cx="7.6532981"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="767"
+     inkscape:window-y="101"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,81 @@
        id="circle5255"
        style="fill:#505050;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
+       id="g303">
       <rect
-         transform="rotate(-45)"
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
          x="-206.78"
          y="208.69"
          width="0.26458001"
          height="2.6458001"
          id="rect5257"
          style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/unmaximize_focused_pressed.svg
+++ b/gtk/src/default/unity/unmaximize_focused_pressed.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="unmaximize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
-     inkscape:cx="14.9944"
+     inkscape:cx="7.6532981"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="869"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,81 @@
        id="circle5255"
        style="fill:#5c5c5c;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
+       id="g303">
       <rect
-         transform="rotate(-45)"
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
          x="-206.78"
          y="208.69"
          width="0.26458001"
          height="2.6458001"
          id="rect5257"
          style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/unmaximize_unfocused.svg
+++ b/gtk/src/default/unity/unmaximize_unfocused.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="unmaximize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
-     inkscape:cx="14.9944"
+     inkscape:cx="7.6532981"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="3075"
+     inkscape:window-y="197"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,81 @@
        id="circle5255"
        style="fill:#323030;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
+       id="g303">
       <rect
-         transform="rotate(-45)"
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
          x="-206.78"
          y="208.69"
          width="0.26458001"
          height="2.6458001"
          id="rect5257"
          style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/unmaximize_unfocused_prelight.svg
+++ b/gtk/src/default/unity/unmaximize_unfocused_prelight.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="unmaximize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
-     inkscape:cx="14.9944"
+     inkscape:cx="7.6532981"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="1026"
+     inkscape:window-y="129"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,81 @@
        id="circle5255"
        style="fill:#505050;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
+       id="g303">
       <rect
-         transform="rotate(-45)"
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
          x="-206.78"
          y="208.69"
          width="0.26458001"
          height="2.6458001"
          id="rect5257"
          style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/gtk/src/default/unity/unmaximize_unfocused_pressed.svg
+++ b/gtk/src/default/unity/unmaximize_unfocused_pressed.svg
@@ -12,8 +12,8 @@
    version="1.1"
    viewBox="0 0 6.35 6.3499636"
    id="svg5275"
-   sodipodi:docname="maximize.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   sodipodi:docname="unmaximize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
   <metadata
      id="metadata5281">
     <rdf:RDF>
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,17 +37,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
      id="namedview5277"
      showgrid="true"
      inkscape:zoom="21.454545"
-     inkscape:cx="14.9944"
+     inkscape:cx="7.6532981"
      inkscape:cy="9.8855007"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5275">
+     inkscape:window-x="614"
+     inkscape:window-y="146"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid5826" />
@@ -62,52 +63,81 @@
        id="circle5255"
        style="fill:#5c5c5c;stroke-width:0.66123003" />
     <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,88.637)"
-       id="g5259">
+       id="g303">
       <rect
-         transform="rotate(-45)"
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
          x="-206.78"
          y="208.69"
          width="0.26458001"
          height="2.6458001"
          id="rect5257"
          style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-202.54,462.36)"
-       id="g5263">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5261"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(-0.70711,-0.56569,0.70711,-0.56569,-204.39,462.36)"
-       id="g5267">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5265"
-         style="fill:#ffffff;stroke-width:0.19721" />
-    </g>
-    <g
-       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83,86.785)"
-       id="g5271">
-      <rect
-         transform="rotate(-45)"
-         x="-206.78"
-         y="208.69"
-         width="0.26458001"
-         height="2.6458001"
-         id="rect5269"
-         style="fill:#ffffff;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#ffffff;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#ffffff;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
     </g>
   </g>
 </svg>

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project('Yaru',
         default_options: ['prefix=/usr'])
 
 
-components = ['icons', 'gnome-shell', 'gtk', 'gtksourceview', 'sounds', 'sessions']
+components = ['icons', 'metacity', 'gnome-shell', 'gtk', 'gtksourceview', 'sounds', 'sessions']
 
 foreach component: components
   if not get_option(component)

--- a/metacity/meson.build
+++ b/metacity/meson.build
@@ -1,0 +1,11 @@
+flavours = []
+foreach flavour: ['default', 'dark', 'light']
+  if not get_option(flavour)
+    message('skip flavour ' + flavour)
+    continue
+  endif
+  flavours += flavour
+endforeach
+
+
+subdir('src')

--- a/metacity/src/dark/metacity-1/close_focused_normal.svg
+++ b/metacity/src/dark/metacity-1/close_focused_normal.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4634"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#e95420;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="rotate(-90)"
+         x="-295.67999"
+         y="2.7781"
+         width="3.175"
+         height="0.26458001"
+         id="rect4630" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/close_focused_prelight.svg
+++ b/metacity/src/dark/metacity-1/close_focused_prelight.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4634"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#fa6140;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="rotate(-90)"
+         x="-295.67999"
+         y="2.7781"
+         width="3.175"
+         height="0.26458001"
+         id="rect4630" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/close_focused_pressed.svg
+++ b/metacity/src/dark/metacity-1/close_focused_pressed.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#e84425;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/close_unfocused.svg
+++ b/metacity/src/dark/metacity-1/close_unfocused.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#575757;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#D2D2D2;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/close_unfocused_prelight.svg
+++ b/metacity/src/dark/metacity-1/close_unfocused_prelight.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#f5f5f5"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#636363;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#f5f5f5;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/close_unfocused_pressed.svg
+++ b/metacity/src/dark/metacity-1/close_unfocused_pressed.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="785"
+     inkscape:window-y="32"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#636363;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#D2D2D2;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/maximize_focused_normal.svg
+++ b/metacity/src/dark/metacity-1/maximize_focused_normal.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="643"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#2C2C2C;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/maximize_focused_prelight.svg
+++ b/metacity/src/dark/metacity-1/maximize_focused_prelight.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="660"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#4A4A4A;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/maximize_focused_pressed.svg
+++ b/metacity/src/dark/metacity-1/maximize_focused_pressed.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="663"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5E5E5E;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/maximize_unfocused.svg
+++ b/metacity/src/dark/metacity-1/maximize_unfocused.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="693"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#3E3E3E;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/maximize_unfocused_prelight.svg
+++ b/metacity/src/dark/metacity-1/maximize_unfocused_prelight.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="751"
+     inkscape:window-y="151"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5A5A5A;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/maximize_unfocused_pressed.svg
+++ b/metacity/src/dark/metacity-1/maximize_unfocused_pressed.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="850"
+     inkscape:window-y="190"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5E5E5E;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/menu_focused_normal.svg
+++ b/metacity/src/dark/metacity-1/menu_focused_normal.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="642"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#2C2C2C;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#F7F7F7;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/menu_focused_prelight.svg
+++ b/metacity/src/dark/metacity-1/menu_focused_prelight.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="659"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#4A4A4A;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#F7F7F7;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/menu_focused_pressed.svg
+++ b/metacity/src/dark/metacity-1/menu_focused_pressed.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="662"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5E5E5E;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#F7F7F7;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/menu_unfocused.svg
+++ b/metacity/src/dark/metacity-1/menu_unfocused.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="692"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#3E3E3E;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#D2D2D2;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/menu_unfocused_prelight.svg
+++ b/metacity/src/dark/metacity-1/menu_unfocused_prelight.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="750"
+     inkscape:window-y="117"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5A5A5A;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#D2D2D2;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/menu_unfocused_pressed.svg
+++ b/metacity/src/dark/metacity-1/menu_unfocused_pressed.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="849"
+     inkscape:window-y="156"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5E5E5E;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#D2D2D2;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/minimize_focused_normal.svg
+++ b/metacity/src/dark/metacity-1/minimize_focused_normal.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="0.11803297"
+     inkscape:cy="11.881967"
+     inkscape:window-x="363"
+     inkscape:window-y="274"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#2C2C2C;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.51541"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/minimize_focused_prelight.svg
+++ b/metacity/src/dark/metacity-1/minimize_focused_prelight.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="0.11803297"
+     inkscape:cy="11.881967"
+     inkscape:window-x="333"
+     inkscape:window-y="283"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#4A4A4A;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/minimize_focused_pressed.svg
+++ b/metacity/src/dark/metacity-1/minimize_focused_pressed.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="-0.39344243"
+     inkscape:cy="11.881967"
+     inkscape:window-x="398"
+     inkscape:window-y="283"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#5E5E5E;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/minimize_unfocused.svg
+++ b/metacity/src/dark/metacity-1/minimize_unfocused.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="-0.39344243"
+     inkscape:cy="11.881967"
+     inkscape:window-x="503"
+     inkscape:window-y="307"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#3E3E3E;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.51541"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#D2D2D2;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/minimize_unfocused_prelight.svg
+++ b/metacity/src/dark/metacity-1/minimize_unfocused_prelight.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="-0.39344243"
+     inkscape:cy="11.881967"
+     inkscape:window-x="455"
+     inkscape:window-y="253"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#5A5A5A;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.51541"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#D2D2D2;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/minimize_unfocused_pressed.svg
+++ b/metacity/src/dark/metacity-1/minimize_unfocused_pressed.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="5.8032788"
+     inkscape:cy="11.881967"
+     inkscape:window-x="425"
+     inkscape:window-y="283"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#5E5E5E;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#D2D2D2;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/unmaximize_focused_normal.svg
+++ b/metacity/src/dark/metacity-1/unmaximize_focused_normal.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="416"
+     inkscape:window-y="101"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#2C2C2C;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/unmaximize_focused_prelight.svg
+++ b/metacity/src/dark/metacity-1/unmaximize_focused_prelight.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="767"
+     inkscape:window-y="101"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#4A4A4A;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/unmaximize_focused_pressed.svg
+++ b/metacity/src/dark/metacity-1/unmaximize_focused_pressed.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="869"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5E5E5E;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/unmaximize_unfocused.svg
+++ b/metacity/src/dark/metacity-1/unmaximize_unfocused.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="3075"
+     inkscape:window-y="197"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#3E3E3E;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#D2D2D2;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#D2D2D2;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/unmaximize_unfocused_prelight.svg
+++ b/metacity/src/dark/metacity-1/unmaximize_unfocused_prelight.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="1026"
+     inkscape:window-y="129"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5A5A5A;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#D2D2D2;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#D2D2D2;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/dark/metacity-1/unmaximize_unfocused_pressed.svg
+++ b/metacity/src/dark/metacity-1/unmaximize_unfocused_pressed.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#D2D2D2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="614"
+     inkscape:window-y="146"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5E5E5E;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#D2D2D2;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#D2D2D2;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#D2D2D2;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/close_focused_normal.svg
+++ b/metacity/src/default/metacity-1/close_focused_normal.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4634"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#e95420;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="rotate(-90)"
+         x="-295.67999"
+         y="2.7781"
+         width="3.175"
+         height="0.26458001"
+         id="rect4630" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/close_focused_prelight.svg
+++ b/metacity/src/default/metacity-1/close_focused_prelight.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4634"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#fa6140;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="rotate(-90)"
+         x="-295.67999"
+         y="2.7781"
+         width="3.175"
+         height="0.26458001"
+         id="rect4630" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/close_focused_pressed.svg
+++ b/metacity/src/default/metacity-1/close_focused_pressed.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#e84425;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/close_unfocused.svg
+++ b/metacity/src/default/metacity-1/close_unfocused.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#636363;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#F7F7F7;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/close_unfocused_prelight.svg
+++ b/metacity/src/default/metacity-1/close_unfocused_prelight.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#707070;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/close_unfocused_pressed.svg
+++ b/metacity/src/default/metacity-1/close_unfocused_pressed.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="785"
+     inkscape:window-y="32"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#636363;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#A3A2A2;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/maximize_focused_normal.svg
+++ b/metacity/src/default/metacity-1/maximize_focused_normal.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="643"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#323030;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/maximize_focused_prelight.svg
+++ b/metacity/src/default/metacity-1/maximize_focused_prelight.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="660"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#4F4F4F;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/maximize_focused_pressed.svg
+++ b/metacity/src/default/metacity-1/maximize_focused_pressed.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="663"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5C5C5C;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/maximize_unfocused.svg
+++ b/metacity/src/default/metacity-1/maximize_unfocused.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="693"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#3F3C3C;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/maximize_unfocused_prelight.svg
+++ b/metacity/src/default/metacity-1/maximize_unfocused_prelight.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="751"
+     inkscape:window-y="151"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#4F4F4F;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/maximize_unfocused_pressed.svg
+++ b/metacity/src/default/metacity-1/maximize_unfocused_pressed.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="850"
+     inkscape:window-y="190"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5C5C5C;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/menu_focused_normal.svg
+++ b/metacity/src/default/metacity-1/menu_focused_normal.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="642"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#323030;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#F7F7F7;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/menu_focused_prelight.svg
+++ b/metacity/src/default/metacity-1/menu_focused_prelight.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="659"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#4F4F4F;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#F7F7F7;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/menu_focused_pressed.svg
+++ b/metacity/src/default/metacity-1/menu_focused_pressed.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="662"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5C5C5C;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#F7F7F7;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/menu_unfocused.svg
+++ b/metacity/src/default/metacity-1/menu_unfocused.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="692"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#3F3C3C;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#A3A2A2;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/menu_unfocused_prelight.svg
+++ b/metacity/src/default/metacity-1/menu_unfocused_prelight.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="750"
+     inkscape:window-y="117"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#4F4F4F;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#A3A2A2;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/menu_unfocused_pressed.svg
+++ b/metacity/src/default/metacity-1/menu_unfocused_pressed.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="849"
+     inkscape:window-y="156"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5C5C5C;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#A3A2A2;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/minimize_focused_normal.svg
+++ b/metacity/src/default/metacity-1/minimize_focused_normal.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="0.11803297"
+     inkscape:cy="11.881967"
+     inkscape:window-x="363"
+     inkscape:window-y="274"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#323030;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.51541"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/minimize_focused_prelight.svg
+++ b/metacity/src/default/metacity-1/minimize_focused_prelight.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="0.11803297"
+     inkscape:cy="11.881967"
+     inkscape:window-x="333"
+     inkscape:window-y="283"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#4F4F4F;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/minimize_focused_pressed.svg
+++ b/metacity/src/default/metacity-1/minimize_focused_pressed.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="-0.39344243"
+     inkscape:cy="11.881967"
+     inkscape:window-x="398"
+     inkscape:window-y="283"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#5C5C5C;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/minimize_unfocused.svg
+++ b/metacity/src/default/metacity-1/minimize_unfocused.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="-0.39344243"
+     inkscape:cy="11.881967"
+     inkscape:window-x="503"
+     inkscape:window-y="307"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#3F3C3C;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.51541"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#A3A2A2;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/minimize_unfocused_prelight.svg
+++ b/metacity/src/default/metacity-1/minimize_unfocused_prelight.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="-0.39344243"
+     inkscape:cy="11.881967"
+     inkscape:window-x="455"
+     inkscape:window-y="253"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#4F4F4F;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.51541"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#A3A2A2;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/minimize_unfocused_pressed.svg
+++ b/metacity/src/default/metacity-1/minimize_unfocused_pressed.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="5.8032788"
+     inkscape:cy="11.881967"
+     inkscape:window-x="425"
+     inkscape:window-y="283"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#5C5C5C;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#A3A2A2;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/unmaximize_focused_normal.svg
+++ b/metacity/src/default/metacity-1/unmaximize_focused_normal.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="416"
+     inkscape:window-y="101"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#323030;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/unmaximize_focused_prelight.svg
+++ b/metacity/src/default/metacity-1/unmaximize_focused_prelight.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="767"
+     inkscape:window-y="101"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#4F4F4F;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/unmaximize_focused_pressed.svg
+++ b/metacity/src/default/metacity-1/unmaximize_focused_pressed.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#F7F7F7"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="869"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5C5C5C;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#F7F7F7;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#F7F7F7;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#F7F7F7;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/unmaximize_unfocused.svg
+++ b/metacity/src/default/metacity-1/unmaximize_unfocused.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="3075"
+     inkscape:window-y="197"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#3F3C3C;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#A3A2A2;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#A3A2A2;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/unmaximize_unfocused_prelight.svg
+++ b/metacity/src/default/metacity-1/unmaximize_unfocused_prelight.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="1026"
+     inkscape:window-y="129"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#4F4F4F;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#A3A2A2;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#A3A2A2;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/default/metacity-1/unmaximize_unfocused_pressed.svg
+++ b/metacity/src/default/metacity-1/unmaximize_unfocused_pressed.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#A3A2A2"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="614"
+     inkscape:window-y="146"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#5C5C5C;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#A3A2A2;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#A3A2A2;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#A3A2A2;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/close_focused_normal.svg
+++ b/metacity/src/light/metacity-1/close_focused_normal.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4634"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#e95420;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="rotate(-90)"
+         x="-295.67999"
+         y="2.7781"
+         width="3.175"
+         height="0.26458001"
+         id="rect4630" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/close_focused_prelight.svg
+++ b/metacity/src/light/metacity-1/close_focused_prelight.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4634"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#fa6140;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="rotate(-90)"
+         x="-295.67999"
+         y="2.7781"
+         width="3.175"
+         height="0.26458001"
+         id="rect4630" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/close_focused_pressed.svg
+++ b/metacity/src/light/metacity-1/close_focused_pressed.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#e84425;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#ffffff;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/close_unfocused.svg
+++ b/metacity/src/light/metacity-1/close_unfocused.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#f9f9f9"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#A3A3A3;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#f9f9f9;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/close_unfocused_prelight.svg
+++ b/metacity/src/light/metacity-1/close_unfocused_prelight.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#f9f9f9"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1373"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="2560"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#b0b0b0;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#f9f9f9;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/close_unfocused_pressed.svg
+++ b/metacity/src/light/metacity-1/close_unfocused_pressed.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.3499636 6.3499636"
+   id="svg4636"
+   sodipodi:docname="close_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4642">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4640" />
+  <sodipodi:namedview
+     pagecolor="#f9f9f9"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview4638"
+     showgrid="true"
+     inkscape:zoom="30.341309"
+     inkscape:cx="11.685857"
+     inkscape:cy="9.8749984"
+     inkscape:window-x="785"
+     inkscape:window-y="32"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4632"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5187" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0.26456383,-290.915)"
+     id="g4634">
+    <circle
+       cx="2.9103999"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4626"
+       style="fill:#636363;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.6922639,-0.69225987,0.6922639,0.69225987,-202.69389,92.516372)"
+       id="g4632"
+       style="fill:#f9f9f9;stroke-width:0.28984">
+      <rect
+         x="1.3229001"
+         y="293.95999"
+         width="3.175"
+         height="0.26458001"
+         id="rect4628" />
+      <rect
+         transform="matrix(2.8943627e-6,-1,1,-2.8943627e-6,0,0)"
+         x="-295.67999"
+         y="2.7789528"
+         width="3.175195"
+         height="0.26459625"
+         id="rect4630"
+         style="stroke-width:0.289858" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/maximize_focused_normal.svg
+++ b/metacity/src/light/metacity-1/maximize_focused_normal.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="643"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#DEDEDE;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/maximize_focused_prelight.svg
+++ b/metacity/src/light/metacity-1/maximize_focused_prelight.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="660"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#C6C6C6;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/maximize_focused_pressed.svg
+++ b/metacity/src/light/metacity-1/maximize_focused_pressed.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="663"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#B5B5B5;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/maximize_unfocused.svg
+++ b/metacity/src/light/metacity-1/maximize_unfocused.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="693"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#F7F7F7;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/maximize_unfocused_prelight.svg
+++ b/metacity/src/light/metacity-1/maximize_unfocused_prelight.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="751"
+     inkscape:window-y="151"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#dbdbdb;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/maximize_unfocused_pressed.svg
+++ b/metacity/src/light/metacity-1/maximize_unfocused_pressed.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="maximize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="850"
+     inkscape:window-y="190"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#B5B5B5;stroke-width:0.66123003" />
+    <g
+       id="g115">
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83969,88.637)"
+         id="g5259">
+        <rect
+           transform="rotate(-45)"
+           x="-206.51036"
+           y="208.69376"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5257"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.56569253,0.70711,-0.56569253,-202.54761,462.10239)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(-0.70711566,-0.56569253,0.70711566,-0.56569253,-204.40134,462.10239)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,86.51527)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/menu_focused_normal.svg
+++ b/metacity/src/light/metacity-1/menu_focused_normal.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="642"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#DEDEDE;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#3D3D3D;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/menu_focused_prelight.svg
+++ b/metacity/src/light/metacity-1/menu_focused_prelight.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="659"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#C6C6C6;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#3D3D3D;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/menu_focused_pressed.svg
+++ b/metacity/src/light/metacity-1/menu_focused_pressed.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="662"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#B5B5B5;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#3D3D3D;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/menu_unfocused.svg
+++ b/metacity/src/light/metacity-1/menu_unfocused.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="692"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#F7F7F7;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#626262;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/menu_unfocused_prelight.svg
+++ b/metacity/src/light/metacity-1/menu_unfocused_prelight.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="750"
+     inkscape:window-y="117"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#dbdbdb;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#626262;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/menu_unfocused_pressed.svg
+++ b/metacity/src/light/metacity-1/menu_unfocused_pressed.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="menu_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1564"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="14.9944"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="849"
+     inkscape:window-y="156"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#B5B5B5;stroke-width:0.66123003" />
+    <circle
+       cx="3.175"
+       cy="294.08997"
+       id="circle5255-3"
+       style="fill:#626262;stroke-width:0.264495"
+       r="1.0583333" />
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/minimize_focused_normal.svg
+++ b/metacity/src/light/metacity-1/minimize_focused_normal.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="0.11803297"
+     inkscape:cy="11.881967"
+     inkscape:window-x="363"
+     inkscape:window-y="274"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#DEDEDE;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.51541"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#3D3D3D;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/minimize_focused_prelight.svg
+++ b/metacity/src/light/metacity-1/minimize_focused_prelight.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="0.11803297"
+     inkscape:cy="11.881967"
+     inkscape:window-x="333"
+     inkscape:window-y="283"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#C6C6C6;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#3D3D3D;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/minimize_focused_pressed.svg
+++ b/metacity/src/light/metacity-1/minimize_focused_pressed.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="-0.39344243"
+     inkscape:cy="11.881967"
+     inkscape:window-x="398"
+     inkscape:window-y="283"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#B5B5B5;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#3D3D3D;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/minimize_unfocused.svg
+++ b/metacity/src/light/metacity-1/minimize_unfocused.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="-0.39344243"
+     inkscape:cy="11.881967"
+     inkscape:window-x="503"
+     inkscape:window-y="307"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#F7F7F7;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.51541"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#626262;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/minimize_unfocused_prelight.svg
+++ b/metacity/src/light/metacity-1/minimize_unfocused_prelight.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="-0.39344243"
+     inkscape:cy="11.881967"
+     inkscape:window-x="455"
+     inkscape:window-y="253"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4575"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#dbdbdb;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.367351)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.51541"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#626262;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/minimize_unfocused_pressed.svg
+++ b/metacity/src/light/metacity-1/minimize_unfocused_pressed.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.35"
+   id="svg4579"
+   sodipodi:docname="minimize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata4585">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4583" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1465"
+     inkscape:window-height="897"
+     id="namedview4581"
+     showgrid="true"
+     inkscape:zoom="25.416667"
+     inkscape:cx="5.8032788"
+     inkscape:cy="11.881967"
+     inkscape:window-x="425"
+     inkscape:window-y="283"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4577"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4587" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91496)"
+     id="g4577">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle4571"
+       style="fill:#B5B5B5;stroke-width:0.66123003" />
+    <g
+       transform="matrix(0.56569,-0.70711,0.56569,0.70711,-164.83669,88.102768)"
+       id="g4575">
+      <rect
+         transform="rotate(-45)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect4573"
+         style="fill:#626262;stroke-width:0.19721" />
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/unmaximize_focused_normal.svg
+++ b/metacity/src/light/metacity-1/unmaximize_focused_normal.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_focused_normal.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="416"
+     inkscape:window-y="101"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#DEDEDE;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#3D3D3D;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#3D3D3D;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/unmaximize_focused_prelight.svg
+++ b/metacity/src/light/metacity-1/unmaximize_focused_prelight.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_focused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="767"
+     inkscape:window-y="101"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#C6C6C6;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#3D3D3D;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#3D3D3D;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/unmaximize_focused_pressed.svg
+++ b/metacity/src/light/metacity-1/unmaximize_focused_pressed.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_focused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#3D3D3D"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="869"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#B5B5B5;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#3D3D3D;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#3D3D3D;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#3D3D3D;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/unmaximize_unfocused.svg
+++ b/metacity/src/light/metacity-1/unmaximize_unfocused.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_unfocused.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="3075"
+     inkscape:window-y="197"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#F7F7F7;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#626262;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#626262;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/unmaximize_unfocused_prelight.svg
+++ b/metacity/src/light/metacity-1/unmaximize_unfocused_prelight.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_unfocused_prelight.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="1026"
+     inkscape:window-y="129"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#dbdbdb;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#626262;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#626262;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/light/metacity-1/unmaximize_unfocused_pressed.svg
+++ b/metacity/src/light/metacity-1/unmaximize_unfocused_pressed.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   version="1.1"
+   viewBox="0 0 6.35 6.3499636"
+   id="svg5275"
+   sodipodi:docname="unmaximize_unfocused_pressed.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)">
+  <metadata
+     id="metadata5281">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5279" />
+  <sodipodi:namedview
+     pagecolor="#626262"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1548"
+     inkscape:window-height="1208"
+     id="namedview5277"
+     showgrid="true"
+     inkscape:zoom="21.454545"
+     inkscape:cx="7.6532981"
+     inkscape:cy="9.8855007"
+     inkscape:window-x="614"
+     inkscape:window-y="146"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5273"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5826" />
+  </sodipodi:namedview>
+  <g
+     transform="translate(0,-290.91498)"
+     id="g5273">
+    <circle
+       cx="3.175"
+       cy="294.09"
+       r="2.6458001"
+       id="circle5255"
+       style="fill:#B5B5B5;stroke-width:0.66123003" />
+    <g
+       id="g303">
+      <rect
+         transform="matrix(0,-1.0000046,0.60000258,0,-123.09786,88.367361)"
+         x="-206.78"
+         y="208.69"
+         width="0.26458001"
+         height="2.6458001"
+         id="rect5257"
+         style="fill:#626262;stroke-width:0.19721" />
+      <g
+         transform="matrix(-0.70712378,-0.28341845,0.70712378,-0.28341845,-203.0808,378.52763)"
+         id="g5263">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.67967"
+           width="0.26457697"
+           height="2.6458001"
+           id="rect5261"
+           style="fill:#626262;stroke-width:0.197209" />
+      </g>
+      <g
+         transform="matrix(-0.70711,-0.28284658,0.70711,-0.28284658,-204.39968,378.36085)"
+         id="g5267">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78"
+           y="208.69"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5265"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70711,0.4242694,0.70711,-123.08922,87.038233)"
+         id="g5271">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269"
+           style="fill:#626262;stroke-width:0.19721" />
+      </g>
+      <g
+         id="right-edge"
+         transform="matrix(1,0,0,0.99531863,-3.8027428e-6,2.6959391)"
+         inkscape:label="right-edge">
+        <g
+           transform="matrix(-0.70710999,-0.35522075,0.70710999,-0.35522075,-202.5476,398.12812)"
+           id="g5263-3">
+          <rect
+             transform="rotate(-45)"
+             x="-206.78"
+             y="208.67967"
+             width="0.26458001"
+             height="2.6458001"
+             id="rect5261-6"
+             style="fill:#a3a3a3;stroke-width:0.19721" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.4242694,-0.70710999,0.4242694,0.70710999,-122.56004,86.509064)"
+         id="top-edge"
+         inkscape:label="top-edge">
+        <rect
+           transform="rotate(-45)"
+           x="-206.78621"
+           y="208.67384"
+           width="0.26458001"
+           height="2.6458001"
+           id="rect5269-5"
+           style="fill:#a3a3a3;stroke-width:0.19721" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/metacity/src/meson.build
+++ b/metacity/src/meson.build
@@ -1,0 +1,62 @@
+foreach flavour: flavours
+  suffix = flavour == 'default' ? '' : '-@0@'.format(flavour)
+  theme_name = meson.project_name() + suffix
+  theme_dir = join_paths(get_option('datadir'), 'themes', theme_name)
+  metacity_dir = join_paths(theme_dir, 'metacity-1')
+
+  conf_data = configuration_data()
+  conf_data.set('ThemeName', meson.project_name())
+  conf_data.set('FlavourThemeName', theme_name)
+
+  if flavour == 'dark'
+    conf_data.set('titlebar', '#2c2c2c')
+    conf_data.set('titlebar_unfocused', '#3e3e3e')
+    conf_data.set('titlebar_border_focused', '#232323')
+    conf_data.set('titlebar_border_unfocused', '#222222')
+    conf_data.set('titlebar_highlight_focused', '#3a3a3a')
+    conf_data.set('titlebar_highlight_unfocused', '#4b4b4b')
+    conf_data.set('border_focused', '#232323')
+    conf_data.set('border_unfocused', '#222222')
+    conf_data.set('title_focused', '#f7f7f7')
+    conf_data.set('title_unfocused', '#d2d2d2')
+  elif flavour == 'light'
+    conf_data.set('titlebar', '#dedede')
+    conf_data.set('titlebar_unfocused', '#f7f7f7')
+    conf_data.set('titlebar_border_focused', '#919191')
+    conf_data.set('titlebar_border_unfocused', '#b8b8b8')
+    conf_data.set('titlebar_highlight_focused', '#f8f8f8')
+    conf_data.set('titlebar_highlight_unfocused', '#fdfdfd')
+    conf_data.set('border_focused', '#919191')
+    conf_data.set('border_unfocused', '#b8b8b8')
+    conf_data.set('title_focused', '#3d3d3d')
+    conf_data.set('title_unfocused', '#626262')
+  elif flavour == 'default'
+    conf_data.set('titlebar', '#323030')
+    conf_data.set('titlebar_unfocused', '#3f3c3c')
+    conf_data.set('titlebar_border_focused', '#232323')
+    conf_data.set('titlebar_border_unfocused', '#222222')
+    conf_data.set('titlebar_highlight_focused', '#474444')
+    conf_data.set('titlebar_highlight_unfocused', '#474444')
+    conf_data.set('border_focused', '#919191')
+    conf_data.set('border_unfocused', '#b8b8b8')
+    conf_data.set('title_focused', '#f7f7f7')
+    conf_data.set('title_unfocused', '#bcbcbc')
+  endif
+
+  configure_file(input: 'metacity-theme-1.xml.in',
+    output: '@0@-metacity-theme-1.xml'.format(flavour),
+    configuration: conf_data,
+    install_dir: metacity_dir
+  )
+
+  # install metacity assets
+  metacity_asset_dir = join_paths(flavour, 'metacity-1')
+  metacity_svg_data = run_command(
+    'find', metacity_asset_dir, '-name', '*.svg'
+    ).stdout().strip().split('\n')
+
+  metacity_assets_dest = join_paths(theme_dir, 'metacity-1')
+  install_data(metacity_svg_data, install_dir: metacity_assets_dest)
+
+  meson.add_install_script('post_install.py', get_option('datadir'), meson.project_name(), flavour)
+endforeach

--- a/metacity/src/metacity-theme-1.xml.in
+++ b/metacity/src/metacity-theme-1.xml.in
@@ -1,0 +1,1472 @@
+<?xml version="1.0"?>
+<metacity_theme>
+	<info>
+		<name>@FlavourThemeName@</name>
+		<author>Martin Wimpress</author>
+		<copyright>Martin Wimpress, 2021</copyright>
+		<date>January 20, 2021</date>
+		<description>@FlavourThemeName@ Metacity (Marco) Theme</description>
+	</info>
+
+	<!-- CONSTANTS -->
+	<constant name="C_titlebar" value="@titlebar@" />
+	<constant name="C_titlebar_unfocused" value="@titlebar_unfocused@" />
+	<constant name="C_titlebar_border_focused" value="@titlebar_border_focused@" />
+	<constant name="C_titlebar_border_unfocused" value="@titlebar_border_unfocused@" />
+	<constant name="C_titlebar_highlight_focused" value="@titlebar_highlight_focused@" />
+	<constant name="C_titlebar_highlight_unfocused" value="@titlebar_highlight_unfocused@" />
+	<constant name="C_border_focused" value="@border_focused@" />
+	<constant name="C_border_unfocused" value="@border_unfocused@" />
+	<constant name="C_title_focused" value="@title_focused@" />
+	<constant name="C_title_unfocused" value="@title_unfocused@" />
+
+	<!-- GEOMETRY -->
+	<!-- focused window -->
+	<frame_geometry name="normal" title_scale="medium" rounded_top_left="true" rounded_top_right="true">
+		<distance name="left_width" value="1" />
+		<distance name="right_width" value="1" />
+		<distance name="bottom_height" value="1" />
+		<distance name="left_titlebar_edge" value="6" />
+		<distance name="right_titlebar_edge" value="6" />
+		<distance name="title_vertical_pad" value="1" />
+		<aspect_ratio name="button" value="1" />
+		<border name="title_border" left="0" right="0" top="8" bottom="8" />
+		<border name="button_border" left="11" right="0" top="3" bottom="3" />
+	</frame_geometry>
+	<frame_geometry name="normal_shaded" rounded_bottom_left="true" rounded_bottom_right="true" parent="normal" />
+
+	<!-- no buttons -->
+	<frame_geometry name="nobuttons" hide_buttons="true" parent="normal" />
+	<frame_geometry name="nobuttons_shaded" rounded_bottom_left="true" rounded_bottom_right="true" parent="nobuttons" />
+
+	<!-- maximized window -->
+	<frame_geometry name="max" title_scale="medium" rounded_top_left="false" rounded_top_right="false" parent="normal">
+		<distance name="left_width" value="0" />
+		<distance name="right_width" value="0" />
+		<distance name="bottom_height" value="0" />
+	</frame_geometry>
+
+	<!-- tiled -->
+	<frame_geometry name="tiled_left_active" parent="max" />
+
+	<frame_geometry name="tiled_left_inactive" parent="max" />
+
+	<!-- tiled_right have a left_width so a border is always rendered so when
+		 two windows are tiled next to each other a single pixel line
+		 can be draw to separate them
+	-->
+	<frame_geometry name="tiled_right_active" parent="max">
+		<distance name="left_width" value="1" />
+	</frame_geometry>
+
+	<frame_geometry name="tiled_right_inactive" parent="max">
+		<distance name="left_width" value="1" />
+	</frame_geometry>
+
+	<!-- border -->
+	<frame_geometry name="border" has_title="false" rounded_top_left="false" rounded_top_right="false" parent="normal">
+		<distance name="left_width" value="0" />
+		<distance name="right_width" value="0" />
+		<distance name="bottom_height" value="0" />
+		<border name="title_border" left="0" right="0" top="0" bottom="0" />
+		<border name="button_border" left="0" right="0" top="0" bottom="0" />
+	</frame_geometry>
+
+	<!-- borderless -->
+	<frame_geometry name="borderless" has_title="false" rounded_top_left="false" rounded_top_right="false" parent="normal">
+		<distance name="left_width" value="0" />
+		<distance name="right_width" value="0" />
+		<distance name="bottom_height" value="0" />
+		<border name="title_border" left="0" right="0" top="0" bottom="0" />
+		<border name="button_border" left="0" right="0" top="0" bottom="0" />
+	</frame_geometry>
+
+	<!-- title -->
+	<draw_ops name="title_focused">
+		<title x="(0 `max` ((frame_x_center - title_width / 2) `min` (width - title_width)))" y="(0 `max` ((height - title_height) / 2))" color="C_title_focused" />
+	</draw_ops>
+
+	<draw_ops name="title_unfocused">
+		<title x="(0 `max` ((frame_x_center - title_width / 2) `min` (width - title_width)))" y="(0 `max` ((height - title_height) / 2))" color="C_title_unfocused" />
+	</draw_ops>
+
+	<!-- WINDOW DECORATIONS -->
+	<draw_ops name="entire_background_focused">
+		<rectangle color="C_titlebar" x="0" y="0" width="width" height="height" filled="true" />
+	</draw_ops>
+
+	<draw_ops name="entire_background_unfocused">
+		<rectangle color="C_titlebar_unfocused" x="0" y="0" width="width" height="height" filled="true" />
+	</draw_ops>
+
+	<draw_ops name="titlebar_fill_focused">
+		<rectangle color="C_titlebar" x="0" y="0" width="width" height="height" filled="true" />
+	</draw_ops>
+
+	<draw_ops name="titlebar_fill_unfocused">
+		<rectangle color="C_titlebar_unfocused" x="0" y="0" width="width" height="height" filled="true" />
+	</draw_ops>
+
+	<draw_ops name="titlebar_tiled_focused">
+		<rectangle color="C_titlebar" x="0" y="0" width="width" height="height" filled="true" />
+	</draw_ops>
+
+	<draw_ops name="titlebar_tiled_unfocused">
+		<rectangle color="C_titlebar_unfocused" x="0" y="0" width="width" height="height" filled="true" />
+	</draw_ops>
+
+	<draw_ops name="border_focused">
+		<rectangle color="C_border_focused" x="0" y="0" width="width-1" height="height-1" filled="false" />
+	</draw_ops>
+
+	<draw_ops name="border_unfocused">
+		<rectangle color="C_border_unfocused" x="0" y="0" width="width-1" height="height-1" filled="false" />
+	</draw_ops>
+
+	<draw_ops name="rounded_border_focused">
+		<line color="C_titlebar_border_focused" x1="2" y1="0" x2="width-3" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="1" y1="top_height-1" x2="width-1" y2="top_height-1" />
+		<line color="C_border_focused" x1="0" y1="height-1" x2="width-1" y2="height-1" />
+		<line color="C_border_focused" x1="0" y1="2" x2="0" y2="height-2" />
+		<line color="C_border_focused" x1="width-1" y1="2" x2="width-1" y2="height-2" />
+
+		<!-- left arch -->
+		<line color="C_titlebar_border_focused" x1="0" x2="4" y1="1" y2="1" />
+		<line color="C_titlebar_border_focused" x1="0" x2="2" y1="2" y2="2" />
+		<line color="C_titlebar_border_focused" x1="0" x2="1" y1="3" y2="3" />
+		<line color="C_titlebar_border_focused" x1="0" x2="1" y1="4" y2="4" />
+		<!-- left title bar edge -->
+		<gradient type="vertical" x="0" y="2" width="1" height="height/3">
+			<color value="C_titlebar_border_focused" />
+			<color value="C_border_focused" />
+		</gradient>
+
+		<!-- right arch -->
+		<line color="C_titlebar_border_focused" x1="width-5" x2="width" y1="1" y2="1" />
+		<line color="C_titlebar_border_focused" x1="width-3" x2="width" y1="2" y2="2" />
+		<line color="C_titlebar_border_focused" x1="width-2" x2="width" y1="3" y2="3" />
+		<line color="C_titlebar_border_focused" x1="width-2" x2="width" y1="4" y2="4" />
+		<!-- right title bar edge -->
+		<gradient type="vertical" x="width-1" y="2" width="1" height="height/3">
+			<color value="C_titlebar_border_focused" />
+			<color value="C_border_focused" />
+		</gradient>
+
+		<!-- title bar top highlight -->
+		<line color="C_titlebar_highlight_focused" x1="5" y1="1" x2="width-6" y2="1" />
+		<line color="C_titlebar_highlight_focused" x1="3" x2="4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_focused" x1="2" x2="2" y1="3" y2="3" />
+		<line color="C_titlebar_highlight_focused" x1="width-5" x2="width-4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_focused" x1="width-3" x2="width-3" y1="3" y2="3" />
+	</draw_ops>
+
+	<draw_ops name="rounded_border_unfocused">
+		<line color="C_titlebar_border_unfocused" x1="2" y1="0" x2="width-3" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="1" y1="top_height-1" x2="width-1" y2="top_height-1" />
+		<line color="C_border_unfocused" x1="0" y1="height-1" x2="width-1" y2="height-1" />
+		<line color="C_border_unfocused" x1="0" y1="2" x2="0" y2="height-2" />
+		<line color="C_border_unfocused" x1="width-1" y1="2" x2="width-1" y2="height-2" />
+
+		<!-- left arch -->
+		<line color="C_titlebar_border_unfocused" x1="0" x2="4" y1="1" y2="1" />
+		<line color="C_titlebar_border_unfocused" x1="0" x2="2" y1="2" y2="2" />
+		<line color="C_titlebar_border_unfocused" x1="0" x2="1" y1="3" y2="3" />
+		<line color="C_titlebar_border_unfocused" x1="0" x2="1" y1="4" y2="4" />
+		<!-- left title bar edge -->
+		<gradient type="vertical" x="0" y="2" width="1" height="height/3">
+			<color value="C_titlebar_border_unfocused" />
+			<color value="C_border_unfocused" />
+		</gradient>
+
+		<!-- right arch -->
+		<line color="C_titlebar_border_unfocused" x1="width-5" x2="width" y1="1" y2="1" />
+		<line color="C_titlebar_border_unfocused" x1="width-3" x2="width" y1="2" y2="2" />
+		<line color="C_titlebar_border_unfocused" x1="width-2" x2="width" y1="3" y2="3" />
+		<line color="C_titlebar_border_unfocused" x1="width-2" x2="width" y1="4" y2="4" />
+		<!-- right title bar edge -->
+		<gradient type="vertical" x="width-1" y="2" width="1" height="height/3">
+			<color value="C_titlebar_border_unfocused" />
+			<color value="C_border_unfocused" />
+		</gradient>
+
+		<!-- title bar top highlight -->
+		<line color="C_titlebar_highlight_unfocused" x1="5" y1="1" x2="width-6" y2="1" />
+		<line color="C_titlebar_highlight_unfocused" x1="3" x2="4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_unfocused" x1="2" x2="2" y1="3" y2="3" />
+		<line color="C_titlebar_highlight_unfocused" x1="width-5" x2="width-4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_unfocused" x1="width-3" x2="width-3" y1="3" y2="3" />
+	</draw_ops>
+
+	<draw_ops name="rounded_border_shaded_focused">
+		<line color="C_titlebar_border_focused" x1="2" y1="0" x2="width-3" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="1" y1="top_height-1" x2="width-1" y2="top_height-1" />
+		<line color="C_titlebar_border_focused" x1="0" y1="height-1" x2="width-1" y2="height-1" />
+		<line color="C_titlebar_border_focused" x1="0" y1="2" x2="0" y2="height-2" />
+		<line color="C_titlebar_border_focused" x1="width-1" y1="2" x2="width-1" y2="height-2" />
+
+		<!-- left arch -->
+		<line color="C_titlebar_border_focused" x1="0" x2="4" y1="1" y2="1" />
+		<line color="C_titlebar_border_focused" x1="0" x2="2" y1="2" y2="2" />
+		<line color="C_titlebar_border_focused" x1="0" x2="1" y1="3" y2="3" />
+		<line color="C_titlebar_border_focused" x1="0" x2="1" y1="4" y2="4" />
+
+		<!-- right arch -->
+		<line color="C_titlebar_border_focused" x1="width-5" x2="width" y1="1" y2="1" />
+		<line color="C_titlebar_border_focused" x1="width-3" x2="width" y1="2" y2="2" />
+		<line color="C_titlebar_border_focused" x1="width-2" x2="width" y1="3" y2="3" />
+		<line color="C_titlebar_border_focused" x1="width-2" x2="width" y1="4" y2="4" />
+
+		<!-- title bar top highlight -->
+		<line color="C_titlebar_highlight_focused" x1="5" y1="1" x2="width-6" y2="1" />
+		<line color="C_titlebar_highlight_focused" x1="3" x2="4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_focused" x1="2" x2="2" y1="3" y2="3" />
+		<line color="C_titlebar_highlight_focused" x1="width-5" x2="width-4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_focused" x1="width-3" x2="width-3" y1="3" y2="3" />
+	</draw_ops>
+
+	<draw_ops name="rounded_border_shaded_unfocused">
+		<line color="C_titlebar_border_unfocused" x1="2" y1="0" x2="width-3" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="1" y1="top_height-1" x2="width-1" y2="top_height-1" />
+		<line color="C_titlebar_border_unfocused" x1="0" y1="height-1" x2="width-1" y2="height-1" />
+		<line color="C_titlebar_border_unfocused" x1="0" y1="2" x2="0" y2="height-2" />
+		<line color="C_titlebar_border_unfocused" x1="width-1" y1="2" x2="width-1" y2="height-2" />
+
+		<!-- left arch -->
+		<line color="C_titlebar_border_unfocused" x1="0" x2="4" y1="1" y2="1" />
+		<line color="C_titlebar_border_unfocused" x1="0" x2="2" y1="2" y2="2" />
+		<line color="C_titlebar_border_unfocused" x1="0" x2="1" y1="3" y2="3" />
+		<line color="C_titlebar_border_unfocused" x1="0" x2="1" y1="4" y2="4" />
+
+		<!-- right arch -->
+		<line color="C_titlebar_border_unfocused" x1="width-5" x2="width" y1="1" y2="1" />
+		<line color="C_titlebar_border_unfocused" x1="width-3" x2="width" y1="2" y2="2" />
+		<line color="C_titlebar_border_unfocused" x1="width-2" x2="width" y1="3" y2="3" />
+		<line color="C_titlebar_border_unfocused" x1="width-2" x2="width" y1="4" y2="4" />
+
+		<!-- title bar top highlight -->
+		<line color="C_titlebar_highlight_unfocused" x1="5" y1="1" x2="width-6" y2="1" />
+		<line color="C_titlebar_highlight_unfocused" x1="3" x2="4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_unfocused" x1="2" x2="2" y1="3" y2="3" />
+		<line color="C_titlebar_highlight_unfocused" x1="width-5" x2="width-4" y1="2" y2="2" />
+		<line color="C_titlebar_highlight_unfocused" x1="width-3" x2="width-3" y1="3" y2="3" />
+	</draw_ops>
+
+	<!-- maximized -->
+	<draw_ops name="max_border_focused">
+		<line color="C_titlebar_highlight_focused" x1="0" y1="0" x2="width" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="0" y1="top_height-1" x2="width" y2="top_height-1" />
+	</draw_ops>
+
+	<draw_ops name="max_border_unfocused">
+		<line color="C_titlebar_highlight_unfocused" x1="0" y1="0" x2="width" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="0" y1="top_height-1" x2="width" y2="top_height-1" />
+	</draw_ops>
+
+	<!-- tiled -->
+	<draw_ops name="tiled_left_border_focused">
+		<include name="max_border_focused" />
+	</draw_ops>
+
+	<draw_ops name="tiled_left_border_unfocused">
+		<include name="max_border_unfocused" />
+	</draw_ops>
+
+	<draw_ops name="tiled_right_border_focused">
+		<line color="C_titlebar_highlight_focused" x1="0" y1="0" x2="width" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="0" y1="top_height-1" x2="width" y2="top_height-1" />
+		<line color="C_titlebar_border_focused" x1="0" y1="1" x2="0" y2="top_height-2" />
+		<line color="C_titlebar_border_focused" x1="0" y1="top_height" x2="0" y2="height" />
+	</draw_ops>
+
+	<draw_ops name="tiled_right_border_unfocused">
+		<line color="C_titlebar_highlight_unfocused" x1="0" y1="0" x2="width" y2="0" />
+		<line color="C_titlebar_border_unfocused" x1="0" y1="top_height-1" x2="width" y2="top_height-1" />
+		<line color="C_titlebar_border_focused" x1="0" y1="1" x2="0" y2="top_height-2" />
+		<line color="C_titlebar_border_focused" x1="0" y1="top_height" x2="0" y2="height" />
+	</draw_ops>
+
+	<!-- BUTTON ICONS -->
+	<!-- note: negative values in x or y causes gnome-shell to crash -->
+
+	<!-- Close icon -->
+	<draw_ops name="close_focused">
+		<image filename="close_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="close_focused_prelight">
+		<image filename="close_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="close_focused_pressed">
+		<image filename="close_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="close_unfocused">
+		<image filename="close_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="close_unfocused_prelight">
+		<image filename="close_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="close_unfocused_pressed">
+		<image filename="close_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+
+	<!-- Maximize icon -->
+	<draw_ops name="maximize_focused">
+		<image filename="maximize_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="maximize_focused_prelight">
+		<image filename="maximize_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="maximize_focused_pressed">
+		<image filename="maximize_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="maximize_unfocused">
+		<image filename="maximize_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="maximize_unfocused_prelight">
+		<image filename="maximize_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="maximize_unfocused_pressed">
+		<image filename="maximize_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+
+	<!-- Unmaximize icon -->
+	<draw_ops name="unmaximize_focused">
+		<image filename="unmaximize_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="unmaximize_focused_prelight">
+		<image filename="unmaximize_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="unmaximize_focused_pressed">
+		<image filename="unmaximize_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="unmaximize_unfocused">
+		<image filename="unmaximize_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="unmaximize_unfocused_prelight">
+		<image filename="unmaximize_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="unmaximize_unfocused_pressed">
+		<image filename="unmaximize_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+
+	<!-- Minimize icon -->
+	<draw_ops name="minimize_focused">
+		<image filename="minimize_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="minimize_focused_prelight">
+		<image filename="minimize_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="minimize_focused_pressed">
+		<image filename="minimize_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="minimize_unfocused">
+		<image filename="minimize_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="minimize_unfocused_prelight">
+		<image filename="minimize_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="minimize_unfocused_pressed">
+		<image filename="minimize_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+
+	<!-- Menu icon -->
+	<draw_ops name="menu_focused">
+		<image filename="menu_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="menu_focused_prelight">
+		<image filename="menu_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="menu_focused_pressed">
+		<image filename="menu_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="menu_unfocused">
+		<image filename="menu_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="menu_unfocused_prelight">
+		<image filename="menu_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+	<draw_ops name="menu_unfocused_pressed">
+		<image filename="menu_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+	</draw_ops>
+
+	<!-- FRAME STYLES -->
+	<frame_style name="normal_focused" geometry="normal">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="normal_unfocused" geometry="normal">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="normal_shaded_focused" geometry="normal_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="normal_shaded_unfocused" geometry="normal_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="normal_max_focused" geometry="max">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="max_border_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="unmaximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="unmaximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="unmaximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="normal_max_unfocused" geometry="max">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="max_border_focused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="unmaximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="unmaximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="unmaximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="normal_max_shaded_focused" geometry="max">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="max_border_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="unmaximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="unmaximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="unmaximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="normal_max_shaded_unfocused" geometry="max">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="max_border_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="unmaximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="unmaximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="unmaximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="dialog_focused" geometry="nobuttons">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="dialog_unfocused" geometry="nobuttons">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="dialog_shaded_focused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="dialog_shaded_unfocused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="modal_dialog_focused" geometry="nobuttons">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="modal_dialog_unfocused" geometry="nobuttons">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="modal_dialog_shaded_focused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="modal_dialog_shaded_unfocused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="utility_focused" geometry="normal">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="utility_unfocused" geometry="normal">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="utility_shaded_focused" geometry="normal_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="utility_shaded_unfocused" geometry="normal_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="border_focused" geometry="border">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="overlay" draw_ops="border_focused" />
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="border_unfocused" geometry="border">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="overlay" draw_ops="border_unfocused" />
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="borderless" geometry="borderless">
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="attached_focused" geometry="nobuttons">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_focused" />
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="attached_unfocused" geometry="nobuttons">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_unfocused" />
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="attached_shaded_focused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_focused" />
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="attached_shaded_unfocused" geometry="nobuttons_shaded">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="rounded_border_shaded_unfocused" />
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="tiled_left_focused" geometry="tiled_left_active">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_tiled_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="tiled_left_border_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="tiled_left_unfocused" geometry="tiled_left_inactive">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_tiled_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="tiled_left_border_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="tiled_right_focused" geometry="tiled_right_active">
+		<piece position="entire_background" draw_ops="entire_background_focused" />
+		<piece position="titlebar" draw_ops="titlebar_tiled_focused" />
+		<piece position="title" draw_ops="title_focused" />
+		<piece position="overlay" draw_ops="tiled_right_border_focused" />
+		<button function="close" state="normal" draw_ops="close_focused" />
+		<button function="close" state="prelight" draw_ops="close_focused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_focused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_focused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_focused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_focused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_focused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_focused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_focused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_focused" />
+		<button function="menu" state="prelight" draw_ops="menu_focused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_focused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<frame_style name="tiled_right_unfocused" geometry="tiled_right_inactive">
+		<piece position="entire_background" draw_ops="entire_background_unfocused" />
+		<piece position="titlebar" draw_ops="titlebar_tiled_unfocused" />
+		<piece position="title" draw_ops="title_unfocused" />
+		<piece position="overlay" draw_ops="tiled_right_border_unfocused" />
+		<button function="close" state="normal" draw_ops="close_unfocused" />
+		<button function="close" state="prelight" draw_ops="close_unfocused_prelight" />
+		<button function="close" state="pressed" draw_ops="close_unfocused_pressed" />
+		<button function="maximize" state="normal" draw_ops="maximize_unfocused" />
+		<button function="maximize" state="prelight" draw_ops="maximize_unfocused_prelight" />
+		<button function="maximize" state="pressed" draw_ops="maximize_unfocused_pressed" />
+		<button function="minimize" state="normal" draw_ops="minimize_unfocused" />
+		<button function="minimize" state="prelight" draw_ops="minimize_unfocused_prelight" />
+		<button function="minimize" state="pressed" draw_ops="minimize_unfocused_pressed" />
+		<button function="menu" state="normal" draw_ops="menu_unfocused" />
+		<button function="menu" state="prelight" draw_ops="menu_unfocused_prelight" />
+		<button function="menu" state="pressed" draw_ops="menu_unfocused_pressed" />
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<!-- placeholder for unimplementated styles-->
+	<frame_style name="blank" geometry="normal">
+		<button function="close" state="normal"><draw_ops></draw_ops></button>
+		<button function="close" state="pressed"><draw_ops></draw_ops></button>
+		<button function="maximize" state="normal"><draw_ops></draw_ops></button>
+		<button function="maximize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="minimize" state="normal"><draw_ops></draw_ops></button>
+		<button function="minimize" state="pressed"><draw_ops></draw_ops></button>
+		<button function="menu" state="normal"><draw_ops></draw_ops></button>
+		<button function="menu" state="pressed"><draw_ops></draw_ops></button>
+		<button function="shade" state="normal"><draw_ops></draw_ops></button>
+		<button function="shade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="shade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unshade" state="normal"><draw_ops></draw_ops></button>
+		<button function="unshade" state="prelight"><draw_ops></draw_ops></button>
+		<button function="unshade" state="pressed"><draw_ops></draw_ops></button>
+		<button function="above" state="normal"><draw_ops></draw_ops></button>
+		<button function="above" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unabove" state="normal"><draw_ops></draw_ops></button>
+		<button function="unabove" state="pressed"><draw_ops></draw_ops></button>
+		<button function="stick" state="normal"><draw_ops></draw_ops></button>
+		<button function="stick" state="pressed"><draw_ops></draw_ops></button>
+		<button function="unstick" state="normal"><draw_ops></draw_ops></button>
+		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
+	</frame_style>
+
+	<!-- FRAME STYLE SETS -->
+	<frame_style_set name="normal_style_set">
+		<frame focus="yes" state="normal" resize="both" style="normal_focused" />
+		<frame focus="no" state="normal" resize="both" style="normal_unfocused" />
+		<frame focus="yes" state="maximized" style="normal_max_focused" />
+		<frame focus="no" state="maximized" style="normal_max_unfocused" />
+		<frame focus="yes" state="tiled_left" style="tiled_left_focused" />
+		<frame focus="no" state="tiled_left" style="tiled_left_unfocused" />
+		<frame focus="yes" state="tiled_right" style="tiled_right_focused" />
+		<frame focus="no" state="tiled_right" style="tiled_right_unfocused" />
+		<frame focus="yes" state="shaded" style="normal_shaded_focused" />
+		<frame focus="no" state="shaded" style="normal_shaded_unfocused" />
+		<frame focus="yes" state="maximized_and_shaded" style="normal_max_shaded_focused" />
+		<frame focus="no" state="maximized_and_shaded" style="normal_max_shaded_unfocused" />
+	</frame_style_set>
+
+	<frame_style_set name="dialog_style_set">
+		<frame focus="yes" state="normal" resize="both" style="dialog_focused" />
+		<frame focus="no" state="normal" resize="both" style="dialog_unfocused" />
+		<frame focus="yes" state="maximized" style="blank" />
+		<frame focus="no" state="maximized" style="blank" />
+		<frame focus="yes" state="shaded" style="dialog_shaded_focused" />
+		<frame focus="no" state="shaded" style="dialog_shaded_unfocused" />
+		<frame focus="yes" state="maximized_and_shaded" style="blank" />
+		<frame focus="no" state="maximized_and_shaded" style="blank" />
+	</frame_style_set>
+
+	<frame_style_set name="modal_dialog_style_set">
+		<frame focus="yes" state="normal" resize="both" style="modal_dialog_focused" />
+		<frame focus="no" state="normal" resize="both" style="modal_dialog_unfocused" />
+		<frame focus="yes" state="maximized" style="blank" />
+		<frame focus="no" state="maximized" style="blank" />
+		<frame focus="yes" state="shaded" style="modal_dialog_shaded_focused" />
+		<frame focus="no" state="shaded" style="modal_dialog_shaded_unfocused" />
+		<frame focus="yes" state="maximized_and_shaded" style="blank" />
+		<frame focus="no" state="maximized_and_shaded" style="blank" />
+	</frame_style_set>
+
+	<frame_style_set name="utility_style_set">
+		<frame focus="yes" state="normal" resize="both" style="utility_focused" />
+		<frame focus="no" state="normal" resize="both" style="utility_unfocused" />
+		<frame focus="yes" state="maximized" style="blank" />
+		<frame focus="no" state="maximized" style="blank" />
+		<frame focus="yes" state="shaded" style="utility_shaded_focused" />
+		<frame focus="no" state="shaded" style="utility_shaded_unfocused" />
+		<frame focus="yes" state="maximized_and_shaded" style="blank" />
+		<frame focus="no" state="maximized_and_shaded" style="blank" />
+	</frame_style_set>
+
+	<frame_style_set name="border_style_set">
+		<frame focus="yes" state="normal" resize="both" style="border_focused" />
+		<frame focus="no" state="normal" resize="both" style="border_unfocused" />
+		<frame focus="yes" state="maximized" style="borderless" />
+		<frame focus="no" state="maximized" style="borderless" />
+		<frame focus="yes" state="shaded" style="blank" />
+		<frame focus="no" state="shaded" style="blank" />
+		<frame focus="yes" state="maximized_and_shaded" style="blank" />
+		<frame focus="no" state="maximized_and_shaded" style="blank" />
+	</frame_style_set>
+
+	<!-- WINDOWS -->
+	<window type="normal" style_set="normal_style_set" />
+	<window type="dialog" style_set="dialog_style_set" />
+	<window type="modal_dialog" style_set="modal_dialog_style_set" />
+	<window type="menu" style_set="utility_style_set" />
+	<window type="utility" style_set="utility_style_set" />
+	<window type="border" style_set="border_style_set" />
+</metacity_theme>

--- a/metacity/src/post_install.py
+++ b/metacity/src/post_install.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from contextlib import suppress
+from os import environ, path, remove, symlink
+from shutil import move
+import sys
+
+with suppress(IndexError):
+    data_dir = sys.argv[1]
+    project_name = sys.argv[2]
+    flavour = sys.argv[3]
+
+PREFIX = environ.get('MESON_INSTALL_DESTDIR_PREFIX', '/usr')
+themes_dir = path.join(PREFIX, data_dir, 'themes')
+
+if flavour == 'default':
+    flavour_name = project_name
+else:
+    flavour_name = "{project}-{flavour}".format(project=project_name, flavour=flavour)
+
+flavour_dir = path.join(themes_dir, flavour_name)
+
+# rename metacity-theme-1.xml
+theme_name = "{flavour}-metacity-theme-1.xml".format(flavour=flavour)
+theme_src = path.join(flavour_dir, 'metacity-1', theme_name)
+if path.exists(theme_src):
+    theme_dst = path.join(flavour_dir, 'metacity-1', 'metacity-theme-1.xml')
+    move(theme_src, theme_dst)
+    # create symlinks
+    for v in ["2", "3"]:
+        theme_link = path.join(flavour_dir, 'metacity-1', "metacity-theme-{ver}.xml".format(ver=v))
+        try:
+            symlink('metacity-theme-1.xml', theme_link)
+        except FileExistsError:
+            remove(theme_link)
+            symlink('metacity-theme-1.xml', theme_link)


### PR DESCRIPTION
This pull request updates the Unity window button svg files to provide pixel-perfect replicas of the window buttons rendered by CSD windows in GNOME Shell. Menu button assets have been added to Unity, that while not used by Unity, serve are source origin assets for the Metacity window buttons.

A script to transform the authoritative Unity window buttons into the 3 variants of Metacity theme is included. The script was used to populate the Metacity window button assets.

A template `metacity-theme-1.xml.in` is included which perfectly emulates window border rendering from GNOME Shell and CSD windows, including window button spacing, off-sets, titles and colours.

Finally, the meson build system configuration is updated to install the Metacity themes. Versioned symlinks of the `metacity-theme-x.xml` are also catered for, to support Metacity, Marco, Compiz, etc.