### PR TITLE
Fix Login Screen disabled button color

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
@@ -10,7 +10,9 @@
   border: none;
   background-color: transparent;
 
-  $_gdm_bg: $porcelain; // Yaru: we force the light colors because GDM doesn't change on shell theme switch
+   // Yaru: we force the light colors because GDM doesn't change on shell theme switch
+  $_gdm_bg: $porcelain;
+  $_gdm_fg: $inkstone;
 
   StEntry {
     @if $variant=='dark' {
@@ -26,7 +28,7 @@
     box-shadow: 0 1px 3px rgba(0,0,0,0.2);
     background-color: $_gdm_bg;
     border-color: $_gdm_bg;
-    color: $inkstone; // Yaru: we force the light colors because GDM doesn't change on shell theme switch
+    color: $_gdm_fg;
 
     $_hover_c: lighten($_gdm_bg, 5%);
     &:hover, &:focus {
@@ -43,7 +45,7 @@
       @include button(insensitive);
       border-color: darken($_gdm_bg, 5%);
       background-color: darken($_gdm_bg, 5%);
-      color: transparentize($fg_color, 0.3);
+      color: transparentize($_gdm_fg, 0.3);
     }
     &:default { // Yaru: our suggested action color is green
       @include button(normal, $c:$suggested_bg_color, $tc:$selected_fg_color);
@@ -77,8 +79,8 @@
     width: $base_icon_size * 2;
     height: $base_icon_size * 2;
     border-color: transparentize($bg_color,0.7);
-    background-color: $_gdm_bg; // Yaru: we force the light colors because GDM doesn't change on shell theme switch
-    color: $inkstone;
+    background-color: $_gdm_bg;
+    color: $_gdm_fg;
 
     StIcon { icon-size: $base_icon_size; }
   }


### PR DESCRIPTION
I am sure that the problem comes from this line:

https://github.com/ubuntu/yaru/blob/4f1d31c5d4de784e9671cadf1303a9ba14f9f0cd/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss#L46

But I can't be able to test this on my computer (can't update GDM theme). I tried the way described into `CONTRIBUTING.md` but that doesn't work.

Closes #2746