### PR TITLE
Fix for mate and unity windows

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -1229,3 +1229,11 @@ window.background.caja-navigation-window #Toolbar:backdrop { background-color: $
     border-radius: 0 $button_radius $button_radius 0;
     border-right-width: 1px;
 }
+
+// Removes roundness and highlight from
+// Headerbars that are not the last vertical top element
+// of the window
+background:not(.csd) headerbar:not(.titlebar) {
+  border-radius: 0;
+  box-shadow: none;
+}


### PR DESCRIPTION
This removes the roundness and highlight from headerbars that are not the last vertical top element of a window

Closes #2715