### PR TITLE
Gtk theme: darker dark theme

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -23,8 +23,15 @@ $ambiance: null !default;
     // keep details box visible
     // details box looks ugly when many items are selected and it floats above the orange
     background-image: none;
-    background-color: if($variant=='light', white, $base_color);
-    &:backdrop { background-color: $backdrop_base_color }
+    background-color: if($variant=='light', white, $bg_color);
+    &:backdrop { background-color: if($variant=='light',  $backdrop_base_color, $backdrop_bg_color); }
+
+    placessidebar {
+      background-color: if($variant=='light', $bg_color, $base_color);
+      &:backdrop {
+        background-color: if($variant=='light', $backdrop_bg_color, $backdrop_base_color);
+      }
+    }
 
     // Makes icons less bright in backdrop
     @at-root %dim_icons_in_backdrop,

--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -29,7 +29,7 @@ $ambiance: null !default;
     placessidebar {
       background-color: if($variant=='light', $bg_color, $base_color);
       &:backdrop {
-        background-color: if($variant=='light', $backdrop_bg_color, $backdrop_base_color);
+        background-color: $backdrop_bg_color;
       }
     }
 

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -55,9 +55,9 @@ $insensitive_borders_color: $borders_color;
 
 //colors for the backdrop state, derived from the main colors.
 $backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 3%));
-$backdrop_text_color: if($variant == 'light', mix($text_color, $backdrop_base_color, 80%), mix($text_color, $backdrop_base_color, 60%));
+$backdrop_text_color: if($variant == 'light', mix($text_color, $backdrop_base_color, 80%), transparentize(white, 0.45));
 $backdrop_bg_color: if($variant == 'light', $bg_color, lighten($bg_color, 3%));
-$backdrop_fg_color: if($variant == 'light', mix($fg_color, $backdrop_bg_color, 80%), mix($fg_color, $backdrop_bg_color, 60%));
+$backdrop_fg_color: if($variant == 'light', mix($fg_color, $backdrop_bg_color, 80%), transparentize(white, 0.35));
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
 $backdrop_borders_color: mix($borders_color, $bg_color, 80%);

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -55,9 +55,9 @@ $insensitive_borders_color: $borders_color;
 
 //colors for the backdrop state, derived from the main colors.
 $backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 3%));
-$backdrop_text_color: mix($text_color, $backdrop_base_color, 80%);
+$backdrop_text_color: if($variant == 'light', mix($text_color, $backdrop_base_color, 80%), mix($text_color, $backdrop_base_color, 60%));
 $backdrop_bg_color: if($variant == 'light', $bg_color, lighten($bg_color, 3%));
-$backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 80%);
+$backdrop_fg_color: if($variant == 'light', mix($fg_color, $backdrop_bg_color, 80%), mix($fg_color, $backdrop_bg_color, 60%));
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
 $backdrop_borders_color: mix($borders_color, $bg_color, 80%);

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -2,25 +2,25 @@
 // it gets @if ed depending on $variant
 @import 'palette';
 
-$base_color: if($variant == 'light', #ffffff, lighten(desaturate($jet, 20%), 11%));
+$base_color: if($variant == 'light', #ffffff, lighten($jet, 6%));
 $text_color: if($variant == 'light', black, white);
-$bg_color: if($variant == 'light', $porcelain, lighten($inkstone, 0.5%));
+$bg_color: if($variant == 'light', #FAFAFA, lighten($jet, 8%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 
 $selected_fg_color: $primary_accent_fg_color;
 $selected_bg_color: if($variant == 'light', $primary_accent_bg_color, darken($primary_accent_bg_color, 4%));
 
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 11%));
-$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
+$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 8%));
+$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 9%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', $linkblue, $blue);
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
-$menu_color: if($variant == 'light', #FAFAFA, lighten($inkstone, 1%));
-$popover_bg_color: if($variant == 'light', #FAFAFA, lighten($inkstone, 1%));
+$menu_color: if($variant == 'light', #FAFAFA, $base_color);
+$popover_bg_color: if($variant == 'light', #FAFAFA, $base_color);
 $popover_hover_color: transparentize($fg_color, 0.85);
 
 $scrollbar_bg_color: if($variant == 'light', mix($bg_color, $fg_color, 80%), mix($base_color, $bg_color, 50%));

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -19,8 +19,8 @@ $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
-$menu_color: if($variant == 'light', #FAFAFA, $base_color);
-$popover_bg_color: if($variant == 'light', #FAFAFA, $base_color);
+$menu_color: if($variant == 'light', $bg_color, $base_color);
+$popover_bg_color: if($variant == 'light', $bg_color, $base_color);
 $popover_hover_color: transparentize($fg_color, 0.85);
 
 $scrollbar_bg_color: if($variant == 'light', mix($bg_color, $fg_color, 80%), mix($base_color, $bg_color, 50%));

--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -54,9 +54,9 @@ $insensitive_bg_color: mix($bg_color, $base_color, 60%);
 $insensitive_borders_color: $borders_color;
 
 //colors for the backdrop state, derived from the main colors.
-$backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 1%));
+$backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 3%));
 $backdrop_text_color: mix($text_color, $backdrop_base_color, 80%);
-$backdrop_bg_color: $bg_color;
+$backdrop_bg_color: if($variant == 'light', $bg_color, lighten($bg_color, 3%));
 $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 80%);
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -351,7 +351,7 @@
   // backdrop insensitive button
   //
 
-    $_bg: if($c != $bg_color, mix($c, $base_color, 85%), $insensitive_bg_color);
+    $_bg: if($c != $bg_color, mix($c, $base_color, 85%), if($variant=='light', $insensitive_bg_color, lighten($insensitive_bg_color, 3%))); // Yaru change
     $_bc: if($variant == 'light', $_bg,_border_color($c));
 
     color: if($c != $bg_color, mix($tc, $_bg, 35%), $backdrop_insensitive_color);

--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -492,7 +492,7 @@
 //
   $gradient: linear-gradient(to top, darken($c, 0%), lighten($c, 0%)); // Yaru change: no gradients
 
-  @if $variant == 'dark' { $gradient: linear-gradient(to top, lighten($c, 3%), lighten($c, 3%)); } // Yaru change: no gradients
+  @if $variant == 'dark' { $gradient: linear-gradient(to top, lighten($c, 6%), lighten($c, 6%)); } // Yaru change: no gradients
 
   @if $ov != none { background: $c $ov, $gradient; }
   @else { background: $c $gradient; }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -379,6 +379,7 @@ decoration {
 popover.background {  
   .csd &, & {
     border-color: if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
+    &:backdrop { border-color: $backdrop_borders_color; }
   }
 }
 

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -369,10 +369,10 @@ levelbar {
 
 // Strengthen the menu shadows
 // And lighten up the dark shell menu/popover border to increase visibility
-$_dark_theme_outer_menu_border: lighten($base_color, 11%);
+$_dark_theme_outer_menu_border: lighten(desaturate($base_color, 100%), 12%);
 decoration {
   .csd.popup & {
-    box-shadow: 0 1px 2px 1px transparentize(black, 0.7),
+    box-shadow: 0 1px 2px 1px transparentize(black, if($variant=='light', 0.7, 0.6)),
                 0 0 0 1px if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
   }
 }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -367,13 +367,18 @@ levelbar {
   }
 }
 
-// Strengthen the menu shadows to increase visibility
+// Strengthen the menu shadows
+// And lighten up the dark shell menu/popover border to increase visibility
+$_dark_theme_outer_menu_border: lighten($base_color, 11%);
 decoration {
-  $_wm_border: if($variant=='light', transparentize(black, 0.77), transparentize($borders_color, 0.1));
   .csd.popup & {
-    border-radius: $menu_radius;
     box-shadow: 0 1px 2px 1px transparentize(black, 0.7),
-                0 0 0 1px $_wm_border;
+                0 0 0 1px if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
+  }
+}
+popover.background {  
+  .csd &, & {
+    border-color: if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
   }
 }
 

--- a/gtk/src/default/gtk-4.0/_colors.scss
+++ b/gtk/src/default/gtk-4.0/_colors.scss
@@ -2,25 +2,25 @@
 // it gets @if ed depending on $variant
 @import 'palette';
 
-$base_color: if($variant == 'light', #ffffff, lighten(desaturate($jet, 20%), 11%));
+$base_color: if($variant == 'light', #ffffff, lighten($jet, 6%));
 $text_color: if($variant == 'light', black, white);
-$bg_color: if($variant == 'light', $porcelain, lighten($inkstone, 0.5%));
+$bg_color: if($variant == 'light', #FAFAFA, lighten($jet, 8%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 
 $selected_fg_color: $primary_accent_fg_color;
 $selected_bg_color: if($variant == 'light', $primary_accent_bg_color, darken($primary_accent_bg_color, 6%));
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 11%));
-$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
+$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 8%));
+$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 9%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', $linkblue, $blue);
 $link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_bg_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
-$menu_color: $base_color;
+$menu_color: if($variant == 'light', $bg_color, $base_color);
 $menu_selected_color: if($variant == 'light', darken($bg_color, 6%), darken($bg_color, 8%));
-$popover_bg_color: if($variant == 'light', #FAFAFA, lighten($inkstone, 1%));
+$popover_bg_color: if($variant == 'light', $bg_color, $base_color);
 $popover_hover_color: transparentize($fg_color, 0.85);
 
 $scrollbar_bg_color: if($variant == 'light', mix($bg_color, $fg_color, 80%), mix($base_color, $bg_color, 50%));

--- a/gtk/src/default/gtk-4.0/_colors.scss
+++ b/gtk/src/default/gtk-4.0/_colors.scss
@@ -53,9 +53,9 @@ $insensitive_bg_color: mix($bg_color, $base_color, 60%);
 $insensitive_borders_color: mix($borders_color, $bg_color, 80%);
 
 //colors for the backdrop state, derived from the main colors.
-$backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 1%));
+$backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 3%));
 $backdrop_text_color: mix($text_color, $backdrop_base_color, 80%);
-$backdrop_bg_color: $bg_color;
+$backdrop_bg_color: if($variant == 'light', $bg_color, lighten($bg_color, 3%));
 $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 50%);
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);

--- a/gtk/src/default/gtk-4.0/_colors.scss
+++ b/gtk/src/default/gtk-4.0/_colors.scss
@@ -54,9 +54,9 @@ $insensitive_borders_color: mix($borders_color, $bg_color, 80%);
 
 //colors for the backdrop state, derived from the main colors.
 $backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 3%));
-$backdrop_text_color: if($variant == 'light', mix($text_color, $backdrop_base_color, 80%), mix($text_color, $backdrop_base_color, 60%));
+$backdrop_text_color: if($variant == 'light', mix($text_color, $backdrop_base_color, 80%), transparentize(white, 0.45));
 $backdrop_bg_color: if($variant == 'light', $bg_color, lighten($bg_color, 3%));
-$backdrop_fg_color: if($variant == 'light', mix($fg_color, $backdrop_bg_color, 50%), mix($fg_color, $backdrop_bg_color, 60%));
+$backdrop_fg_color: if($variant == 'light', mix($fg_color, $backdrop_bg_color, 80%), transparentize(white, 0.35));
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
 $backdrop_borders_color: mix($borders_color, $bg_color, 80%);

--- a/gtk/src/default/gtk-4.0/_colors.scss
+++ b/gtk/src/default/gtk-4.0/_colors.scss
@@ -54,9 +54,9 @@ $insensitive_borders_color: mix($borders_color, $bg_color, 80%);
 
 //colors for the backdrop state, derived from the main colors.
 $backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 3%));
-$backdrop_text_color: mix($text_color, $backdrop_base_color, 80%);
+$backdrop_text_color: if($variant == 'light', mix($text_color, $backdrop_base_color, 80%), mix($text_color, $backdrop_base_color, 60%));
 $backdrop_bg_color: if($variant == 'light', $bg_color, lighten($bg_color, 3%));
-$backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 50%);
+$backdrop_fg_color: if($variant == 'light', mix($fg_color, $backdrop_bg_color, 50%), mix($fg_color, $backdrop_bg_color, 60%));
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_selected_fg_color: if($variant == 'light', $backdrop_base_color, $backdrop_text_color);
 $backdrop_borders_color: mix($borders_color, $bg_color, 80%);

--- a/gtk/src/default/gtk-4.0/_drawing.scss
+++ b/gtk/src/default/gtk-4.0/_drawing.scss
@@ -357,7 +357,7 @@ $_default_button_c: lighten($bg_color,2%);
 // $c:  base color
 // $ov: a background layer for background shorthand (hence no commas!)
 //
-  $gradient: if($variant=='light', image($c), image(lighten($c, 4%)));  // Yaru change: remove gradient
+  $gradient: if($variant=='light', image($c), image(lighten($c, 6%)));  // Yaru change: remove gradient
 
   @if $ov != none { background: $c $ov, $gradient; }
   @else { background: $c $gradient; }

--- a/gtk/src/default/gtk-4.0/_drawing.scss
+++ b/gtk/src/default/gtk-4.0/_drawing.scss
@@ -230,7 +230,7 @@ $_default_button_c: lighten($bg_color,2%);
   // backdrop insensitive button
   //
 
-    $_bg: if($c != $_default_button_c, mix($c, $base_color, 85%), $insensitive_bg_color);
+    $_bg: if($c != $bg_color, mix($c, $base_color, 85%), if($variant=='light', $insensitive_bg_color, lighten($insensitive_bg_color, 3%))); // Yaru change
     $_bc: if($variant == 'light', $_bg,_border_color($c));
 
     color: if($c != $_default_button_c, mix($tc, $_bg, 35%), $backdrop_insensitive_color);

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -288,6 +288,7 @@ decoration {
 popover.background {  
   .csd &, & {
     border-color: if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
+    &:backdrop { border-color: $backdrop_borders_color; }
   }
 }
 

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -276,14 +276,19 @@ levelbar > trough > block {
     }
 }
 
-// Strengthen the menu shadows to increase visibility
+// Strengthen the menu shadows
+// And lighten up the dark shell menu/popover border to increase visibility
+$_dark_theme_outer_menu_border: lighten(desaturate($base_color, 100%), 12%);
 decoration {
-    $_wm_border: if($variant=='light', transparentize(black, 0.77), transparentize($borders_color, 0.1));
-    .csd.popup & {
-        border-radius: $menu_radius;
-        box-shadow: 0 1px 2px 1px transparentize(black, 0.7),
-        0 0 0 1px $_wm_border;
-    }
+  .csd.popup & {
+    box-shadow: 0 1px 2px 1px transparentize(black, if($variant=='light', 0.7, 0.6)),
+                0 0 0 1px if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
+  }
+}
+popover.background {  
+  .csd &, & {
+    border-color: if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
+  }
 }
 
 // Reduce hyper prominent dark theme check switch border in backdrop


### PR DESCRIPTION
- base the whole gtk dark theme on $jet `#181818` instead of $inkstone `#3b3b3b`
- as a result everything is now a bit darker
- another result is that the dark gtk theme is now closer to the shell popups/dialogs/notifications
- the gtk theme however does not use half transparent borders to avoid glitches
- gtk4 is adapted to this change (should be the same result ideally)

WIP: up-to-date screenshots can be followed through in the conversation below


Everyone please have a look and share your feedback.

Closes #2227 