### PR TITLE
GtkTheme: do not change tab fg color on hover

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -270,7 +270,6 @@ notebook > header {
                   border-color: transparent;
                 }
               }
-              &:hover:not(:checked):not(:backdrop) { color: $insensitive_fg_color; }
             }
           }
         }


### PR DESCRIPTION
![ya](https://user-images.githubusercontent.com/15329494/107038103-51deca80-67bc-11eb-9fa5-ab1141a4394f.png)
![Peek 2021-02-05 14-11](https://user-images.githubusercontent.com/15329494/107038105-52776100-67bc-11eb-8354-7cf3882f290a.gif)

Fixes #2588 