### PR TITLE
Sync Gtk4 with upstream

### DIFF
--- a/gtk/src/default/gtk-4.0/widgets/_scale.scss
+++ b/gtk/src/default/gtk-4.0/widgets/_scale.scss
@@ -123,24 +123,12 @@ scale {
   }
 
   &.marks-before, &.marks-after {
-    // Adjust box-shadow for the 45deg rotation, for 0px 2px we ideally want
-    // 1/√2px 1/√2px, round that to 1px 1px
-    $_shadow_size: 1px 1px;
-
     > trough > slider {
       transform: rotate(45deg);
 
-      box-shadow: $_shadow_size 4px transparentize(black, .8);
-    }
-
-    &:hover > trough > slider {
-      box-shadow: $_shadow_size 4px transparentize(black, .6);
-    }
-
-    &.dragging, &:disabled {
-      > trough > slider {
-        box-shadow: $_shadow_size 4px transparent;
-      }
+      // Adjust box-shadow for the 45deg rotation, for 0px 2px we ideally want
+      // 1/√2px 1/√2px, round that to 1px 1px
+      box-shadow: 1px 1px 4px transparentize(black, .8);
     }
   }
 

--- a/gtk/src/default/gtk-4.0/widgets/_switch.scss
+++ b/gtk/src/default/gtk-4.0/widgets/_switch.scss
@@ -28,7 +28,7 @@ switch {
     > image { color: transparent; }
    }
 
-  @include focus-ring($offset: 0, $outer: true);
+  @include focus-ring($offset: 1px, $outer: true);
 
   &:disabled {
     filter: opacity(0.5);


### PR DESCRIPTION
Sync Gtk4 with upstream.

**Major changes:**

- Remove leftover scale slider shadows (https://gitlab.gnome.org/GNOME/libadwaita/-/commit/72c24397feaa40b5f4836214f5a0a1bf2b00da35)
- Add an offset for switch focus ring (https://gitlab.gnome.org/GNOME/libadwaita/-/commit/015892d88dcff10435a9a8152c9327705b81f042).