### PR TITLE
Use correct placeholder for workspace previews

### DIFF
--- a/gnome-shell/src/data/gnome-shell-theme.gresource.xml
+++ b/gnome-shell/src/data/gnome-shell-theme.gresource.xml
@@ -13,7 +13,7 @@
     <file>checkbox.svg</file>
     <file>checkbox-dark.svg</file>
     <file alias="icons/scalable/actions/color-pick.svg">color-pick.svg</file>
-    <file>dash-placeholder.svg</file>
+    <file>workspace-placeholder.svg</file>
     <file alias="icons/scalable/status/message-indicator-symbolic.svg">message-indicator-symbolic.svg</file>
     <file>no-events.svg</file>
     <file>no-notifications.svg</file>


### PR DESCRIPTION
![wsthumbs_new](https://user-images.githubusercontent.com/29968331/121068477-2d522980-c781-11eb-937a-bb675d4abe0b.png)

The upstream shell theme has a placeholder when dragging a window in-between two workspace previews. This is not the case on Yaru. This tiny change properly renders the workspace preview on Yaru shell.