### PR TITLE
GtkTheme: align dark themes separators to shell

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -376,11 +376,21 @@ decoration {
                 0 0 0 1px if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
   }
 }
-popover.background {  
+@if $variant=='dark' {
+  menu separator {
+    background-color: $_dark_theme_outer_menu_border;
+  }
+}
+popover.background {
   .csd &, & {
     border-color: if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
     &:backdrop { border-color: $backdrop_borders_color; }
   }
+  @if $variant=='dark' {
+    separator {
+      background-color: $_dark_theme_outer_menu_border;
+    }
+  }  
 }
 
 // Reduce hyper prominent dark theme check switch border in backdrop

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -285,20 +285,21 @@ decoration {
                 0 0 0 1px if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
   }
 }
-popover.background {  
+@if $variant=='dark' {
+  menu separator {
+    background-color: $_dark_theme_outer_menu_border;
+  }
+}
+popover.background {
   .csd &, & {
     border-color: if($variant=='light', transparentize(black, 0.77), $_dark_theme_outer_menu_border);
     &:backdrop { border-color: $backdrop_borders_color; }
   }
-}
-
-// Reduce hyper prominent dark theme check switch border in backdrop
-switch {
-    &:backdrop {
-        &:checked {
-            &, slider { border-color: if($variant=='light', $checkradio_borders_color, $backdrop_borders_color); }
-        }
+  @if $variant=='dark' {
+    separator {
+      background-color: $_dark_theme_outer_menu_border;
     }
+  }  
 }
 
 // Add some transitions on checks and radios


### PR DESCRIPTION
This aligns gtk dark themes menus and popovers to shell themes popup separators 

Before:
![popovers_before](https://user-images.githubusercontent.com/15329494/109936583-5cfb1c80-7cce-11eb-9025-a40c70b64306.png)
![menus_before](https://user-images.githubusercontent.com/15329494/109936590-5e2c4980-7cce-11eb-973a-adc0d10cb6ba.png)


After:
![popovers_after](https://user-images.githubusercontent.com/15329494/109936628-65535780-7cce-11eb-88c2-7772b597a2ed.png)
![menu_after](https://user-images.githubusercontent.com/15329494/109936633-65ebee00-7cce-11eb-8c7d-caec550ce60b.png)

CC @madsrh @elioqoshi 