### PR TITLE
Add macOS .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ stage/
 prime/
 snap/.snapcraft/state
 *.snap
+
+# filesystem clutter
+.DS_Store


### PR DESCRIPTION
macOS will automatically add [`.DS_Store`](https://en.wikipedia.org/wiki/.DS_Store) files when you browse to a location in the Finder. It even does this if you are browsing a remote server that isn't a Mac (which is admittedly annoying). Adding `.DS_Store` to `.gitignore` eliminates the annoyance of having to manually exclude these files from Git.