### PR TITLE
Add scalable/ui folder to index.theme

### DIFF
--- a/icons/Suru/index.theme
+++ b/icons/Suru/index.theme
@@ -5,7 +5,7 @@ Inherits=Humanity,hicolor
 Example=folder
 
 # Directory list
-Directories=8x8/emblems,16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/emblems,16x16/emotes,16x16/legacy,16x16/mimetypes,16x16/panel,16x16/places,16x16/status,22x22/legacy,24x24/actions,24x24/animations,24x24/apps,24x24/categories,24x24/devices,24x24/emblems,24x24/emotes,24x24/legacy,24x24/mimetypes,24x24/panel,24x24/places,24x24/status,32x32/actions,32x32/apps,32x32/categories,32x32/devices,32x32/emblems,32x32/emotes,32x32/legacy,32x32/mimetypes,32x32/places,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/emblems,48x48/emotes,48x48/legacy,48x48/mimetypes,48x48/notifications,48x48/places,48x48/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/emblems,256x256/emotes,256x256/legacy,256x256/mimetypes,256x256/places,256x256/status,8x8@2x/emblems,16x16@2x/actions,16x16@2x/apps,16x16@2x/categories,16x16@2x/devices,16x16@2x/emblems,16x16@2x/emotes,16x16@2x/mimetypes,16x16@2x/places,16x16@2x/status,24x24@2x/actions,24x24@2x/apps,24x24@2x/categories,24x24@2x/devices,24x24@2x/emblems,24x24@2x/emotes,24x24@2x/mimetypes,24x24@2x/places,24x24@2x/status,32x32@2x/actions,32x32@2x/apps,32x32@2x/categories,32x32@2x/devices,32x32@2x/emblems,32x32@2x/emotes,32x32@2x/mimetypes,32x32@2x/places,32x32@2x/status,48x48@2x/actions,48x48@2x/apps,48x48@2x/categories,48x48@2x/devices,48x48@2x/emblems,48x48@2x/emotes,48x48@2x/mimetypes,48x48@2x/places,48x48@2x/status,256x256@2x/actions,256x256@2x/apps,256x256@2x/categories,256x256@2x/devices,256x256@2x/emblems,256x256@2x/emotes,256x256@2x/mimetypes,256x256@2x/places,256x256@2x/status,scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/emblems,scalable/emotes,scalable/mimetypes,scalable/places,scalable/status,scalable-max-32/status
+Directories=8x8/emblems,16x16/actions,16x16/apps,16x16/categories,16x16/devices,16x16/emblems,16x16/emotes,16x16/legacy,16x16/mimetypes,16x16/panel,16x16/places,16x16/status,22x22/legacy,24x24/actions,24x24/animations,24x24/apps,24x24/categories,24x24/devices,24x24/emblems,24x24/emotes,24x24/legacy,24x24/mimetypes,24x24/panel,24x24/places,24x24/status,32x32/actions,32x32/apps,32x32/categories,32x32/devices,32x32/emblems,32x32/emotes,32x32/legacy,32x32/mimetypes,32x32/places,32x32/status,48x48/actions,48x48/apps,48x48/categories,48x48/devices,48x48/emblems,48x48/emotes,48x48/legacy,48x48/mimetypes,48x48/notifications,48x48/places,48x48/status,256x256/actions,256x256/apps,256x256/categories,256x256/devices,256x256/emblems,256x256/emotes,256x256/legacy,256x256/mimetypes,256x256/places,256x256/status,8x8@2x/emblems,16x16@2x/actions,16x16@2x/apps,16x16@2x/categories,16x16@2x/devices,16x16@2x/emblems,16x16@2x/emotes,16x16@2x/mimetypes,16x16@2x/places,16x16@2x/status,24x24@2x/actions,24x24@2x/apps,24x24@2x/categories,24x24@2x/devices,24x24@2x/emblems,24x24@2x/emotes,24x24@2x/mimetypes,24x24@2x/places,24x24@2x/status,32x32@2x/actions,32x32@2x/apps,32x32@2x/categories,32x32@2x/devices,32x32@2x/emblems,32x32@2x/emotes,32x32@2x/mimetypes,32x32@2x/places,32x32@2x/status,48x48@2x/actions,48x48@2x/apps,48x48@2x/categories,48x48@2x/devices,48x48@2x/emblems,48x48@2x/emotes,48x48@2x/mimetypes,48x48@2x/places,48x48@2x/status,256x256@2x/actions,256x256@2x/apps,256x256@2x/categories,256x256@2x/devices,256x256@2x/emblems,256x256@2x/emotes,256x256@2x/mimetypes,256x256@2x/places,256x256@2x/status,scalable/actions,scalable/apps,scalable/categories,scalable/devices,scalable/emblems,scalable/emotes,scalable/mimetypes,scalable/places,scalable/status,scalable/ui,scalable-max-32/status
 
 # Actions
 
@@ -411,6 +411,15 @@ Context=Status
 Size=16
 MinSize=16
 MaxSize=32
+Type=Scalable
+
+# UI
+
+[scalable/ui]
+Context=UI
+Size=16
+MinSize=8
+MaxSize=512
 Type=Scalable
 
 


### PR DESCRIPTION
Here on Arch Linux I'm seeing the below issue where window controls on GTK apps with client-side decorations render the incorrect icon when using the Yaru icon theme.

![Peek 2021-05-12 16-42](https://user-images.githubusercontent.com/1044087/117957090-b0e63b00-b2e7-11eb-825f-8defaa47beec.gif)

This appears to be due to the icons used on the controls recently moving in #2806. They  used to be here:
```
usr/share/icons/Yaru/scalable/actions/window-close-symbolic.svg
usr/share/icons/Yaru/scalable/actions/window-maximize-symbolic.svg
usr/share/icons/Yaru/scalable/actions/window-minimize-symbolic.svg
usr/share/icons/Yaru/scalable/actions/window-new-symbolic.svg
usr/share/icons/Yaru/scalable/actions/window-restore-symbolic.svg
usr/share/icons/Yaru/scalable/actions/window-symbolic.svg
```
and now they are here:
```
usr/share/icons/Yaru/scalable/actions/window-symbolic.svg
usr/share/icons/Yaru/scalable/ui/window-close-symbolic.svg
usr/share/icons/Yaru/scalable/ui/window-maximize-symbolic.svg
usr/share/icons/Yaru/scalable/ui/window-minimize-symbolic.svg
usr/share/icons/Yaru/scalable/ui/window-new-symbolic.svg
usr/share/icons/Yaru/scalable/ui/window-restore-symbolic.svg
```

But `index.theme` does not have an entry for the new `scalable/ui/` folder, so on my system at least (others don't seem to be experiencing this issue, I'm not sure why not), the window controls use the `scalable/actions/window-symbolic` icon as a fallback.

This PR adds an entry for `scalable/ui/` to `index.theme`, which resolves the issue for me. I copied the entry from Adwaita.