### PR TITLE
Add Gtk4 and Libadwaita install infos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,22 +41,26 @@ update-alternatives --install /usr/share/gnome-shell/theme/gdm3.css gdm3.css /us
 
 If you reboot, select the Yaru session in GDM and you should be all right.
 
-### Help to install Gtk4
+### Help to install Gtk4 and Libadwaita
 
-If you want to test the Gtk4 theme, you need to compile Gtk from source (awaiting an official ubuntu packaging).
+If you want to test the Gtk4 theme, you need to install both Gtk4 and Libadwaita.
+
+#### Install Gtk4
+
+**Note:** If you don't want to install Gtk4 from source, just install `libgtk-4-dev` package (Ubuntu > 21.04 only).
 
 Firstly clone the repository:
-```bash
-git clone git@gitlab.gnome.org:GNOME/gtk.git
+```console
+git clone https://gitlab.gnome.org/GNOME/gtk.git
 ```
 
 Then, you need to install dependencies (please report if more ones are needed):
-```bash
-sudo apt install libgraphene-1.0-dev
+```console
+sudo apt install sassc clang libglib2.0-dev libcairo2-dev libpango1.0-dev libgdk-pixbuf-2.0-dev libepoxy-dev libxkbcommon-dev libgraphene-1.0-dev cmake libwayland-dev libxrandr-dev libxi-dev
 ```
 
 And finally compile using meson:
-```bash
+```console
 meson --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/x86_64-linux-gnu _build .
 cd _build
 ninja
@@ -64,6 +68,28 @@ sudo ninja install
 ```
 
 Now you can use the "gtk4-widget-factory" app.
+
+#### Install Libadwaita
+
+Firstly clone the repository:
+```console
+git clone https://gitlab.gnome.org/GNOME/libadwaita.git
+```
+
+Then, you need to install dependencies (please report if more ones are needed):
+```console
+sudo apt install sassc valac libglib2.0-dev
+```
+
+And finally compile using meson:
+```console
+meson --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/x86_64-linux-gnu _build .
+cd _build
+ninja
+sudo ninja install
+```
+
+Now you can use the "adwaita-1-demo" app.
 
 ### More granular changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ sudo apt install sassc clang libglib2.0-dev libcairo2-dev libpango1.0-dev libgdk
 
 And finally compile using meson:
 ```console
+cd gtk
 meson --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/x86_64-linux-gnu _build .
 cd _build
 ninja
@@ -83,6 +84,7 @@ sudo apt install sassc valac libglib2.0-dev
 
 And finally compile using meson:
 ```console
+cd libadwaita
 meson --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/x86_64-linux-gnu _build .
 cd _build
 ninja

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ ninja
 sudo ninja install
 ```
 
-Now you can use the "gtk4-widget-factory" app.
+Now you can use the `gtk4-widget-factory` app.
 
 #### Install Libadwaita
 
@@ -91,7 +91,13 @@ ninja
 sudo ninja install
 ```
 
-Now you can use the "adwaita-1-demo" app.
+Now you can run the `adwaita-1-demo` using the console:
+
+```console
+adwaita-1-demo
+```
+
+**Note:** regardless of your current gtk theme, `adwaita-1-demo` use **Adwaita** by default. You must switch to **Yaru** using the gtk inspector.
 
 ### More granular changes
 


### PR DESCRIPTION
After days and days of trying and searching, I found all dependencies of Gtk4 and Libadwaita 😅
So I updated `CONTRIBUTING.md` with these new information.

@Feichtmeier That could be great if you can try this.

Gtk4 dev deps:
```console
sudo apt install sassc clang libglib2.0-dev libcairo2-dev libpango1.0-dev libgdk-pixbuf-2.0-dev libepoxy-dev libxkbcommon-dev libgraphene-1.0-dev cmake libwayland-dev libxrandr-dev libxi-dev
```

Libadwaita dev deps:
```console
sudo apt install sassc valac libglib2.0-dev
```

Both use the same **meson/ninja** command to compile:
```console
meson --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/x86_64-linux-gnu _build .
cd _build
ninja
sudo ninja install
```