### PR TITLE
Fix list rows orange flash when unselected

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -436,13 +436,13 @@ list row, placessidebar row, sidebar row, .sidebar row {
   &:selected {
     &.activatable, & {
       &, &:hover {
-        background-image: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
+        background: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
         &, button, button image { color: $text_color; }
         button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
         &:backdrop {
           &, button, button image { color: $backdrop_fg_color; }
           button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
-          background-image: linear-gradient(
+          background: linear-gradient(
             to right,
             $selected_bg_color 4px,
             if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%)) 1px

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -170,7 +170,7 @@ list row, placessidebar row, sidebar row, .sidebar row {
   &:selected {
     &.activatable, & {
       &, &:hover {
-        background-image: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
+        background: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
         &, button, button image { color: $text_color; }
         button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
       }


### PR DESCRIPTION
I just used `background` instead of `background-image`.

![Peek 20-05-2021 12-32](https://user-images.githubusercontent.com/36476595/118964237-95be9f80-b967-11eb-988b-b9cc12c2318f.gif)

Closes #2858