### PR TITLE
rename sessions according to ubuntu 21.04 sessions

### DIFF
--- a/sessions/THEMENAME-xorg.desktop.in
+++ b/sessions/THEMENAME-xorg.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
-Name=@ThemeName@ session on wayland
-Comment=This session logs you with @ThemeName@ on wayland
+Name=@ThemeName@ session on xorg
+Comment=This session logs you with @ThemeName@ on xorg
 Exec=env GNOME_SHELL_SESSION_MODE=@LowerCaseThemeName@ gnome-session
 TryExec=gnome-session
 Type=Application

--- a/sessions/THEMENAME-xorg.desktop.in
+++ b/sessions/THEMENAME-xorg.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=@ThemeName@ session on xorg
+Name=@ThemeName@ session on Xorg
 Comment=This session logs you with @ThemeName@ on xorg
 Exec=env GNOME_SHELL_SESSION_MODE=@LowerCaseThemeName@ gnome-session
 TryExec=gnome-session

--- a/sessions/THEMENAME.desktop.in
+++ b/sessions/THEMENAME.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=@ThemeName@ session
-Comment=This session logs you with @ThemeName@
+Comment=This session logs you with @ThemeName@ on wayland
 Exec=env GNOME_SHELL_SESSION_MODE=@LowerCaseThemeName@ gnome-session
 TryExec=gnome-session
 Type=Application

--- a/sessions/meson.build
+++ b/sessions/meson.build
@@ -16,12 +16,12 @@ configure_file(input : 'mode.json.in',
 configure_file(input : 'THEMENAME.desktop.in',
               output : meson.project_name()+'.desktop',
               configuration : conf_data,
-              install_dir: join_paths(get_option('datadir'), 'xsessions'))
-
-configure_file(input : 'THEMENAME-wayland.desktop.in',
-              output : meson.project_name()+'-wayland.desktop',
-              configuration : conf_data,
               install_dir: join_paths(get_option('datadir'), 'wayland-sessions'))
+
+configure_file(input : 'THEMENAME-xorg.desktop.in',
+              output : meson.project_name()+'-xorg.desktop',
+              configuration : conf_data,
+              install_dir: join_paths(get_option('datadir'), 'xsessions'))
 
 configure_file(input : 'THEMENAME.gschema.override.in',
               output : '99_'+meson.project_name()+'.gschema.override',


### PR DESCRIPTION
Hi,

Since wayland will be the default-session starting ubuntu-21.04, this PR renames and aligns the session names for both wayland and Xorg same as Ubuntu session. 

#### screenshot: 
![Screenshot from 2021-03-28 13-58-28](https://user-images.githubusercontent.com/54065734/112746649-d801db00-8fcd-11eb-8dd2-2a82e23a71ce.png)

*Note: Screenshot taken in vm of hirsute-daily builds*