### PR TITLE
Fix Gnome-shell blurry slider

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -7,7 +7,7 @@ $slider_size: 15px;
   // slider trough
   -barlevel-height: 3px; // has to be an odd number
   -barlevel-background-color: $borders_color; //background of the trough
-  -barlevel-border-width: 1px; 
+  -barlevel-border-width: 0px; 
   -barlevel-border-color: $borders_color; // trough border color
   // fill style
   -barlevel-active-background-color: $progress_bg_color; //active trough fill // Yaru: we detached progress from selected


### PR DESCRIPTION
**Before:**

![Capture d’écran de 2021-03-21 12-13-39](https://user-images.githubusercontent.com/36476595/111902719-11bb6a80-8a3f-11eb-9cd7-8a7c48c6f728.png)

**After:**

![Capture d’écran de 2021-03-21 12-12-20](https://user-images.githubusercontent.com/36476595/111902726-15e78800-8a3f-11eb-999a-11d647968df0.png)
