### PR TITLE
Simplify parsing to work with non-Inkscape SVGs

### DIFF
--- a/icons/src/fullcolor/render-bitmaps-verbose.py
+++ b/icons/src/fullcolor/render-bitmaps-verbose.py
@@ -23,15 +23,15 @@ import xml.sax
 import subprocess
 import argparse
 
-INKSCAPE = '/usr/bin/inkscape'
-OPTIPNG = '/usr/bin/optipng'
-MAINDIR = '../usr/share/icons/Mint-Y'
-SOURCES = ['apps', 'categories']
+INKSCAPE_PATH = '/usr/bin/inkscape'
+OPTIPNG_PATH = '/usr/bin/optipng'
+OUTPUT_DIRECTORY = '../../Suru'
+CATEGORIES_TO_RENDER = ['apps', 'categories']
 
 # assert ('linux' in sys.platform), "This code runs on Linux only."
-assert (os.path.isfile(INKSCAPE)), "Expected to find Inkscape at /usr/bin/inkscape, but file does not exist."
-assert (os.path.isfile(OPTIPNG)), "Expected to find OptiPNG at /usr/bin/optipng, but file does not exist."
-assert (os.path.isdir(MAINDIR)), "Expected to find Mint-Y at ../usr/share/icons/Mint-Y, but directory does not exist."
+assert (os.path.isfile(INKSCAPE_PATH)), "Expected to find Inkscape at " + INKSCAPE_PATH + ", but file does not exist."
+assert (os.path.isfile(OPTIPNG_PATH)), "Expected to find OptiPNG at " + OPTIPNG_PATH + " but file does not exist."
+assert (os.path.isdir(OUTPUT_DIRECTORY)), "Expected to find output directory at " + OUTPUT_DIRECTORY + ", but directory does not exist."
 
 # the resolution that non-hi-dpi icons are rendered at (may be 90 or 96 depending on your inkscape build)
 inkscape_version = str(subprocess.check_output(['inkscape', '-V'])).split(' ')[1].split('.')
@@ -49,8 +49,8 @@ inkscape_process = None
 def main(args, SRC):
 
     def optimize_png(png_file):
-        if os.path.exists(OPTIPNG):
-            process = subprocess.Popen([OPTIPNG, '-quiet', '-o7', png_file])
+        if os.path.exists(OPTIPNG_PATH):
+            process = subprocess.Popen([OPTIPNG_PATH, '-quiet', '-o7', png_file])
             process.wait()
 
     def wait_for_prompt(process, command=None):
@@ -69,7 +69,7 @@ def main(args, SRC):
             output = output[1:]
 
     def start_inkscape():
-        process = subprocess.Popen([INKSCAPE, '--shell'], bufsize=0, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        process = subprocess.Popen([INKSCAPE_PATH, '--shell'], bufsize=0, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         wait_for_prompt(process)
         return process
 
@@ -79,9 +79,9 @@ def main(args, SRC):
             inkscape_process = start_inkscape()
 
         cmd = [icon_file,
-               '--export-dpi', str(dpi),
-               '-i', rect,
-               '-e', output_file]
+               '--export-dpi={}'.format(str(dpi)),
+               '--export-id={}'.format(str(rect)),
+               '--export-filename={}'.format(output_file)]
         wait_for_prompt(inkscape_process, ' '.join(cmd))
         optimize_png(output_file)
 
@@ -175,7 +175,7 @@ def main(args, SRC):
                         if dpi_factor != 1:
                             size_str += "@%sx" % dpi_factor
 
-                        dir = os.path.join(MAINDIR, self.context, size_str)
+                        dir = os.path.join(OUTPUT_DIRECTORY, self.context, size_str)
                         outfile = os.path.join(dir, self.icon_name+'.png')
                         if not os.path.exists(dir):
                             os.makedirs(dir)
@@ -184,7 +184,7 @@ def main(args, SRC):
                         if self.force or not os.path.exists(outfile):
                             inkscape_render_rect(self.path, id, dpi, outfile)
                             if args.verbose:
-                                print("├─ Rendered new \"".decode('utf-8') + outfile + "\"")
+                                print("├─ Rendered new \"" + outfile + "\"")
                             new_renders += 1
 
                         # If PNG exists, compare modify time to that of SVG
@@ -196,27 +196,27 @@ def main(args, SRC):
                             if stat_in.st_mtime > stat_out.st_mtime:
                                 inkscape_render_rect(self.path, id, dpi, outfile)
                                 if args.verbose:
-                                    print("├─ Rendered updated \"".decode('utf-8') + outfile + "\"")
+                                    print("├─ Rendered updated \"" + outfile + "\"")
                                 # print("Rendered updated " + outfile)
                                 updated_renders += 1
 
                             # If PNG is newer than SVG, leave PNG as is
                             else:
                                 if args.verbose:
-                                    print("├─ \"".decode('utf-8') + outfile + "\" is newer than SVG")
+                                    print("├─ \"" + outfile + "\" is newer than SVG")
                                 skipped_renders += 1
                 if args.verbose:
-                    print("├────────────────────────────────┤".decode('utf-8'))
+                    print("├────────────────────────────────┤")
                 if args.svg is None:
                     print("")
-                    print("┌────────────────────────────────┐".decode('utf-8'))
-                    print("│ Directory: ".decode('utf-8') + self.context)
-                    print("│ Icon Name: ".decode('utf-8') + self.icon_name)
-                    print("├────────────────────────────────┤".decode('utf-8'))
-                    print("├─ Rendered %d new PNGs".decode('utf-8') % new_renders)
-                    print("├─ Rendered %d updated PNGs".decode('utf-8') % updated_renders)
-                    print("├─ Skipped %d up-to-date PNGs".decode('utf-8') % skipped_renders)
-                    print("└────────────────────────────────┘".decode('utf-8'))
+                    print("┌────────────────────────────────┐")
+                    print("│ Directory: " + self.context)
+                    print("│ Icon Name: " + self.icon_name)
+                    print("├────────────────────────────────┤")
+                    print("├─ Rendered %d new PNGs" % new_renders)
+                    print("├─ Rendered %d updated PNGs" % updated_renders)
+                    print("├─ Skipped %d up-to-date PNGs" % skipped_renders)
+                    print("└────────────────────────────────┘")
                     print("")
 
         def characters(self, chars):
@@ -227,20 +227,20 @@ def main(args, SRC):
         file = os.path.join(SRC, args.svg + '.svg')
 
         if os.path.exists(os.path.join(file)):
-            print("├─ Rendering from \"".decode('utf-8') + os.path.join(file) + "\"")
+            print("├─ Rendering from \"" + os.path.join(file) + "\"")
             handler = ContentHandler(file, True, filter=args.filter)
             xml.sax.parse(open(file), handler)
             return True
         else:
             # icon not in this directory, try the next one
-            print("├─ Input file \"".decode('utf-8') + file + "\" does not exist.")
+            print("├─ Input file \"" + file + "\" does not exist.")
             return False
 
     # If invocation does not include a file name, process all SVGs in listed sources
     else:
-        print("Rendering from path \"".decode('utf-8') + SRC + "\"")
-        if not os.path.exists(MAINDIR):
-            os.mkdir(MAINDIR)
+        print("Rendering from path \"" + SRC + "\"")
+        if not os.path.exists(OUTPUT_DIRECTORY):
+            os.mkdir(OUTPUT_DIRECTORY)
 
         for file in os.listdir(SRC):
             if file[-4:] == '.svg':
@@ -265,17 +265,17 @@ args = parser.parse_args()
 
 if args.svg is None:
     print("\nNo arguments provided; processing listed sources:\n")
-    for source in SOURCES:
+    for source in CATEGORIES_TO_RENDER:
         print("-- \"" + os.path.join('.', source) + "\"")
     print("")
 else:
-    print("┌────────────────────────────────┐".decode('utf-8'))
-    print("│ Rendering from command-line argument \"".decode('utf-8') + args.svg + "\"")
-    print("├────────────────────────────────┤".decode('utf-8'))
+    print("┌────────────────────────────────┐")
+    print("│ Rendering from command-line argument \"" + args.svg + "\"")
+    print("├────────────────────────────────┤")
 
 success_directory = ""
 
-for source in SOURCES:
+for source in CATEGORIES_TO_RENDER:
     if os.path.exists(os.path.join('.', source)):
         SRC = os.path.join('.', source)
         if main(args, SRC):
@@ -283,7 +283,7 @@ for source in SOURCES:
     else:
         print("Source path \"" + os.path.join('.', source) + "\" does not exist.")
 if args.svg is not None:
-    print("└────────────────────────────────┘".decode('utf-8'))
+    print("└────────────────────────────────┘")
 
 if success_directory != "" and args.svg is not None:
     print("\nSuccessfully processed \"" + args.svg + "\" in \"" + success_directory + "\".\n")

--- a/icons/src/fullcolor/render-bitmaps-verbose.py
+++ b/icons/src/fullcolor/render-bitmaps-verbose.py
@@ -1,234 +1,217 @@
 #!/usr/bin/python3
 # coding: utf-8
 #
-# Legal Stuff:
+# Original Version Copyright (C) by the GNOME icon developers
 #
-# This file is part of the Moka Icon Theme and is free software; you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the Free Software
-# Foundation; version 3.
+# Modifications Copyright (C) by Moka Icon Theme developers
+# Modifications Copyright (C) by Yaru Icon Theme developers
+# Modifications Copyright (C) by Elsie Hupp <gpl at elsiehupp dot com>
 #
-# This file is part of the Moka Icon Theme and is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
-# details.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
 #
-# You should have received a copy of the GNU General Public License along with
-# this program; if not, see <https://www.gnu.org/licenses/lgpl-3.0.txt>
-#
-#
-# Thanks to the GNOME icon developers for the original version of this script
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+
+
 import os
 import sys
 import xml.sax
 import subprocess
 import argparse
 
-INKSCAPE_PATH = '/usr/bin/inkscape'
-OPTIPNG_PATH = '/usr/bin/optipng'
-OUTPUT_DIRECTORY = '../../Suru'
-CATEGORIES_TO_RENDER = ['apps', 'categories']
 
-# assert ('linux' in sys.platform), "This code runs on Linux only."
-assert (os.path.isfile(INKSCAPE_PATH)), "Expected to find Inkscape at " + INKSCAPE_PATH + ", but file does not exist."
-assert (os.path.isfile(OPTIPNG_PATH)), "Expected to find OptiPNG at " + OPTIPNG_PATH + " but file does not exist."
-assert (os.path.isdir(OUTPUT_DIRECTORY)), "Expected to find output directory at " + OUTPUT_DIRECTORY + ", but directory does not exist."
+def optimize_png(png_file, args):
 
-# the resolution that non-hi-dpi icons are rendered at (may be 90 or 96 depending on your inkscape build)
-inkscape_version = str(subprocess.check_output(['inkscape', '-V'])).split(' ')[1].split('.')
-inkscape_version = float(inkscape_version[0] + '.' + inkscape_version[1])
-assert (inkscape_version < 1.0), "Expected Inkscape version lower than 1.0. This script doesn't work with Inkscape version 1.0 or higher. This will be changed in the future." 
-if inkscape_version < 0.92: # inkscape version 0.92 changed the default dpi from 90 to 96
-    DPI_1_TO_1 = 90
-else:
-    DPI_1_TO_1 = 96
-# DPI multipliers to render at
-DPIS = [1, 2] # for hidpi icons change to [1, 2] (not yet supported in Mint-Y)
+    if os.path.exists(args.optipng_path):
+        process = subprocess.Popen([args.optipng_path, '-quiet', '-o7', png_file])
+        process.wait()
 
-inkscape_process = None
 
-def main(args, SRC):
+def inkscape_render_rect(icon_file, rect, dpi, output_file, args):
 
-    def optimize_png(png_file):
-        if os.path.exists(OPTIPNG_PATH):
-            process = subprocess.Popen([OPTIPNG_PATH, '-quiet', '-o7', png_file])
-            process.wait()
+    cmd = ["inkscape",
+        "--batch-process",
+        '--export-dpi={}'.format(str(dpi)),
+        '--export-id={}'.format(str(rect)),
+        '--export-filename={}'.format(output_file),
+        icon_file]
 
-    def wait_for_prompt(process, command=None):
-        if command is not None:
-            process.stdin.write((command+'\n').encode('utf-8'))
+    ret = subprocess.run(cmd, capture_output=True)
+    if ret.returncode != 0:
+        print("execution of")
+        print('  %s' % "".join(cmd))
+        print("returned with error %d" % ret.returncode)
+        print(5*"=", "stdout", 5*"=")
+        print(ret.stdout.decode())
+        print(5*"=", "stderr", 5*"=")
+        print(ret.stderr.decode())
+        return
 
-        # This is kinda ugly ...
-        # Wait for just a '>', or '\n>' if some other char appearead first
-        output = process.stdout.read(1)
-        if output == b'>':
-            return
+    optimize_png(output_file, args)
 
-        output += process.stdout.read(1)
-        while output != b'\n>':
-            output += process.stdout.read(1)
-            output = output[1:]
 
-    def start_inkscape():
-        process = subprocess.Popen([INKSCAPE_PATH, '--shell'], bufsize=0, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        wait_for_prompt(process)
-        return process
+class ContentHandler(xml.sax.ContentHandler):
+    ROOT = 0
+    SVG = 1
+    LAYER = 2
+    OTHER = 3
+    TEXT = 4
+    def __init__(self, path, args, force=False):
+        self.args = args
+        self.stack = [self.ROOT]
+        self.inside = [self.ROOT]
+        self.path = path
+        self.rects = []
+        self.state = self.ROOT
+        self.chars = ""
+        self.force = force
+        self.filter = args.filter
 
-    def inkscape_render_rect(icon_file, rect, dpi, output_file):
-        global inkscape_process
-        if inkscape_process is None:
-            inkscape_process = start_inkscape()
+    def endDocument(self):
+        pass
 
-        cmd = [icon_file,
-               '--export-dpi={}'.format(str(dpi)),
-               '--export-id={}'.format(str(rect)),
-               '--export-filename={}'.format(output_file)]
-        wait_for_prompt(inkscape_process, ' '.join(cmd))
-        optimize_png(output_file)
-
-    class ContentHandler(xml.sax.ContentHandler):
-        ROOT = 0
-        SVG = 1
-        LAYER = 2
-        OTHER = 3
-        TEXT = 4
-        def __init__(self, path, force=False, filter=None):
-            self.stack = [self.ROOT]
-            self.inside = [self.ROOT]
-            self.path = path
-            self.rects = []
-            self.state = self.ROOT
-            self.chars = ""
-            self.force = force
-            self.filter = filter
-
-        def endDocument(self):
-            pass
-
-        def startElement(self, name, attrs):
-            if self.inside[-1] == self.ROOT:
-                if name == "svg":
-                    self.stack.append(self.SVG)
-                    self.inside.append(self.SVG)
+    def startElement(self, name, attrs):
+        if self.inside[-1] == self.ROOT:
+            if name == "svg":
+                self.stack.append(self.SVG)
+                self.inside.append(self.SVG)
+                return
+        elif self.inside[-1] == self.SVG:
+            for attr in attrs.values():
+                if attr == 'Baseplate':
+                    self.stack.append(self.LAYER)
+                    self.inside.append(self.LAYER)
+                    self.context = None
+                    self.icon_name = None
+                    self.rects = []
                     return
-            elif self.inside[-1] == self.SVG:
-                for attr in attrs.values():
-                    if attr == 'Baseplate':
-                        self.stack.append(self.LAYER)
-                        self.inside.append(self.LAYER)
-                        self.context = None
-                        self.icon_name = None
-                        self.rects = []
-                        return
-            elif self.inside[-1] == self.LAYER:
-                for attr in attrs.values():
-                    if attr == "context":
-                        self.stack.append(self.TEXT)
-                        self.inside.append(self.TEXT)
-                        self.text='context'
-                        self.chars = ""
-                        return
-                    if attr == "icon-name":
-                        self.stack.append(self.TEXT)
-                        self.inside.append(self.TEXT)
-                        self.text='icon-name'
-                        self.chars = ""
-                        return
-                    if name == "rect":
-                        self.rects.append(attrs)
-
-            self.stack.append(self.OTHER)
-
-
-        def endElement(self, name):
-            stacked = self.stack.pop()
-            if self.inside[-1] == stacked:
-                self.inside.pop()
-
-            if stacked == self.TEXT and self.text is not None:
-                assert self.text in ['context', 'icon-name']
-                if self.text == 'context':
-                    self.context = self.chars
-                elif self.text == 'icon-name':
-                    self.icon_name = self.chars
-                self.text = None
-            elif stacked == self.LAYER:
-                assert self.icon_name
-                assert self.context
-
-                if self.filter is not None and not self.icon_name in self.filter:
+        elif self.inside[-1] == self.LAYER:
+            for attr in attrs.values():
+                if attr == "context":
+                    self.stack.append(self.TEXT)
+                    self.inside.append(self.TEXT)
+                    self.text='context'
+                    self.chars = ""
                     return
+                if attr == "icon-name":
+                    self.stack.append(self.TEXT)
+                    self.inside.append(self.TEXT)
+                    self.text='icon-name'
+                    self.chars = ""
+                    return
+                if name == "rect":
+                    self.rects.append(attrs)
+        self.stack.append(self.OTHER)
 
 
-                new_renders = 0
-                updated_renders = 0
-                skipped_renders = 0
+    def endElement(self, name):
+        stacked = self.stack.pop()
+        if self.inside[-1] == stacked:
+            self.inside.pop()
 
-                # Each rect represents an icon size to export
-                for rect in self.rects:
-                    for dpi_factor in DPIS:
-                        width = rect['width']
-                        # height = rect['height']
-                        id = rect['id']
-                        dpi = DPI_1_TO_1 * dpi_factor
+        if stacked == self.TEXT and self.text is not None:
+            assert self.text in ['context', 'icon-name']
+            if self.text == 'context':
+                self.context = self.chars
+            elif self.text == 'icon-name':
+                self.icon_name = self.chars
+            self.text = None
 
-                        size_str = "%s" % (width)
-                        if dpi_factor != 1:
-                            size_str += "@%sx" % dpi_factor
+        elif stacked == self.LAYER:
+            assert self.icon_name
+            assert self.context
 
-                        dir = os.path.join(OUTPUT_DIRECTORY, self.context, size_str)
-                        outfile = os.path.join(dir, self.icon_name+'.png')
-                        if not os.path.exists(dir):
-                            os.makedirs(dir)
+            if self.filter is not None and not self.icon_name in self.filter:
+                return
 
-                        # If PNG does not exist, create it new
-                        if self.force or not os.path.exists(outfile):
+            new_renders = 0
+            updated_renders = 0
+            skipped_renders = 0
+
+            # Each rect represents an icon size to export
+            for rect in self.rects:
+                for dpi_factor in self.args.scaling_factors:
+                    width = rect['width']
+                    # height = rect['height']
+                    id = rect['id']
+                    dpi = self.args.base_dpi * dpi_factor
+
+                    size_str = "%s" % (width)
+                    if dpi_factor != 1:
+                        size_str += "@%sx" % dpi_factor
+
+                    dir = os.path.join(self.args.output_path, self.context, size_str)
+                    outfile = os.path.join(dir, self.icon_name+'.png')
+                    if not os.path.exists(dir):
+                        os.makedirs(dir)
+
+                    # If PNG does not exist, create it new
+                    if self.force or not os.path.exists(outfile):
+                        inkscape_render_rect(self.path, id, dpi, outfile, self.args)
+                        if self.args.verbose:
+                            print("├─ Rendered new \"" + outfile + "\"")
+                        new_renders += 1
+
+                    # If PNG exists, compare modify time to that of SVG
+                    else:
+                        stat_in = os.stat(self.path)
+                        stat_out = os.stat(outfile)
+
+                        # If SVG is newer than PNG, replace PNG with updated version
+                        if stat_in.st_mtime > stat_out.st_mtime:
                             inkscape_render_rect(self.path, id, dpi, outfile)
-                            if args.verbose:
-                                print("├─ Rendered new \"" + outfile + "\"")
-                            new_renders += 1
+                            if self.args.verbose:
+                                print("├─ Rendered updated \"" + outfile + "\"")
+                            # print("Rendered updated " + outfile)
+                            updated_renders += 1
 
-                        # If PNG exists, compare modify time to that of SVG
+                        # If PNG is newer than SVG, leave PNG as is
                         else:
-                            stat_in = os.stat(self.path)
-                            stat_out = os.stat(outfile)
+                            if self.args.verbose:
+                                print("├─ \"" + outfile + "\" is newer than SVG")
+                            skipped_renders += 1
 
-                            # If SVG is newer than PNG, replace PNG with updated version
-                            if stat_in.st_mtime > stat_out.st_mtime:
-                                inkscape_render_rect(self.path, id, dpi, outfile)
-                                if args.verbose:
-                                    print("├─ Rendered updated \"" + outfile + "\"")
-                                # print("Rendered updated " + outfile)
-                                updated_renders += 1
+            # Print horizontal rule below long list
+            if self.args.verbose:
+                print("├────────────────────────────────┤")
 
-                            # If PNG is newer than SVG, leave PNG as is
-                            else:
-                                if args.verbose:
-                                    print("├─ \"" + outfile + "\" is newer than SVG")
-                                skipped_renders += 1
-                if args.verbose:
-                    print("├────────────────────────────────┤")
-                if args.svg is None:
-                    print("")
-                    print("┌────────────────────────────────┐")
-                    print("│ Directory: " + self.context)
-                    print("│ Icon Name: " + self.icon_name)
-                    print("├────────────────────────────────┤")
-                    print("├─ Rendered %d new PNGs" % new_renders)
-                    print("├─ Rendered %d updated PNGs" % updated_renders)
-                    print("├─ Skipped %d up-to-date PNGs" % skipped_renders)
-                    print("└────────────────────────────────┘")
-                    print("")
+            # Print summary
+            if self.args.individual_icons is None:
+                print("")
+                print("┌────────────────────────────────┐")
+                print("│ Directory: " + self.context)
+                print("│ Icon Name: " + self.icon_name)
+                print("├────────────────────────────────┤")
+                print("├─ Rendered %d new PNGs" % new_renders)
+                print("├─ Rendered %d updated PNGs" % updated_renders)
+                print("├─ Skipped %d up-to-date PNGs" % skipped_renders)
+                print("└────────────────────────────────┘")
+                print("")
 
-        def characters(self, chars):
-            self.chars += chars.strip()
+    def characters(self, chars):
+        self.chars += chars.strip()
+
+
+def render_category(args, category_to_render):
 
     # If invocation includes a file name, try to process it
-    if args.svg:
-        file = os.path.join(SRC, args.svg + '.svg')
+    if args.individual_icons:
+        file = os.path.join(category_to_render, args.individual_icons + '.svg')
 
         if os.path.exists(os.path.join(file)):
             print("├─ Rendering from \"" + os.path.join(file) + "\"")
-            handler = ContentHandler(file, True, filter=args.filter)
+            #
+            # ContentHandler() implements an interface for xml.sax.parse()
+            #
+            handler = ContentHandler(file, args, True)
+            #
+            # xml.sax.parse() uses the various ContentHandler() methods behind the scenes
+            #
             xml.sax.parse(open(file), handler)
             return True
         else:
@@ -238,60 +221,278 @@ def main(args, SRC):
 
     # If invocation does not include a file name, process all SVGs in listed sources
     else:
-        print("Rendering from path \"" + SRC + "\"")
-        if not os.path.exists(OUTPUT_DIRECTORY):
-            os.mkdir(OUTPUT_DIRECTORY)
+        print("Rendering from path \"" + category_to_render + "\"")
+        if not os.path.exists(args.output_path):
+            os.mkdir(args.output_path)
 
-        for file in os.listdir(SRC):
+        # this is the loop for the files in the given directory
+        for file in os.listdir(category_to_render):
             if file[-4:] == '.svg':
-                file = os.path.join(SRC, file)
-                handler = ContentHandler(file)
+                file = os.path.join(category_to_render, file)
+                #
+                # ContentHandler() implements an interface for xml.sax.parse()
+                #
+                handler = ContentHandler(file, args)
+                #
+                # xml.sax.parse() uses the various ContentHandler() methods behind the scenes
+                #
                 xml.sax.parse(open(file), handler)
         
         return True
 
-    
 
-parser = argparse.ArgumentParser(description='Render icons from SVG to PNG')
+def check_dependencies(args):
 
-parser.add_argument('svg', type=str, nargs='?', metavar='SVG',
-                    help="Optional SVG names (without extensions) to render. If not given, render all icons")
-parser.add_argument('filter', type=str, nargs='?', metavar='FILTER',
-                    help="Optional filter for the SVG file")
-parser.add_argument('--verbose', action='store_true',
-                    help="Print verbose output to the terminal")
+    # assert ('linux' in sys.platform), "This code runs on Linux only."
+    assert (os.path.isfile(args.inkscape_path)), "Expected to find Inkscape at " + args.inkscape_path + ", but file does not exist."
+    assert (os.path.isfile(args.optipng_path)), "Expected to find OptiPNG at " + args.optipng_path + " but file does not exist."
+    assert (os.path.isdir(args.output_path)), "Expected to find output directory at " + args.output_path + ", but directory does not exist."
 
-args = parser.parse_args()
 
-if args.svg is None:
-    print("\nNo arguments provided; processing listed sources:\n")
-    for source in CATEGORIES_TO_RENDER:
-        print("-- \"" + os.path.join('.', source) + "\"")
+def print_help():
+
     print("")
-else:
+    print("┌──────────────────────────────────────────────────┐")
+    print("│ Render icons from SVG to PNG                     │")
+    print("└──────────────────────────────────────────────────┘")
+    print("┌──────────────────────────────────────────────────┐")
+    print("│ Usage                                            │")
+    print("├──────────────────────────────────────────────────┤")
+    print("│ $ [./]render-bitmaps-verbose.py                  │")
+    print("│       [--help]                                   │")
+    print("│       [--base_dpi BASE_DPI]                      │")
+    print("│       [--categories [CATEGORIES]]                │")
+    print("│       [--filter FILTER]                          │")
+    print("│       [--inkscape_path INKSCAPE_PATH]            │")
+    print("│       [--individual_icons [INDIVIDUAL_ICONS]]    │")
+    print("│       [--optipng_path OPTIPNG_PATH]              │")
+    print("│       [--output_path OUTPUT_PATH]                │")
+    print("│       [--scaling_factors [SCALING_FACTORS]]      │")
+    print("│       [--verbose]                                │")
+    print("│                                                  │")
+    print("└──────────────────────────────────────────────────┘")
+    print("┌──────────────────────────────────────────────────┐")
+    print("│ Optional Arguments                               │")
+    print("├──────────────────────────────────────────────────┤")
+    print("│ --help                                           │")
+    print("│                                                  │")
+    print("│   Show this help message and exit.               │")
+    print("│                                                  │")
+    print("│ --base_dpi BASE_DPI                              │")
+    print("│                                                  │")
+    print("│   dpi to use for rendering (by default 96)       │")
+    print("│                                                  │")
+    print("│ --categories [CATEGORIES]                        │")
+    print("│                                                  │")
+    print("│   categories of icons to render (by default all) │")
+    print("│                                                  │")
+    print("│ --filter FILTER                                  │")
+    print("│                                                  │")
+    print("│   Inkscape filter to apply while rendering       │")
+    print("│   (by default none)                              │")
+    print("│                                                  │")
+    print("│ --inkscape_path INKSCAPE_PATH                    │")
+    print("│                                                  │")
+    print("│   path of Inkscape executable                    │")
+    print("│   (if the script can't find it)                  │")
+    print("│                                                  │")
+    print("│ --individual_icons [INDIVIDUAL_ICONS]            │")
+    print("│                                                  │")
+    print("│   individual icon names (without extensions)     │")
+    print("│   to render (by default all)                     │")
+    print("│                                                  │")
+    print("│ --optipng_path OPTIPNG_PATH                      │")
+    print("│                                                  │")
+    print("│   path of OptiPNG executable                     │")
+    print("│   (if the script can't find it)                  │")
+    print("│                                                  │")
+    print("│ --output_path OUTPUT_PATH                        │")
+    print("│                                                  │")
+    print("│   output directory (by default '../../Suru')     │")
+    print("│                                                  │")
+    print("│ --scaling_factors [SCALING_FACTORS]              │")
+    print("│                                                  │")
+    print("│   scaling factors to render at                   │")
+    print("│   (by default [1, 2], e.g. 100% & 200%)          │")
+    print("│                                                  │")
+    print("│ --verbose                                        │")
+    print("│                                                  │")
+    print("│   print verbose output to the terminal           │")
+    print("│                                                  │")
+    print("└──────────────────────────────────────────────────┘")
+    print("")
+    return
+
+
+def print_categories():
+
+    print("")
     print("┌────────────────────────────────┐")
-    print("│ Rendering from command-line argument \"" + args.svg + "\"")
+    print("│ Icon Categories:               │")
     print("├────────────────────────────────┤")
-
-success_directory = ""
-
-for source in CATEGORIES_TO_RENDER:
-    if os.path.exists(os.path.join('.', source)):
-        SRC = os.path.join('.', source)
-        if main(args, SRC):
-            success_directory = source
-    else:
-        print("Source path \"" + os.path.join('.', source) + "\" does not exist.")
-if args.svg is not None:
+    print("│ - actions                      │")
+    print("│ - apps                         │")
+    print("│ - categories                   │")
+    print("│ - devices                      │")
+    print("│ - emblems                      │")
+    print("│ - legacy                       │")
+    print("│ - mimetypes                    │")
+    print("│ - places                       │")
+    print("│ - status                       │")
+    print("│ - wip                          │")
     print("└────────────────────────────────┘")
+    print("")
+    return
 
-if success_directory != "" and args.svg is not None:
-    print("\nSuccessfully processed \"" + args.svg + "\" in \"" + success_directory + "\".\n")
-elif success_directory == "" and args.svg is not None:
-    print("\nFailed to process \"" + args.svg + "\" in " + success_directory + ".\n")
-elif success_directory != "":
-    print("Successfully processed listed sources.\n")
-elif success_directory == "":
-    print("Failed to process listed sources.\n")
-else:
-    raise Exception("Conditional statement falls through.")
+
+def build_parser():
+
+    parser = argparse.ArgumentParser(add_help=False)
+
+    parser.add_argument(
+        '--categories',
+        type=str,
+        nargs='?',
+        default=(
+            "actions",
+            "apps",
+            "categories",
+            "devices",
+            "emblems",
+            "legacy",
+            "mimetypes",
+            "places",
+            "status",
+            "wip",
+        ),
+        help="categories of icons to render (by default all)"
+    )
+    parser.add_argument(
+        '--base_dpi',
+        type=int,
+        nargs=1,
+        default=96,
+        help="dpi to use for rendering (by default 96)"
+    )
+    parser.add_argument(
+        '--filter',
+        type=str,
+        nargs=1,
+        help="Inkscape filter to apply while rendering (by default none)"
+    )
+    parser.add_argument(
+        '--help',
+        action='store_true',
+        help="show this help message and exit"
+    )
+    parser.add_argument(
+        '--inkscape_path',
+        type=str,
+        nargs=1,
+        default = '/usr/bin/inkscape',
+        help="path of Inkscape executable (if the script can't find it)"
+    )
+    parser.add_argument(
+        '--individual_icons',
+        type=str,
+        nargs='?',
+        help="individual icon names (without extensions) to render (by default all)"
+    )
+    parser.add_argument(
+        '--list_categories',
+        action='store_true',
+        help="list categories of icons to choose from and exit"
+    )
+    parser.add_argument(
+        '--optipng_path',
+        type=str,
+        nargs=1,
+        default = '/usr/bin/optipng',
+        help="path of OptiPNG executable (if the script can't find it)"
+    )
+    parser.add_argument(
+        '--output_path',
+        type=str,
+        nargs=1,
+        default = '../../Suru',
+        help="output directory (by default '../../Suru')"
+    )
+    parser.add_argument(
+        '--scaling_factors',
+        type=int,
+        nargs='?',
+        default=[1, 2],
+        help="scaling factors to render at (by default [1, 2])"
+    )
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help="print verbose output to the terminal"
+    )
+    return parser
+
+
+def do(args):
+
+    if args.list_categories:
+        print_categories()
+        return None
+
+    if args.help:
+        print_help()
+        return None
+
+    check_dependencies(args)
+    
+    if args.individual_icons is None:
+        print("\nNo arguments provided; processing listed sources:\n")
+        for icon_category in args.categories:
+            print("-- \"" + os.path.join('.', icon_category) + "\"")
+        print("")
+    else:
+        print("┌────────────────────────────────┐")
+        print("│ Rendering from command-line argument \"" + args.individual_icons + "\"")
+        print("├────────────────────────────────┤")
+
+    class Result:
+        def __init__(self, args):
+            self.directory = ""
+            self.named = args.individual_icons
+
+    result = Result(args)
+
+    for source in args.categories:
+        if os.path.exists(os.path.join('.', source)):
+            SRC = os.path.join('.', source)
+            #
+            # render_category() is the main function call
+            #
+            if render_category(args, SRC):
+                result.directory = source
+        else:
+            print("Source path \"" + os.path.join('.', source) + "\" does not exist.")
+    if args.individual_icons is not None:
+        print("└────────────────────────────────┘")
+
+    return result
+
+
+def print_result(result):
+
+    if result is None: return
+
+    if result.directory != "" and result.named is not None:
+        print("\nSuccessfully processed \"" + result.named + "\" in \"" + result.directory + "\".\n")
+    elif result.directory == "" and result.named is not None:
+        print("\nFailed to process \"" + result.named + "\" in " + result.directory + ".\n")
+    elif result.directory != "":
+        print("Successfully processed listed sources.\n")
+    elif result.directory == "":
+        print("Failed to process listed sources.\n")
+    else:
+        raise Exception("Conditional statement falls through.")
+    return
+
+
+# This is the main function
+print_result(do(build_parser().parse_args()))

--- a/icons/src/fullcolor/render-bitmaps-verbose.py
+++ b/icons/src/fullcolor/render-bitmaps-verbose.py
@@ -1,0 +1,297 @@
+#!/usr/bin/python3
+# coding: utf-8
+#
+# Legal Stuff:
+#
+# This file is part of the Moka Icon Theme and is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free Software
+# Foundation; version 3.
+#
+# This file is part of the Moka Icon Theme and is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <https://www.gnu.org/licenses/lgpl-3.0.txt>
+#
+#
+# Thanks to the GNOME icon developers for the original version of this script
+import os
+import sys
+import xml.sax
+import subprocess
+import argparse
+
+INKSCAPE = '/usr/bin/inkscape'
+OPTIPNG = '/usr/bin/optipng'
+MAINDIR = '../usr/share/icons/Mint-Y'
+SOURCES = ['apps', 'categories']
+
+# assert ('linux' in sys.platform), "This code runs on Linux only."
+assert (os.path.isfile(INKSCAPE)), "Expected to find Inkscape at /usr/bin/inkscape, but file does not exist."
+assert (os.path.isfile(OPTIPNG)), "Expected to find OptiPNG at /usr/bin/optipng, but file does not exist."
+assert (os.path.isdir(MAINDIR)), "Expected to find Mint-Y at ../usr/share/icons/Mint-Y, but directory does not exist."
+
+# the resolution that non-hi-dpi icons are rendered at (may be 90 or 96 depending on your inkscape build)
+inkscape_version = str(subprocess.check_output(['inkscape', '-V'])).split(' ')[1].split('.')
+inkscape_version = float(inkscape_version[0] + '.' + inkscape_version[1])
+assert (inkscape_version < 1.0), "Expected Inkscape version lower than 1.0. This script doesn't work with Inkscape version 1.0 or higher. This will be changed in the future." 
+if inkscape_version < 0.92: # inkscape version 0.92 changed the default dpi from 90 to 96
+    DPI_1_TO_1 = 90
+else:
+    DPI_1_TO_1 = 96
+# DPI multipliers to render at
+DPIS = [1, 2] # for hidpi icons change to [1, 2] (not yet supported in Mint-Y)
+
+inkscape_process = None
+
+def main(args, SRC):
+
+    def optimize_png(png_file):
+        if os.path.exists(OPTIPNG):
+            process = subprocess.Popen([OPTIPNG, '-quiet', '-o7', png_file])
+            process.wait()
+
+    def wait_for_prompt(process, command=None):
+        if command is not None:
+            process.stdin.write((command+'\n').encode('utf-8'))
+
+        # This is kinda ugly ...
+        # Wait for just a '>', or '\n>' if some other char appearead first
+        output = process.stdout.read(1)
+        if output == b'>':
+            return
+
+        output += process.stdout.read(1)
+        while output != b'\n>':
+            output += process.stdout.read(1)
+            output = output[1:]
+
+    def start_inkscape():
+        process = subprocess.Popen([INKSCAPE, '--shell'], bufsize=0, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        wait_for_prompt(process)
+        return process
+
+    def inkscape_render_rect(icon_file, rect, dpi, output_file):
+        global inkscape_process
+        if inkscape_process is None:
+            inkscape_process = start_inkscape()
+
+        cmd = [icon_file,
+               '--export-dpi', str(dpi),
+               '-i', rect,
+               '-e', output_file]
+        wait_for_prompt(inkscape_process, ' '.join(cmd))
+        optimize_png(output_file)
+
+    class ContentHandler(xml.sax.ContentHandler):
+        ROOT = 0
+        SVG = 1
+        LAYER = 2
+        OTHER = 3
+        TEXT = 4
+        def __init__(self, path, force=False, filter=None):
+            self.stack = [self.ROOT]
+            self.inside = [self.ROOT]
+            self.path = path
+            self.rects = []
+            self.state = self.ROOT
+            self.chars = ""
+            self.force = force
+            self.filter = filter
+
+        def endDocument(self):
+            pass
+
+        def startElement(self, name, attrs):
+            if self.inside[-1] == self.ROOT:
+                if name == "svg":
+                    self.stack.append(self.SVG)
+                    self.inside.append(self.SVG)
+                    return
+            elif self.inside[-1] == self.SVG:
+                for attr in attrs.values():
+                    if attr == 'Baseplate':
+                        self.stack.append(self.LAYER)
+                        self.inside.append(self.LAYER)
+                        self.context = None
+                        self.icon_name = None
+                        self.rects = []
+                        return
+            elif self.inside[-1] == self.LAYER:
+                for attr in attrs.values():
+                    if attr == "context":
+                        self.stack.append(self.TEXT)
+                        self.inside.append(self.TEXT)
+                        self.text='context'
+                        self.chars = ""
+                        return
+                    if attr == "icon-name":
+                        self.stack.append(self.TEXT)
+                        self.inside.append(self.TEXT)
+                        self.text='icon-name'
+                        self.chars = ""
+                        return
+                    if name == "rect":
+                        self.rects.append(attrs)
+
+            self.stack.append(self.OTHER)
+
+
+        def endElement(self, name):
+            stacked = self.stack.pop()
+            if self.inside[-1] == stacked:
+                self.inside.pop()
+
+            if stacked == self.TEXT and self.text is not None:
+                assert self.text in ['context', 'icon-name']
+                if self.text == 'context':
+                    self.context = self.chars
+                elif self.text == 'icon-name':
+                    self.icon_name = self.chars
+                self.text = None
+            elif stacked == self.LAYER:
+                assert self.icon_name
+                assert self.context
+
+                if self.filter is not None and not self.icon_name in self.filter:
+                    return
+
+
+                new_renders = 0
+                updated_renders = 0
+                skipped_renders = 0
+
+                # Each rect represents an icon size to export
+                for rect in self.rects:
+                    for dpi_factor in DPIS:
+                        width = rect['width']
+                        # height = rect['height']
+                        id = rect['id']
+                        dpi = DPI_1_TO_1 * dpi_factor
+
+                        size_str = "%s" % (width)
+                        if dpi_factor != 1:
+                            size_str += "@%sx" % dpi_factor
+
+                        dir = os.path.join(MAINDIR, self.context, size_str)
+                        outfile = os.path.join(dir, self.icon_name+'.png')
+                        if not os.path.exists(dir):
+                            os.makedirs(dir)
+
+                        # If PNG does not exist, create it new
+                        if self.force or not os.path.exists(outfile):
+                            inkscape_render_rect(self.path, id, dpi, outfile)
+                            if args.verbose:
+                                print("├─ Rendered new \"".decode('utf-8') + outfile + "\"")
+                            new_renders += 1
+
+                        # If PNG exists, compare modify time to that of SVG
+                        else:
+                            stat_in = os.stat(self.path)
+                            stat_out = os.stat(outfile)
+
+                            # If SVG is newer than PNG, replace PNG with updated version
+                            if stat_in.st_mtime > stat_out.st_mtime:
+                                inkscape_render_rect(self.path, id, dpi, outfile)
+                                if args.verbose:
+                                    print("├─ Rendered updated \"".decode('utf-8') + outfile + "\"")
+                                # print("Rendered updated " + outfile)
+                                updated_renders += 1
+
+                            # If PNG is newer than SVG, leave PNG as is
+                            else:
+                                if args.verbose:
+                                    print("├─ \"".decode('utf-8') + outfile + "\" is newer than SVG")
+                                skipped_renders += 1
+                if args.verbose:
+                    print("├────────────────────────────────┤".decode('utf-8'))
+                if args.svg is None:
+                    print("")
+                    print("┌────────────────────────────────┐".decode('utf-8'))
+                    print("│ Directory: ".decode('utf-8') + self.context)
+                    print("│ Icon Name: ".decode('utf-8') + self.icon_name)
+                    print("├────────────────────────────────┤".decode('utf-8'))
+                    print("├─ Rendered %d new PNGs".decode('utf-8') % new_renders)
+                    print("├─ Rendered %d updated PNGs".decode('utf-8') % updated_renders)
+                    print("├─ Skipped %d up-to-date PNGs".decode('utf-8') % skipped_renders)
+                    print("└────────────────────────────────┘".decode('utf-8'))
+                    print("")
+
+        def characters(self, chars):
+            self.chars += chars.strip()
+
+    # If invocation includes a file name, try to process it
+    if args.svg:
+        file = os.path.join(SRC, args.svg + '.svg')
+
+        if os.path.exists(os.path.join(file)):
+            print("├─ Rendering from \"".decode('utf-8') + os.path.join(file) + "\"")
+            handler = ContentHandler(file, True, filter=args.filter)
+            xml.sax.parse(open(file), handler)
+            return True
+        else:
+            # icon not in this directory, try the next one
+            print("├─ Input file \"".decode('utf-8') + file + "\" does not exist.")
+            return False
+
+    # If invocation does not include a file name, process all SVGs in listed sources
+    else:
+        print("Rendering from path \"".decode('utf-8') + SRC + "\"")
+        if not os.path.exists(MAINDIR):
+            os.mkdir(MAINDIR)
+
+        for file in os.listdir(SRC):
+            if file[-4:] == '.svg':
+                file = os.path.join(SRC, file)
+                handler = ContentHandler(file)
+                xml.sax.parse(open(file), handler)
+        
+        return True
+
+    
+
+parser = argparse.ArgumentParser(description='Render icons from SVG to PNG')
+
+parser.add_argument('svg', type=str, nargs='?', metavar='SVG',
+                    help="Optional SVG names (without extensions) to render. If not given, render all icons")
+parser.add_argument('filter', type=str, nargs='?', metavar='FILTER',
+                    help="Optional filter for the SVG file")
+parser.add_argument('--verbose', action='store_true',
+                    help="Print verbose output to the terminal")
+
+args = parser.parse_args()
+
+if args.svg is None:
+    print("\nNo arguments provided; processing listed sources:\n")
+    for source in SOURCES:
+        print("-- \"" + os.path.join('.', source) + "\"")
+    print("")
+else:
+    print("┌────────────────────────────────┐".decode('utf-8'))
+    print("│ Rendering from command-line argument \"".decode('utf-8') + args.svg + "\"")
+    print("├────────────────────────────────┤".decode('utf-8'))
+
+success_directory = ""
+
+for source in SOURCES:
+    if os.path.exists(os.path.join('.', source)):
+        SRC = os.path.join('.', source)
+        if main(args, SRC):
+            success_directory = source
+    else:
+        print("Source path \"" + os.path.join('.', source) + "\" does not exist.")
+if args.svg is not None:
+    print("└────────────────────────────────┘".decode('utf-8'))
+
+if success_directory != "" and args.svg is not None:
+    print("\nSuccessfully processed \"" + args.svg + "\" in \"" + success_directory + "\".\n")
+elif success_directory == "" and args.svg is not None:
+    print("\nFailed to process \"" + args.svg + "\" in " + success_directory + ".\n")
+elif success_directory != "":
+    print("Successfully processed listed sources.\n")
+elif success_directory == "":
+    print("Failed to process listed sources.\n")
+else:
+    raise Exception("Conditional statement falls through.")

--- a/icons/src/fullcolor/render-bitmaps.py
+++ b/icons/src/fullcolor/render-bitmaps.py
@@ -114,42 +114,30 @@ def main(args, SRC):
                     self.inside.append(self.SVG)
                     return
             elif self.inside[-1] == self.SVG:
-                if (
-                    name == "g"
-                    and ("inkscape:groupmode" in attrs)
-                    and ("inkscape:label" in attrs)
-                    and attrs["inkscape:groupmode"] == "layer"
-                    and attrs["inkscape:label"].startswith("Baseplate")
-                ):
-                    self.stack.append(self.LAYER)
-                    self.inside.append(self.LAYER)
-                    self.context = None
-                    self.icon_name = None
-                    self.rects = []
-                    return
+                for attr in attrs.values():
+                    if attr == 'Baseplate':
+                        self.stack.append(self.LAYER)
+                        self.inside.append(self.LAYER)
+                        self.context = None
+                        self.icon_name = None
+                        self.rects = []
+                        return
             elif self.inside[-1] == self.LAYER:
-                if (
-                    name == "text"
-                    and ("inkscape:label" in attrs)
-                    and attrs["inkscape:label"] == "context"
-                ):
-                    self.stack.append(self.TEXT)
-                    self.inside.append(self.TEXT)
-                    self.text = "context"
-                    self.chars = ""
-                    return
-                elif (
-                    name == "text"
-                    and ("inkscape:label" in attrs)
-                    and attrs["inkscape:label"] == "icon-name"
-                ):
-                    self.stack.append(self.TEXT)
-                    self.inside.append(self.TEXT)
-                    self.text = "icon-name"
-                    self.chars = ""
-                    return
-                elif name == "rect":
-                    self.rects.append(attrs)
+                for attr in attrs.values():
+                    if attr == "context":
+                        self.stack.append(self.TEXT)
+                        self.inside.append(self.TEXT)
+                        self.text='context'
+                        self.chars = ""
+                        return
+                    if attr == "icon-name":
+                        self.stack.append(self.TEXT)
+                        self.inside.append(self.TEXT)
+                        self.text='icon-name'
+                        self.chars = ""
+                        return
+                    if name == "rect":
+                        self.rects.append(attrs)
 
             self.stack.append(self.OTHER)
 

--- a/icons/src/fullcolor/render-bitmaps.py
+++ b/icons/src/fullcolor/render-bitmaps.py
@@ -43,7 +43,33 @@ SOURCES = (
 DPIS = [1, 2]
 
 
+def parse():
+
+    parser = argparse.ArgumentParser(description="Render icons from SVG to PNG")
+
+    parser.add_argument(
+        "svg",
+        type=str,
+        nargs="?",
+        metavar="SVG",
+        help="Optional SVG names (without extensions) to render. If not given, render all icons",
+    )
+    parser.add_argument(
+        "filter",
+        type=str,
+        nargs="?",
+        metavar="FILTER",
+        help="Optional filter for the SVG file",
+    )
+
+    args = parser.parse_args()
+
+    for source in SOURCES:
+        SRC = os.path.join(".", source)
+        main(args, SRC)
+
 def main(args, SRC):
+
     def optimize_png(png_file):
         if os.path.exists(OPTIPNG):
             process = subprocess.Popen([OPTIPNG, "-quiet", "-o7", png_file])
@@ -65,15 +91,17 @@ def main(args, SRC):
             output = output[1:]
 
     def inkscape_render_rect(icon_file, rect, dpi, output_file):
+
         cmd = [
             "inkscape",
             "--batch-process",
             "--export-dpi={}".format(str(dpi)),
-            "-i",
-            rect,
+            "-i", rect,
             "--export-filename={}".format(output_file),
             icon_file,
         ]
+
+        
         ret = subprocess.run(cmd, capture_output=True)
         if ret.returncode != 0:
             print("execution of")
@@ -221,26 +249,4 @@ def main(args, SRC):
             # icon not in this directory, try the next one
             pass
 
-
-parser = argparse.ArgumentParser(description="Render icons from SVG to PNG")
-
-parser.add_argument(
-    "svg",
-    type=str,
-    nargs="?",
-    metavar="SVG",
-    help="Optional SVG names (without extensions) to render. If not given, render all icons",
-)
-parser.add_argument(
-    "filter",
-    type=str,
-    nargs="?",
-    metavar="FILTER",
-    help="Optional filter for the SVG file",
-)
-
-args = parser.parse_args()
-
-for source in SOURCES:
-    SRC = os.path.join(".", source)
-    main(args, SRC)
+parse()


### PR DESCRIPTION
I copied the relevant bits from [my open pull request](https://github.com/linuxmint/mint-y-icons/pull/285) over at `mint-y-icons`. I tested it, and it seems to work.

(If you’re curious, the biggest difference with the version of `render-bitmaps.py` over at `mint-y-icons` is that they replaced all the `"` with `'`, which is the norm if you use `pylint`. Other than that, I think they added a few failsafes.)