### PR TITLE
ShellTheme: dark shell sliders, switches and button improvements

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -175,7 +175,7 @@
   // insensitive button
   @else if $t==insensitive {
     color: $insensitive_fg_color;
-    border-color: $insensitive_borders_color;
+    border-color: if($variant=='light', $insensitive_borders_color, darken($c, 5%)); // Yaru change: dark buttons need a dark border
     background-color: $insensitive_bg_color;
     box-shadow: none;
     text-shadow: none;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -19,7 +19,7 @@ $slider_size: 15px;
   // slider handler
   -slider-handle-radius: $slider_size * 0.5; // half the size of the size
   -slider-handle-border-width: 1px;
-  -slider-handle-border-color: darken($alt_borders_color, 3%); // Yaru: the handle border needs to be darker for the light theme
+  -slider-handle-border-color: if($variant=='light', darken($alt_borders_color, 3%), $borders_color); // Yaru: the handle border needs to be darker for the light theme
 
   color: $osd_fg_color; // Yaru: perma white knob resembles the osd slider look in gtk
   &:hover { color: $hover_bg_color; }

--- a/gnome-shell/src/toggle-off-dark.svg
+++ b/gnome-shell/src/toggle-off-dark.svg
@@ -5,90 +5,79 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="46"
    height="22"
+   viewBox="0 0 46 22"
    version="1.1"
-   id="svg16"
-   sodipodi:docname="toggle-off-dark.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   id="svg2751"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="toggle-off-intl.svg">
+  <defs
+     id="defs2745" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#535353"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="0.23417233"
+     inkscape:cy="13.70951"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     showborder="false"
+     inkscape:window-width="1848"
+     inkscape:window-height="942"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3298" />
+  </sodipodi:namedview>
   <metadata
-     id="metadata20">
+     id="metadata2748">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1056"
-     inkscape:window-height="888"
-     id="namedview18"
-     showgrid="false"
-     inkscape:zoom="8.7391304"
-     inkscape:cx="23"
-     inkscape:cy="10.828358"
-     inkscape:window-x="670"
-     inkscape:window-y="78"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g14" />
-  <defs
-     id="defs8">
-    <linearGradient
-       id="a">
-      <stop
-         offset="0"
-         stop-color="#39393a"
-         id="stop2" />
-      <stop
-         offset="1"
-         stop-color="#302f30"
-         id="stop4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#a"
-       id="b"
-       x1="53"
-       y1="294.429"
-       x2="53"
-       y2="309.804"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-42.76)" />
-  </defs>
   <g
-     transform="translate(0,-291.18)"
-     id="g14"
-     style="stroke-width:1.08500004">
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-291.17916)">
     <rect
-       style="fill:#363636;stroke:#222222;marker:none;fill-opacity:1;stroke-opacity:1"
-       width="44.445999"
-       height="20.910999"
+       style="opacity:1;vector-effect:none;fill:#363636;fill-opacity:1;stroke:#363636;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       id="rect3296"
+       width="44.446434"
+       height="20.910645"
        x="0.625"
-       y="291.715"
-       rx="10.455"
-       ry="10.073"
-       id="rect10" />
+       y="291.71494"
+       rx="10.455324"
+       ry="10.073335" />
     <rect
-       ry="10.455"
-       rx="10.455"
-       y="291.715"
-       x="0.54299998"
-       height="20.910999"
-       width="21.143"
-       style="fill:#595959;stroke:#222222;marker:none;fill-opacity:1;stroke-opacity:1"
-       id="rect12" />
+       ry="10.455322"
+       rx="10.455322"
+       y="291.71494"
+       x="0.5428465"
+       height="20.910645"
+       width="21.142862"
+       id="rect3300"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.08532763;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.64783335;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
   </g>
 </svg>

--- a/gnome-shell/src/toggle-on-dark.svg
+++ b/gnome-shell/src/toggle-on-dark.svg
@@ -13,7 +13,7 @@
    version="1.1"
    id="svg16"
    sodipodi:docname="toggle-on-dark.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
   <metadata
      id="metadata20">
     <rdf:RDF>
@@ -34,17 +34,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1103"
-     inkscape:window-height="691"
+     inkscape:window-width="1848"
+     inkscape:window-height="942"
      id="namedview18"
      showgrid="false"
      inkscape:zoom="7.5652174"
-     inkscape:cx="10.045977"
+     inkscape:cx="-15.399425"
      inkscape:cy="11"
-     inkscape:window-x="78"
-     inkscape:window-y="29"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g14" />
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g14"
+     inkscape:document-rotation="0" />
   <defs
      id="defs8">
     <linearGradient
@@ -73,7 +74,7 @@
      id="g14"
      style="stroke:#7c436f;stroke-width:1.08500004;stroke-opacity:1">
     <rect
-       style="fill:#7c436f;fill-opacity:1;stroke:#222222;stroke-opacity:1;marker:none"
+       style="fill:#7c436f;fill-opacity:1;stroke:#7c436f;stroke-opacity:1;marker:none"
        width="44.445999"
        height="20.910999"
        x="0.625"
@@ -88,7 +89,7 @@
        x="24.304001"
        height="20.910999"
        width="21.143"
-       style="fill:#595959;stroke:#222222;stroke-opacity:1;marker:none;fill-opacity:1"
+       style="fill:#ffffff;stroke:#ffffff;stroke-opacity:0.64999998;marker:none;fill-opacity:1"
        id="rect12" />
   </g>
 </svg>


### PR DESCRIPTION
- dark shell slider border is now crisp
Before:
![Screenshot from 2021-02-13 20-52-20](https://user-images.githubusercontent.com/15329494/107860117-d88b4b80-6e3d-11eb-8be1-2ba53f7fa45f.png)
After:
![Screenshot from 2021-02-13 20-51-31](https://user-images.githubusercontent.com/15329494/107860127-e2ad4a00-6e3d-11eb-9a71-716c947c53e4.png)


- dark shell switch border is now crisp
- dark shell switch knob color is now white like the slider
Before:
![Screenshot from 2021-02-13 20-52-25](https://user-images.githubusercontent.com/15329494/107860143-f0fb6600-6e3d-11eb-8826-f9dbdcf92728.png)
After:
![Screenshot from 2021-02-13 20-51-36](https://user-images.githubusercontent.com/15329494/107860148-f5c01a00-6e3d-11eb-9748-0eaa9ab18af9.png)


- dark shell insensitive button border is now dark and not descending from the light borders
Before:
![Screenshot from 2021-02-13 20-52-30](https://user-images.githubusercontent.com/15329494/107860184-35870180-6e3e-11eb-948a-5f6be9ed20bf.png)
After:
![Screenshot from 2021-02-13 20-51-46](https://user-images.githubusercontent.com/15329494/107860163-12f4e880-6e3e-11eb-8830-4443efbd4000.png)
