### PR TITLE
GtkThemes: fixes for backdrop text and headerbar switches

### DIFF
--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -55,7 +55,7 @@ $insensitive_borders_color: $borders_color;
 
 //colors for the backdrop state, derived from the main colors.
 $backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 3%));
-$backdrop_text_color: if($variant == 'light', mix($text_color, $backdrop_base_color, 80%), transparentize(white, 0.45));
+$backdrop_text_color: if($variant == 'light', transparentize($text_color, 0.31), transparentize(white, 0.45));
 $backdrop_bg_color: if($variant == 'light', $bg_color, lighten($bg_color, 3%));
 $backdrop_fg_color: if($variant == 'light', mix($fg_color, $backdrop_bg_color, 80%), transparentize(white, 0.35));
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));

--- a/gtk/src/default/gtk-3.20/_headerbar.scss
+++ b/gtk/src/default/gtk-3.20/_headerbar.scss
@@ -244,6 +244,9 @@ headerbar,
   // Re-style sliders for switches and scales do make them look sharp on the dark headerbar
   switch, scale {
     slider {
+      &:checked {
+        border-color: $checkradio_borders_color;
+      }
       &:backdrop {
         @include button(backdrop-alt, $_button_bg_color);
 

--- a/gtk/src/default/gtk-4.0/_colors.scss
+++ b/gtk/src/default/gtk-4.0/_colors.scss
@@ -54,7 +54,7 @@ $insensitive_borders_color: mix($borders_color, $bg_color, 80%);
 
 //colors for the backdrop state, derived from the main colors.
 $backdrop_base_color: if($variant == 'light', darken($base_color, 1%), lighten($base_color, 3%));
-$backdrop_text_color: if($variant == 'light', mix($text_color, $backdrop_base_color, 80%), transparentize(white, 0.45));
+$backdrop_text_color: if($variant == 'light', transparentize($text_color, 0.31), transparentize(white, 0.45));
 $backdrop_bg_color: if($variant == 'light', $bg_color, lighten($bg_color, 3%));
 $backdrop_fg_color: if($variant == 'light', mix($fg_color, $backdrop_bg_color, 80%), transparentize(white, 0.35));
 $backdrop_insensitive_color: if($variant == 'light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));

--- a/gtk/src/default/gtk-4.0/_headerbar.scss
+++ b/gtk/src/default/gtk-4.0/_headerbar.scss
@@ -210,12 +210,15 @@ headerbar {
   }
 
   switch, scale {
+    &:checked {
+      border-color: $checkradio_borders_color;
+    }
     slider {
-      @include button(normal-alt, $_button_bg_color);
+      @include button(normal, $_button_bg_color);
     }
 
     &:hover slider {
-      @include button(hover-alt, $_button_bg_color);
+      @include button(hover, $_button_bg_color);
     }
 
     &:checked > slider { border-color: $_button_border_color; }


### PR DESCRIPTION
- default theme: improved the headerbar switch slider border to not overlap too much
- default+light themes: lighten up the backdrop text color to have a similar color to backdrop fg color

Edit: also fixed a typo in gtk4 since there are no longer normal-alt and hover-alt types for the button mixin 

Closes #2227 