### PR TITLE
Add symbolic Snap app and mimetype icons

### DIFF
--- a/icons/Suru/scalable/apps/snap-symbolic.svg
+++ b/icons/Suru/scalable/apps/snap-symbolic.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg fill="#808080" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m0 0 8 3v5l-8-8z"/>
+ <path d="M8.3,9.7L2,16L6.2,7.6L8.3,9.7Z"/>
+ <path d="M9,3.946L9,9L12.675,5.325L9,3.946Z"/>
+ <path d="m9 3h6l1 2.625-7-2.625z"/>
+</svg>

--- a/icons/Suru/scalable/mimetypes/application-vnd.snap-symbolic.svg
+++ b/icons/Suru/scalable/mimetypes/application-vnd.snap-symbolic.svg
@@ -1,0 +1,8 @@
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg clip-rule="evenodd" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="1.5" version="1.1" viewBox="0 0 16 16" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><g fill="#808080" fill-rule="nonzero">
+    <path d="m3 3 5 2v3l-5-5z"/>
+    <path d="M7.8,9.2L4,13L6.533,7.933L7.8,9.2Z"/>
+    <path d="M9,6L9,8L10.429,6.571L9,6Z"/>
+    <path d="m9 5h3.5l0.5 1.6-4-1.6z"/>
+    </g><path d="m14.5 2c0-0.828-0.672-1.5-1.5-1.5h-10c-0.828 0-1.5 0.672-1.5 1.5v12c0 0.828 0.672 1.5 1.5 1.5h10c0.828 0 1.5-0.672 1.5-1.5v-12z" fill="none" stroke="#808080" stroke-width="1px"/>
+</svg>

--- a/icons/src/scalable/apps/snap-symbolic.svg
+++ b/icons/src/scalable/apps/snap-symbolic.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="#808080">
+    <path d="M0,0L8,3L8,8L0,0Z"/>
+    <path d="M8.3,9.7L2,16L6.2,7.6L8.3,9.7Z"/>
+    <path d="M9,3.946L9,9L12.675,5.325L9,3.946Z"/>
+    <path d="M9,3L15,3L16,5.625L9,3Z"/>
+</svg>

--- a/icons/src/scalable/mimetypes/application-vnd.snap-symbolic.svg
+++ b/icons/src/scalable/mimetypes/application-vnd.snap-symbolic.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <path d="M3,3L8,5L8,8L3,3Z" style="fill:rgb(128,128,128);fill-rule:nonzero;"/>
+    <path d="M7.8,9.2L4,13L6.533,7.933L7.8,9.2Z" style="fill:rgb(128,128,128);fill-rule:nonzero;"/>
+    <path d="M9,6L9,8L10.429,6.571L9,6Z" style="fill:rgb(128,128,128);fill-rule:nonzero;"/>
+    <path d="M9,5L12.5,5L13,6.6L9,5Z" style="fill:rgb(128,128,128);fill-rule:nonzero;"/>
+    <path d="M14.5,2C14.5,1.172 13.828,0.5 13,0.5L3,0.5C2.172,0.5 1.5,1.172 1.5,2L1.5,14C1.5,14.828 2.172,15.5 3,15.5L13,15.5C13.828,15.5 14.5,14.828 14.5,14L14.5,2Z" style="fill:none;stroke:rgb(128,128,128);stroke-width:1px;"/>
+</svg>


### PR DESCRIPTION
Fixes https://github.com/ubuntu/yaru/issues/2403.

I based the icon name on the name of [the corresponding fullcolor icon](https://github.com/ubuntu/yaru/blob/master/icons/src/fullcolor/mimetypes/application-vnd.snap.svg).

The primary change I made when scaling down the full-size icon was thickening the negative-space lines and aligning them to the pixel grid so that the icon will look sharper when rendered on screen. There are a number of side-by-side previews in the linked Issue.

Please let me know if there's anything else I need to do for the pull request. (I'm new here.) Thanks!