### PR TITLE
GtkTheme: monochrome spinners and orange links

### DIFF
--- a/gtk/src/default/gtk-3.20/_colors.scss
+++ b/gtk/src/default/gtk-3.20/_colors.scss
@@ -14,8 +14,8 @@ $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%),
 $borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 8%));
 $alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 8%));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
-$link_color: if($variant == 'light', $linkblue, $blue);
-$link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
+$link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
+$link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -71,17 +71,6 @@ headerbar *, button * {
   -gtk-icon-shadow: none;
 }
 
-// blue spinner, white spinner for colored buttons
-spinner {
-  &:not(:backdrop) {
-    color: $blue;
-  }
-  button.suggested-action &, button.destructive-action & {
-    color: $selected_fg_color;
-    &:backdrop { color: $backdrop_selected_fg_color; }
-  }
-}
-
 // titlebutton
 button.titlebutton:not(.appmenu) {
 

--- a/gtk/src/default/gtk-4.0/_colors.scss
+++ b/gtk/src/default/gtk-4.0/_colors.scss
@@ -15,8 +15,8 @@ $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%),
 $borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 8%));
 $alt_borders_color: if($ambiance, darken($bg_color, 7%), if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 8%)));
 $borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
-$link_color: if($variant == 'light', $linkblue, $blue);
-$link_visited_color: if($variant == 'light', darken($link_color, 20%), lighten($link_color, 10%));
+$link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
+$link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
 $top_hilight: if($ambiance, lighten($bg_color, 8%), $borders_edge);
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_bg_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -1,13 +1,3 @@
-// blue spinner, white spinner for colored buttons
-spinner {
-    &:not(:backdrop) {
-        color: $spinner_color;
-    }
-    button.suggested-action &, button.destructive-action & {
-        color: $selected_fg_color;
-    }
-}
-
 // Orange close button
 windowcontrols {
     button {


### PR DESCRIPTION
- revert to "upstream" monochrome spinners
- get rid of blue links, as the last part of blue in the theme which is now jarringly out of place

![grafik](https://user-images.githubusercontent.com/15329494/120889617-49798d80-c5fe-11eb-8863-ddb4848b8f83.png)

