### PR TITLE
Fix menus checks wiggling effect

### DIFF
--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -47,6 +47,14 @@ scale > trough > highlight {
     transition: $button_transition;
 }
 
+// Fix popover wiggling effect (see #2903)
+popover.menu {
+    check,
+    radio {
+        transition: none;
+    }
+}
+
 // Use our own palette for 
 levelbar {
     > trough {

--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -55,7 +55,7 @@ popover.menu {
     }
 }
 
-// Use our own palette for 
+// Use our own palette for high and not empty levelbar
 levelbar {
     > trough {
         > block {


### PR DESCRIPTION
Remove transition for check/radio inside popover menus to fix wiggling effect.

Closes #2903