### PR TITLE
Mate: do not round brisk menu

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -1095,7 +1095,7 @@ MsdOsdWindow.background.osd {
     margin: 4px;
   }
 
-  &, .apps-list, .categories-list {
+  .apps-list, .categories-list {
     border-radius: $menu_radius;
   }
 


### PR DESCRIPTION
I failed to round the brisk menu without a black surface behind leaking through.
This axes the border-radius for the brisk menu