### PR TITLE
Dark shell theme: tone down calendar separator

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
@@ -17,7 +17,7 @@
 // Calendar menu side column
 .datemenu-calendar-column {
   spacing: $base_spacing;
-  border: 0 solid $bubble_borders_color;
+  border: 0 solid if($variant=='light', $bubble_borders_color, darken($bubble_borders_color, 5%));
   padding: 0 $base_padding * 2;
 
   &:ltr {margin-right: $base_margin * 2; border-left-width: 1px; }


### PR DESCRIPTION
in the dark shell theme the calendar separator is too bright, this tones it down a bit

Before:
![Screenshot from 2021-03-11 19-51-34](https://user-images.githubusercontent.com/15329494/110839103-7f2f0480-82a3-11eb-926e-a9df54e65cf6.png)

After:
![Screenshot from 2021-03-11 19-50-02](https://user-images.githubusercontent.com/15329494/110839099-7e966e00-82a3-11eb-9b2d-fa816a97f9e8.png)