### PR TITLE
Fix app grid folder border-radius

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
@@ -31,7 +31,7 @@ $app_grid_fg_color: #fff;
 /* App Folders */
 .app-well-app.app-folder {
   background-color: transparentize($osd_bg_color, 0.8);
-  border-radius: $base_border_radius + 4px; // same as %icon_tile
+  border-radius: $base_border_radius; // same as %icon_tile - Yaru: tile radius is too big for our theme
 }
 
 // expanded folder


### PR DESCRIPTION
Here is a "backport" of the fix I did for GS40 (https://github.com/ubuntu/yaru/pull/2736/commits/bce61903168e28f4bc89c8642f2c8f1525b6422f).

Closes #2801