### PR TITLE
Gtk4: dark switch improvements

### DIFF
--- a/gtk/src/default/gtk-3.20/_drawing.scss
+++ b/gtk/src/default/gtk-3.20/_drawing.scss
@@ -243,7 +243,7 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    @include _shadows(0 1px transparentize(black, 0.99)); // Yaru change: less shadows for flatter buttons
+    @include _shadows(0 1px transparentize(black, 0.95)); // Yaru change: stronger shadows for flatter buttons
     background-image: image(if($variant=='light', lighten($c, 10%), $warm_gray)); // Yaru change: brighter alt
   }
 
@@ -637,4 +637,3 @@
     background-image: image($insensitive_bg_color);
   }
 }
-

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -375,6 +375,9 @@ list row, placessidebar row, sidebar row, .sidebar row {
 
 // Reduce hyper prominent dark theme check switch border in backdrop
 switch {
+  @if $variant=='dark' {
+    &:not(:checked):not(:backdrop):not(:disabled) { background-color: lighten($bg_color, 5%); }
+  }
   &:backdrop {
     &:checked:not(:disabled) {
       &, slider { border-color: if($variant=='light', $checkradio_borders_color, $backdrop_borders_color); }


### PR DESCRIPTION
Continued from #2704

![1](https://user-images.githubusercontent.com/36476595/110238218-a9e62980-7f40-11eb-9af1-8f48aeb0e1ae.png)

@Feichtmeier I see you changed the shadow of Gtk3 alt-buttons, as Gtk4 drop alt it is needed to add some more tweaks?