### PR TITLE
Update Gtk2 assets render scripts

### DIFF
--- a/gtk/src/dark/gtk-2.0/render-all-assets.sh
+++ b/gtk/src/dark/gtk-2.0/render-all-assets.sh
@@ -17,8 +17,7 @@ else
     echo Rendering $ASSETS_DIR/$i.png
     $INKSCAPE --export-id=$i \
               --export-id-only \
-              --export-background-opacity=0 \
-              --export-png=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null \
+              -o $ASSETS_DIR/$i.png $SRC_FILE >/dev/null \
     && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png 
 fi
 done

--- a/gtk/src/default/gtk-2.0/assets.svg
+++ b/gtk/src/default/gtk-2.0/assets.svg
@@ -13,7 +13,7 @@
    height="12.7cm"
    id="svg3032"
    version="1.1"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
    sodipodi:docname="assets.svg">
   <defs
      id="defs3034">
@@ -1160,7 +1160,7 @@
      pagecolor="#f5f6f7"
      bordercolor="#9d9d99"
      borderopacity="1"
-     inkscape:pageopacity="1"
+     inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="16"
      inkscape:cx="579.43198"
@@ -1173,7 +1173,7 @@
      inkscape:snap-nodes="true"
      inkscape:window-width="1920"
      inkscape:window-height="1016"
-     inkscape:window-x="1920"
+     inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
      showguides="false"
@@ -1204,7 +1204,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/gtk/src/default/gtk-2.0/render-all-assets.sh
+++ b/gtk/src/default/gtk-2.0/render-all-assets.sh
@@ -17,8 +17,7 @@ else
     echo Rendering $ASSETS_DIR/$i.png
     $INKSCAPE --export-id=$i \
               --export-id-only \
-              --export-background-opacity=0 \
-              --export-png=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null \
+              -o $ASSETS_DIR/$i.png $SRC_FILE >/dev/null \
     && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png 
 fi
 done

--- a/gtk/src/light/gtk-2.0/assets.svg
+++ b/gtk/src/light/gtk-2.0/assets.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -15,7 +13,7 @@
    height="12.7cm"
    id="svg3032"
    version="1.1"
-   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
    sodipodi:docname="assets.svg">
   <defs
      id="defs3034">
@@ -1162,12 +1160,12 @@
      pagecolor="#f5f6f7"
      bordercolor="#9d9d99"
      borderopacity="1"
-     inkscape:pageopacity="1"
+     inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.8284271"
-     inkscape:cx="467.07668"
-     inkscape:cy="339.70585"
-     inkscape:current-layer="menu-radio-mixed"
+     inkscape:zoom="0.99999999"
+     inkscape:cx="292.81625"
+     inkscape:cy="212.17403"
+     inkscape:current-layer="layer1"
      inkscape:document-units="px"
      showgrid="false"
      inkscape:snap-bbox="true"
@@ -1192,7 +1190,8 @@
      inkscape:snap-to-guides="true"
      inkscape:snap-others="false"
      units="cm"
-     inkscape:pagecheckerboard="false">
+     inkscape:pagecheckerboard="false"
+     inkscape:document-rotation="0">
     <inkscape:grid
        type="xygrid"
        id="grid3076" />
@@ -1205,7 +1204,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/gtk/src/light/gtk-2.0/render-all-assets.sh
+++ b/gtk/src/light/gtk-2.0/render-all-assets.sh
@@ -17,8 +17,7 @@ else
     echo Rendering $ASSETS_DIR/$i.png
     $INKSCAPE --export-id=$i \
               --export-id-only \
-              --export-background-opacity=0 \
-              --export-png=$ASSETS_DIR/$i.png $SRC_FILE >/dev/null \
+              -o $ASSETS_DIR/$i.png $SRC_FILE >/dev/null \
     && $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png 
 fi
 done


### PR DESCRIPTION
@Jannomag I found a solution for Inkscape 1.0:

- modify all **assets.svg** files: replace `inkscape:pageopacity="1"` with `inkscape:pageopacity="0"`
- edit all scripts: drop `--export-background-opacity=0` and also replace `--export-png=$ASSETS_DIR/$i.png` by `-o $ASSETS_DIR/$i.png`

That's it :)

Closes #2815