### PR TITLE
Gtk3 theme: remove firefox border axing

### DIFF
--- a/gtk/src/default/gtk-3.20/apps/_firefox.scss
+++ b/gtk/src/default/gtk-3.20/apps/_firefox.scss
@@ -1,12 +1,5 @@
 #MozillaGtkWidget.background {
 
-    // REMOVE THIS when firefox supports rounded menus
-    menu,
-    .menu,
-    .context-menu {
-        border-radius: 0;
-    }
-
     @if $ambiance {
 
         menubar,


### PR DESCRIPTION
- it is no longer needed and this could cause issues once the fire next-UI-menus are in (forgot how that UI overhaul is named, but on windows firefox nightly the new menus are already in and they are big and round)

![grafik](https://user-images.githubusercontent.com/15329494/119841292-f882de80-bf05-11eb-881d-308220377010.png)
