### PR TITLE
Disable gresource meson option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 option('icons', type: 'boolean', value: true, description:'build icons component')
 option('gnome-shell', type: 'boolean', value: true, description:'build gnome-shell component')
-option('gnome-shell-gresource', type: 'boolean', value: true, description: 'build gnome-shell component in gresources')
+option('gnome-shell-gresource', type: 'boolean', value: false, description: 'build gnome-shell component in gresources')
 option('gtk', type: 'boolean', value: true, description:'build gtk component')
 option('gtksourceview', type: 'boolean', value: true, description:'build gtksourceview component')
 option('metacity', type: 'boolean', value: true, description:'build metacity component')


### PR DESCRIPTION
Because it looks like the gresource meson option cause some problems with Gnome Shell, this PR disable that option.

Revert #2825