### PR TITLE
GtkTheme: tone down selected rows

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -89,6 +89,21 @@ $ambiance: null !default;
 
       // Hide superfluous treeview drop target indication
       &.dnd { border-style: none; }
+
+      $_selection_bg: if($variant=='light', darken($bg_color, 5%), lighten($base_color, 5%));
+      treeview {
+        &:selected {
+          background-color: $_selection_bg;
+          color: $fg_color;
+          &:hover {
+            background-color: if($variant=='light', darken($_selection_bg, 5%), lighten($_selection_bg, 5%));
+          }
+          &:backdrop {
+            color: $backdrop_fg_color;
+            background-color: $_selection_bg;
+          }
+        }
+      }
     }
 
     notebook > header {

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -391,3 +391,23 @@ switch {
     }
   }
 }
+
+// Due to the ubuntu orange beeing quiet bright
+// we change the sidebar selection from a full orange
+// row to a thin orange stripe plus a soft gray selection
+$_selection_bg: if($variant=='light', darken($bg_color, 5%), lighten($base_color, 5%));
+list row, placessidebar row, sidebar row, .sidebar row {
+  &:selected {
+    &.activatable, & {
+      &, &:hover {
+        background-color: $_selection_bg;
+        &, button { &, & image { color: if($variant=='light', $fg_color, darken($fg_color, 10%)); } }
+        box-shadow: inset 4px 0 0 $selected_bg_color;
+        &:backdrop {
+          color: $backdrop_fg_color;
+          background-color: if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%));
+        }      
+      }
+    }
+  }
+}

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -401,7 +401,7 @@ list row, placessidebar row, sidebar row, .sidebar row {
     &.activatable, & {
       &, &:hover {
         background-color: $_selection_bg;
-        &, button { &, & image { color: if($variant=='light', $fg_color, darken($fg_color, 10%)); } }
+        &, button { &, & image { color: $text_color; } }
         box-shadow: inset 4px 0 0 $selected_bg_color;
         &:backdrop {
           color: $backdrop_fg_color;

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -404,7 +404,7 @@ list row, placessidebar row, sidebar row, .sidebar row {
         &, button { &, & image { color: $text_color; } }
         box-shadow: inset 4px 0 0 $selected_bg_color;
         &:backdrop {
-          color: $backdrop_fg_color;
+          &, button { &, & image { color: $backdrop_fg_color; } }
           background-color: if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%));
         }      
       }

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -318,7 +318,7 @@ list row, placessidebar row, sidebar row, .sidebar row {
     &.activatable, & {
       &, &:hover {
         background-color: $_selection_bg;
-        &, button { &, & image { color: if($variant=='light', $fg_color, darken($fg_color, 10%)); } }
+        &, button { &, & image { color: $text_color; } }
         box-shadow: inset 4px 0 0 $selected_bg_color;
         &:backdrop {
           color: $backdrop_fg_color;

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -308,3 +308,23 @@ radio {
     transition-duration: 200ms;
     transition-timing-function: ease;
 }
+
+// Due to the ubuntu orange beeing quiet bright
+// we change the sidebar selection from a full orange
+// row to a thin orange stripe plus a soft gray selection
+$_selection_bg: if($variant=='light', darken($bg_color, 5%), lighten($base_color, 5%));
+list row, placessidebar row, sidebar row, .sidebar row {
+  &:selected {
+    &.activatable, & {
+      &, &:hover {
+        background-color: $_selection_bg;
+        &, button { &, & image { color: if($variant=='light', $fg_color, darken($fg_color, 10%)); } }
+        box-shadow: inset 4px 0 0 $selected_bg_color;
+        &:backdrop {
+          color: $backdrop_fg_color;
+          background-color: if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%));
+        }      
+      }
+    }
+  }
+}

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -321,8 +321,8 @@ list row, placessidebar row, sidebar row, .sidebar row {
         &, button { &, & image { color: $text_color; } }
         box-shadow: inset 4px 0 0 $selected_bg_color;
         &:backdrop {
-          color: $backdrop_fg_color;
-          background-color: if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%));
+            &, button { &, & image { color: $backdrop_fg_color; } }
+            background-color: if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%));
         }      
       }
     }


### PR DESCRIPTION
Due to the ubuntu orange being quiet bright
we change the sidebar selection from a full orange
row to a thin orange stripe plus a soft gray selection
This change does not affect treeview rows, only .nautilus-list-view treeview

Before:
![grafik](https://user-images.githubusercontent.com/15329494/108713716-e8c7b880-7518-11eb-8c87-4268c2c4cf43.png)
![grafik](https://user-images.githubusercontent.com/15329494/108713743-f2e9b700-7518-11eb-882d-db35df119194.png)

![grafik](https://user-images.githubusercontent.com/15329494/108713779-fed57900-7518-11eb-89cd-3f321a122b88.png)
![grafik](https://user-images.githubusercontent.com/15329494/108713820-08f77780-7519-11eb-8f6b-83178f9f6714.png)


After:
![grafik](https://user-images.githubusercontent.com/15329494/108713538-a8683a80-7518-11eb-9634-71b3a4019686.png)
![grafik](https://user-images.githubusercontent.com/15329494/108713572-b322cf80-7518-11eb-99dd-face6dde2fe3.png)

![grafik](https://user-images.githubusercontent.com/15329494/108713614-c5047280-7518-11eb-8adf-d74177463f3a.png)
![grafik](https://user-images.githubusercontent.com/15329494/108713649-ce8dda80-7518-11eb-9efa-02d499b15ee5.png)

CC @madsrh @elioqoshi @waynecrosby

Closes #2666 
Closes #2408 