### PR TITLE
Check upstream icons changes

### DIFF
--- a/.github/workflows/open-pr-on-icons-changes.yaml
+++ b/.github/workflows/open-pr-on-icons-changes.yaml
@@ -1,0 +1,61 @@
+name: Update PR on upstream icons changes
+on:
+  push:
+    paths:
+      - '.github/workflows/open-pr-on-icons-changes.yaml'
+  schedule:
+    - cron: '8 0 * * *'
+
+jobs:
+  refresh-upstream:
+    name: Check for upstream icons changes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        buildenv: [
+          {
+            project: Adwaita symbolics,
+            repo: "https://gitlab.gnome.org/GNOME/adwaita-icon-theme.git",
+            upstreambranch: master,
+            localbranch: adwaita-symbolics,
+            projectdir: adwaita-icon-theme,
+            src: Adwaita/scalable,
+            dest: icons/upstream/symbolics.list
+          },
+      ]
+    steps:
+      # Checkout code
+      - uses: actions/checkout@v2
+      - name: Download from ${{ matrix.buildenv.repo }}, on branch ${{ matrix.buildenv.upstreambranch }}
+        id: checknewupstream
+        run: |
+          hasModif="false"
+          pushd /tmp
+          git clone --branch ${UPSTEAM_BRANCH} --depth 1 ${UPSTREAM_REPO_URL}
+          popd
+          rm -f ${DEST}
+          cd /tmp/${PROJECT_DIR}/${SRC}
+          ls ./* > list.list
+          cd ~/work/yaru/yaru
+          cp /tmp/${PROJECT_DIR}/${SRC}/list.list ${DEST}
+          MODIFIED=$(git status --porcelain)
+          if [ -n "$MODIFIED" ]; then
+            hasModif="true"
+          fi
+          echo "::set-output name=modified::${hasModif}"
+        env:
+          UPSTREAM_REPO_URL: ${{ matrix.buildenv.repo }}
+          UPSTEAM_BRANCH: ${{ matrix.buildenv.upstreambranch }}
+          SRC: ${{ matrix.buildenv.src }}
+          DEST: ${{ matrix.buildenv.dest }}
+          PROJECT_DIR: ${{ matrix.buildenv.projectdir }}
+      - name: Create or update Pull Request
+        if: steps.checknewupstream.outputs.modified == 'true'
+        uses: peter-evans/create-pull-request@v3.8.2
+        with:
+          commit-message: New upstream snapshot for ${{ matrix.buildenv.project }}
+          title: Auto update new upstream snapshot for ${{ matrix.buildenv.project }}
+          labels: automated pr, new upstream
+          body: "[New upstream ${{ matrix.buildenv.project }} changes](https://github.com/ubuntu/yaru/actions?query=workflow%3A%22Update+PR+on+upstream+icons+changes%22) by GitHub Action"
+          branch: upstream-${{ matrix.buildenv.localbranch }}-update
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/open-pr-on-icons-changes.yaml
+++ b/.github/workflows/open-pr-on-icons-changes.yaml
@@ -53,8 +53,8 @@ jobs:
         if: steps.checknewupstream.outputs.modified == 'true'
         uses: peter-evans/create-pull-request@v3.8.2
         with:
-          commit-message: New upstream snapshot for ${{ matrix.buildenv.project }}
-          title: Auto update new upstream snapshot for ${{ matrix.buildenv.project }}
+          commit-message: New upstream icons list for ${{ matrix.buildenv.project }}
+          title: Auto update new upstream  icons list for ${{ matrix.buildenv.project }}
           labels: automated pr, new upstream
           body: "[New upstream ${{ matrix.buildenv.project }} changes](https://github.com/ubuntu/yaru/actions?query=workflow%3A%22Update+PR+on+upstream+icons+changes%22) by GitHub Action"
           branch: upstream-${{ matrix.buildenv.localbranch }}-update


### PR DESCRIPTION
This PR add a way to check upstream Adwaita icons changes. It list all given icons into a `.list` file, so we can easily see new files.

Closes #1544