### PR TITLE
Better list row border left

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -436,14 +436,17 @@ list row, placessidebar row, sidebar row, .sidebar row {
   &:selected {
     &.activatable, & {
       &, &:hover {
-        background-color: $_selection_bg;
+        background-image: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
         &, button, button image { color: $text_color; }
         button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
-        box-shadow: inset 4px 0 0 $selected_bg_color;
         &:backdrop {
           &, button, button image { color: $backdrop_fg_color; }
           button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
-          background-color: if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%));
+          background-image: linear-gradient(
+            to right,
+            $selected_bg_color 4px,
+            if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%)) 1px
+          );
         }    
       }
     }


### PR DESCRIPTION
I used a gradient instead of an inset box-shadow, so there's no more rounded corner.

**Before:**

![Capture d’écran du 2021-05-19 20-40-08](https://user-images.githubusercontent.com/36476595/118866702-8ea17e00-b8e2-11eb-8bcb-e8734911a6a9.png)

**After:**

![Capture d’écran du 2021-05-19 20-35-26](https://user-images.githubusercontent.com/36476595/118866718-92cd9b80-b8e2-11eb-8b8c-5bfa3604e60f.png)

The Gtk4 part will be added to the Libadwaita PR (#2783).
