### PR TITLE
ShellTheme: make the dark shell darker

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -2,14 +2,14 @@
 // it gets @if ed depending on $variant
 @import 'palette';
 
-$base_color: if($variant == 'light', #ffffff, lighten(desaturate($jet, 20%), 10%));
-$bg_color: if($variant == 'light', #FAFAFA, lighten($inkstone, 0.5%));
+$base_color: if($variant == 'light', #ffffff, lighten($jet, 4%));
+$bg_color: if($variant == 'light', #FAFAFA, lighten($jet, 6%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 
 $selected_fg_color: $primary_accent_fg_color;
 $selected_bg_color: if($variant == 'light', $primary_accent_bg_color, darken($primary_accent_bg_color, 4%));
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 11%));
+$borders_color: if($variant == 'light', darken($bg_color, 20%), transparentize(white, 0.9));
 $alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', $linkblue, $blue);

--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -6,7 +6,7 @@ $slider_size: 15px;
   height: $slider_size;
   // slider trough
   -barlevel-height: 3px; // has to be an odd number
-  -barlevel-background-color: $dark_fill; //background of the trough // Yaru: adapt the trough to gtk
+  -barlevel-background-color: darken($osd_fg_color, 35%); //background of the trough // Yaru: improve trough sharpness
   -barlevel-border-width: 1px;
   -barlevel-border-color: $borders_color; // trough border color
   // fill style
@@ -21,7 +21,7 @@ $slider_size: 15px;
   -slider-handle-border-width: 1px;
   -slider-handle-border-color: darken($alt_borders_color, 3%); // Yaru: the handle border needs to be darker for the light theme
 
-  color: lighten($bg_color, 12%);
+  color: $osd_fg_color; // Yaru: perma white knob resembles the osd slider look in gtk
   &:hover { color: $hover_bg_color; }
   &:active { color: $active_bg_color; }
 }


### PR DESCRIPTION
Independent of the decision which theme to default to (light or dark) this commit includes the following changes:

- for popups, notifications and dialogs the dark theme is now much darker, having a transparent border. The background however is *not* transparent, unlike in previous iterations, to prevent visual glitches
- border is also slightly darker than the OSD border
- the slider knob is adapted to the OSD chroma in gtk, the slider trough sharpness is improved by using a solid darkened white
- **_all these changes do not affect the light (currently default) theme_**

![dark_shell_desktop](https://user-images.githubusercontent.com/15329494/107615684-e75edc00-6c4c-11eb-87ff-814cef80cd0a.png)
![dark_shell_overiew](https://user-images.githubusercontent.com/15329494/107615688-e9289f80-6c4c-11eb-859b-297a836ff90e.png)
![Screenshot from 2021-02-11 09-33-48](https://user-images.githubusercontent.com/15329494/107615690-eaf26300-6c4c-11eb-85fa-73f922c046b1.png)
![Screenshot from 2021-02-11 09-41-34](https://user-images.githubusercontent.com/15329494/107615961-66541480-6c4d-11eb-906b-778f4812aa45.png)

Edit: sorry missed this:

the rationale behind this is that the current very light "dark" colors are not blending so well over the gtk windows in my opinion. This dark/jet look features the current ubuntu style better, in my opinion.
So this is exclusively a style change and there are no technical problem with the dark shell currently in master