### PR TITLE
Shell and gtk themes: do not transparentize border

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -9,7 +9,7 @@ $fg_color: if($variant == 'light', $inkstone, $porcelain);
 $selected_fg_color: $primary_accent_fg_color;
 $selected_bg_color: if($variant == 'light', $primary_accent_bg_color, darken($primary_accent_bg_color, 4%));
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-$borders_color: if($variant == 'light', darken($bg_color, 20%), transparentize(white, 0.9));
+$borders_color: if($variant == 'light', darken($bg_color, 20%), lighten(desaturate($base_color, 100%), 14%));
 $alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
 $link_color: if($variant == 'light', $linkblue, $blue);

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -369,7 +369,7 @@ levelbar {
 
 // Strengthen the menu shadows
 // And lighten up the dark shell menu/popover border to increase visibility
-$_dark_theme_outer_menu_border: lighten(desaturate($base_color, 100%), 12%);
+$_dark_theme_outer_menu_border: lighten(desaturate($base_color, 100%), 14%);
 decoration {
   .csd.popup & {
     box-shadow: 0 1px 2px 1px transparentize(black, if($variant=='light', 0.7, 0.6)),

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -278,7 +278,7 @@ levelbar > trough > block {
 
 // Strengthen the menu shadows
 // And lighten up the dark shell menu/popover border to increase visibility
-$_dark_theme_outer_menu_border: lighten(desaturate($base_color, 100%), 12%);
+$_dark_theme_outer_menu_border: lighten(desaturate($base_color, 100%), 14%);
 decoration {
   .csd.popup & {
     box-shadow: 0 1px 2px 1px transparentize(black, if($variant=='light', 0.7, 0.6)),


### PR DESCRIPTION
all dark themes: slightly brighten up the borders
shell theme: do not use a transparent border, as it becomes blurry on certain backgrounds

Before:
![before](https://user-images.githubusercontent.com/15329494/109675603-3c20b300-7b78-11eb-906e-b2aa32054212.png)


After:
![after](https://user-images.githubusercontent.com/15329494/109675633-404cd080-7b78-11eb-8113-28440a906db3.png)

CC @elioqoshi @madsrh 
