### PR TITLE
Add VS Code workspace to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ stage/
 prime/
 snap/.snapcraft/state
 *.snap
+
+# Developer config files
+*.code-workspace


### PR DESCRIPTION
Adding this lets individual developers save personalized VS Code workspace configuration files within the project directory (which is the norm).