### PR TITLE
Symlink mate logout symbolic icon

### DIFF
--- a/icons/Suru/scalable/actions/brisk_system-log-out-symbolic.svg
+++ b/icons/Suru/scalable/actions/brisk_system-log-out-symbolic.svg
@@ -1,0 +1,1 @@
+system-log-out-symbolic.svg

--- a/icons/src/symlinks/symbolic/actions.list
+++ b/icons/src/symlinks/symbolic/actions.list
@@ -42,6 +42,7 @@ pan-end-symbolic.svg pan-start-symbolic-rtl.svg
 pan-start-symbolic.svg pan-end-symbolic-rtl.svg
 selection-end-symbolic.svg selection-start-symbolic-rtl.svg
 selection-start-symbolic.svg selection-end-symbolic-rtl.svg
+system-log-out-symbolic.svg brisk_system-log-out-symbolic.svg
 system-restart-symbolic.svg system-reboot-symbolic.svg
 window-pop-out-symbolic.svg detach-symbolic.svg
 document-properties-symbolic.svg configure-symbolic.svg


### PR DESCRIPTION
The icon is named brisk_system-log-out-symbolic (see: https://github.com/getsolus/brisk-menu/blob/master/data/brisk_system-log-out-symbolic.svg).

![Capture d’écran du 2021-04-19 17-52-14](https://user-images.githubusercontent.com/36476595/115265929-fe7fe580-a137-11eb-967f-6d79f410d459.png)

Closes #2762 