### PR TITLE
gnome-shell: Use $osd_fg_color for all the login messages

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
@@ -84,7 +84,7 @@
   }
 
   .caps-lock-warning-label,
-  .login-dialog-message-warning {
+  .login-dialog-message { // Yaru: we want all login messages to use OSD fg color
     color: $osd_fg_color;
   }
 }


### PR DESCRIPTION
We accidentally reverted this change (commit ad9d2b18) in commit 49b71e3
causing the PAM info messages (as the one for fingerprint) being drawn
with the wrong color.