### PR TITLE
Sync libhandy with upstream

### DIFF
--- a/gtk/src/default/gtk-3.20/libhandy/_Adwaita-base.scss
+++ b/gtk/src/default/gtk-3.20/libhandy/_Adwaita-base.scss
@@ -2,6 +2,9 @@
 @import 'fallback-base';
 @import 'shared-base';
 
+$tab_bg: darken($bg_color, if($variant == 'dark', 6%, 12%));
+$tab_bg_backdrop: darken($backdrop_bg_color, 6%);
+
 // HdyComboRow
 
 popover.combo {
@@ -335,3 +338,228 @@ window.csd.unified:not(.solid-csd):not(.fullscreen) {
     }
   }
 }
+
+// HdyStatusPage
+
+statuspage > scrolledwindow > viewport > box > clamp > box > .icon {
+  color: transparentize($fg_color, 0.5);
+
+  &:backdrop {
+    color: transparentize($backdrop_fg_color, 0.5);
+  }
+}
+
+// Tabs
+
+@mixin undershoot-gradient($dir) {
+  @if $variant == 'dark' {
+    background: linear-gradient(to #{$dir},
+                                transparentize(black, .6),
+                                transparentize(black, 1) 20px);
+  }
+  @else {
+    background: linear-gradient(to #{$dir},
+                                transparentize(black, .93),
+                                transparentize(black, 1) 20px);
+  }
+}
+
+@mixin need-attention-gradient($dir) {
+  background: linear-gradient(to #{$dir},
+                              transparentize($selected_bg_color, .3),
+                              transparentize($selected_bg_color, .5) 1px,
+                              transparentize($selected_bg_color, 1) 20px);
+}
+
+tabbar {
+  .box {
+    min-height: 38px;
+    background: darken($tab_bg, 3%);
+    border-bottom: 1px solid $alt_borders_color;
+
+    &:backdrop {
+      background-color: darken($tab_bg_backdrop, 3%);
+      border-color: $backdrop_borders_color;
+    }
+  }
+
+  scrolledwindow.pinned {
+    undershoot {
+      border: 0 solid $alt_borders_color;
+    }
+
+    &:dir(rtl) undershoot.left {
+      border-left-width: 1px;
+    }
+
+    &:dir(ltr) undershoot.right {
+      border-right-width: 1px;
+    }
+
+    &:backdrop undershoot {
+      border-color: $backdrop_borders_color;
+    }
+
+    tabbox {
+      &:dir(ltr) {
+        padding-right: 1px;
+        box-shadow: inset -1px 0 $alt_borders_color;
+
+        &:backdrop {
+          box-shadow: inset -1px 0 $backdrop_borders_color;
+        }
+      }
+
+      &:dir(rtl) {
+        padding-left: 1px;
+        box-shadow: inset 1px 0 $alt_borders_color;
+
+        &:backdrop {
+          box-shadow: inset 1px 0 $backdrop_borders_color;
+        }
+      }
+    }
+  }
+
+  undershoot {
+    transition: none;
+
+    &.left {
+      @include undershoot-gradient("right");
+    }
+
+    &.right {
+      @include undershoot-gradient("left");
+    }
+  }
+
+  .needs-attention-left undershoot.left {
+    @include need-attention-gradient("right");
+  }
+
+  .needs-attention-right undershoot.right {
+    @include need-attention-gradient("left");
+  }
+
+  tab {
+    border-style: solid;
+    border-color: $alt_borders_color;
+    border-width: 0 1px 0 1px;
+    transition: background 150ms ease-in-out;
+    background-color: $tab_bg;
+
+    &:checked {
+      background-color: lighten($tab_bg, 6%);
+
+      &:hover {
+        background-color: lighten($tab_bg, 9%);
+      }
+    }
+
+    &:hover {
+      background-color: lighten($tab_bg, 3%);
+    }
+
+    &:backdrop {
+      border-color: $backdrop_borders_color;
+      background-color: $tab_bg_backdrop;
+
+      &:checked {
+        background-color: $backdrop_bg_color;
+      }
+    }
+  }
+
+  .start-action,
+  .end-action {
+    background: $tab_bg;
+    border-color: $alt_borders_color;
+    border-style: solid;
+    transition: background 150ms ease-in-out;
+
+    &:backdrop {
+      border-color: $backdrop_borders_color;
+      background-color: $tab_bg_backdrop;
+    }
+
+    button {
+      border: none;
+      border-radius: 0;
+    }
+  }
+
+  .start-action:dir(ltr),
+  .end-action:dir(rtl) {
+    border-right-width: 1px;
+
+    > * {
+      margin-right: 1px;
+    }
+  }
+
+  .start-action:dir(rtl),
+  .end-action:dir(ltr) {
+    border-left-width: 1px;
+
+    > * {
+      margin-left: 1px;
+    }
+  }
+}
+
+.tab-drag-icon {
+  tab {
+    min-height: 26px;
+    background-color: lighten($tab_bg, 9%);
+
+    $_wm_border: if($variant=='light', transparentize(black, 0.77), transparentize($borders_color, 0.1));
+
+    box-shadow: 0 3px 9px 1px transparentize(black, 0.75),
+                0 0 0 1px $_wm_border, //doing borders with box-shadow
+                inset 0 1px $top_hilight;
+
+    margin: 25px;
+  }
+}
+
+tabbar,
+.tab-drag-icon {
+  tab {
+    padding: 6px;
+
+    &.needs-attention {
+      background-image:
+        radial-gradient(ellipse at bottom,
+                        transparentize(white, .2),
+                        transparentize($selected_bg_color, .8) 15%,
+                        transparentize($selected_bg_color, 1) 15%);
+    }
+
+    .tab-close-button,
+    .tab-indicator {
+      padding: 0;
+      margin: 0;
+      min-width: 24px;
+      min-height: 24px;
+      border-radius: 99px;
+
+      border: none;
+      box-shadow: none;
+      -gtk-icon-shadow: none;
+      text-shadow: none;
+      background: none;
+    }
+
+    .tab-close-button,
+    .tab-indicator.clickable {
+      &:hover {
+        background: hdyalpha($fg_color, .15);
+      }
+
+      &:active {
+        background: hdyalpha(black, .2);
+      }
+    }
+  }
+}
+

--- a/gtk/src/default/gtk-3.20/libhandy/_fallback-base.scss
+++ b/gtk/src/default/gtk-3.20/libhandy/_fallback-base.scss
@@ -153,18 +153,63 @@ viewswitchertitle viewswitcher {
 statuspage > scrolledwindow > viewport > box {
   margin: 36px 12px;
 
-  > clamp > box {
-    > .icon {
+  > clamp {
+    &:not(:last-child) > box {
       margin-bottom: 36px;
-      opacity: 0.5;
     }
 
-    > .title {
-      margin-bottom: 12px;
-    }
+    > box {
+      > .icon:not(:last-child) {
+        margin-bottom: 36px;
+      }
 
-    > .description {
-      margin-bottom: 36px;
+      > .title:not(:last-child) {
+        margin-bottom: 12px;
+      }
     }
   }
 }
+
+// Preferences
+
+window.preferences > deck > deck > box > stack > stack > scrolledwindow > viewport > clamp,
+preferencespage > scrolledwindow > viewport > clamp {
+  margin: 0 12px;
+
+  transition: margin-bottom 200ms ease;
+
+  > list,
+  > box > preferencesgroup {
+    transition: margin-top 200ms ease;
+  }
+
+  $sizes: ("small": 18px, "medium": 24px, "large": 30px);
+
+  @each $name, $size in $sizes {
+    &.#{$name} {
+      margin-bottom: $size;
+
+      > list,
+      > box > preferencesgroup { margin-top: $size; }
+    }
+  }
+}
+
+preferencesgroup > box {
+  // Add space between the description and the title.
+  > label:not(:first-child) {
+    margin-top: 6px;
+  }
+
+  // Add space between the box and the labels.
+  > box:not(:first-child) {
+    margin-top: 12px;
+  }
+}
+
+tabbar .tab-indicator:not(.clickable) {
+  background: none;
+  box-shadow: none;
+  border-color: transparent;
+}
+


### PR DESCRIPTION
Sync our libhandy theme with upstream master branch.

The most important change add the "**Tab View**" support:

**Before:**

![Capture d’écran du 2021-04-14 12-04-20](https://user-images.githubusercontent.com/36476595/114693199-a735db80-9d19-11eb-8bc4-e2e08bfe3422.png)

**After:**

![Capture d’écran du 2021-04-14 12-04-02](https://user-images.githubusercontent.com/36476595/114693215-abfa8f80-9d19-11eb-8ded-2ee62ad308b3.png)

**Question:** It still needs to remove all ugly shadows. But do we want to mimic normal Gtk tabs look (I mean the orange bottom border)?