### PR TITLE
GtkThemes: orange close only on :hover / :active

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -110,7 +110,7 @@ button.titlebutton:not(.appmenu) {
   .titlebar &,
   headerbar.selection-mode &,
   & {
-    &.maximize, &.minimize {
+    &.maximize, &.minimize, &.close {
 
       &, &:backdrop {
         &:hover {
@@ -124,21 +124,19 @@ button.titlebutton:not(.appmenu) {
     }
 
     &.close {
-      color: $selected_fg_color;
-      @include draw_circle($selected_bg_color);
-
       &:hover {
+        color: $selected_fg_color;
         @include draw_circle($selected_bg_color);
         @include draw_circle(lighten($selected_bg_color, 5%));
       }
 
       &:active {
+        color: $selected_fg_color;
         @include draw_circle($selected_bg_color);
         @include draw_circle(darken($selected_bg_color, 5%));
       }
 
       &:backdrop {
-        @include draw_circle(lighten($inkstone, if($variant=='light', if($ambiance==true, 15%, 40%), 10%)));
         &:hover { @include draw_circle(lighten($inkstone, if($variant=='light', if($ambiance==true, 20%, 45%), 15%))); }
       }
     }

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -78,7 +78,7 @@ windowcontrols {
         box-shadow: none;
         background: transparent;
 
-        &.maximize, &.minimize {
+        &.maximize, &.minimize, &.close {
             &, &:backdrop {
                 background: transparent;
                 &:hover {
@@ -92,8 +92,6 @@ windowcontrols {
         }
 
         &.close {
-            background: $selected_bg_color;
-
             &:hover {
                 background: lighten($selected_bg_color, 5%);
             }
@@ -103,7 +101,6 @@ windowcontrols {
             }
 
             &:backdrop {
-                background: lighten($inkstone, if($variant=='light', if($ambiance==true, 15%, 40%), 10%));
                 &:hover { background: lighten($inkstone, if($variant=='light', if($ambiance==true, 20%, 45%), 15%)); }
             }
 


### PR DESCRIPTION
This removes the orange close circle and only shows it on :hover or :active or :backdrop:hover
No screenshots provided since this needs real testing.

@ubuntu/yaru-team please test if you :+1: or :-1: this

Edit: inspired by https://github.com/canonical/ubuntu-desktop-installer/issues/43: 
![](https://user-images.githubusercontent.com/10974330/110315051-fac15500-8008-11eb-92d9-77fc25af2dab.png)