### PR TITLE
fixed assets.svg in gtk2 dark

### DIFF
--- a/gtk/src/dark/gtk-2.0/assets.svg
+++ b/gtk/src/dark/gtk-2.0/assets.svg
@@ -2402,10 +2402,9 @@
          style="opacity:1;fill:none;fill-opacity:1;stroke:#b56d54;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <g
-       id="g1967"
-       inkscape:export-filename="/home/jupiter007/yaru/gtk/src/dark/gtk-2.0/assets/scale-slider.png"
-       inkscape:export-xdpi="96"
-       inkscape:export-ydpi="96">
+       id="scale-slider"
+       inkscape:label="#g5227"
+       transform="translate(-43,230)">
       <rect
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect5356-6"


### PR DESCRIPTION
I fixed some wrong lines in assets.svg for dark gtk2 variant. This issue causes the scale-slider.png not being rendered.