### PR TITLE
Missing snapping icons for inkscape

### DIFF
--- a/icons/Suru/16x16/legacy/dialog-selectors.svg
+++ b/icons/Suru/16x16/legacy/dialog-selectors.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg1067"
+   sodipodi:docname="dialog-selectors.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata1073">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1071" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview1069"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="10.625"
+     inkscape:cy="8.9979948"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1067"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2642" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:0.6;vector-effect:none;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect2646-6"
+     width="12"
+     height="13"
+     x="2"
+     y="1"
+     ry="2"
+     rx="2" />
+  <rect
+     style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect2646"
+     width="12"
+     height="13"
+     x="2"
+     y="1"
+     ry="2"
+     rx="2" />
+  <path
+     style="opacity:1;vector-effect:none;fill:#a2bcfe;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 4 1 C 2.892 1 2 1.892 2 3 L 2 4 L 14 4 L 14 3 C 14 1.892 13.108 1 12 1 L 4 1 z "
+     id="rect2646-4" />
+  <path
+     style="fill:#4d4d4d;fill-opacity:1;stroke-width:4;stroke-linecap:round;stroke-linejoin:round"
+     d="M 6,5 C 5.446,5 5,5.446 5,6 V 7.472432 L 3.4700152,9 5,10.501673 V 12 c 0,0.554 0.446,1 1,1 H 7 V 12 H 6 V 10 L 5,9 6,8 V 6 H 7 V 5 Z"
+     id="rect865" />
+  <path
+     style="fill:#4d4d4d;fill-opacity:1;stroke-width:4;stroke-linecap:round;stroke-linejoin:round"
+     d="m 10,5 c 0.554,0 1,0.446 1,1 V 7.472432 L 12.529985,9 11,10.501673 V 12 c 0,0.554 -0.446,1 -1,1 H 9 v -1 h 1 V 10 L 11,9 10,8 V 6 H 9 V 5 Z"
+     id="rect865-3" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-bounding-box-center.svg
+++ b/icons/Suru/16x16/legacy/snap-bounding-box-center.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-bounding-box-center.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="true"
+     inkscape:zoom="15.999999"
+     inkscape:cx="9.7957758"
+     inkscape:cy="10.260733"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1716"
+     width="2"
+     height="1"
+     x="12"
+     y="13" />
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718"
+     width="1"
+     height="2"
+     x="13"
+     y="12" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5"
+     width="1"
+     height="2"
+     x="13"
+     y="9" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-3"
+     width="1"
+     height="2"
+     x="13"
+     y="6" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56"
+     width="1"
+     height="2"
+     x="13"
+     y="3" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56-2"
+     width="1"
+     height="2"
+     x="13"
+     y="0" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9"
+     width="1"
+     height="2"
+     x="-14"
+     y="9"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-1"
+     width="1"
+     height="2"
+     x="-14"
+     y="6"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-2"
+     width="1"
+     height="2"
+     x="-14"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-7"
+     width="1"
+     height="2"
+     x="-14"
+     y="0"
+     transform="rotate(-90)" />
+  <circle
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3130"
+     cx="4.5"
+     cy="4.5"
+     r="2.5" />
+  <circle
+     style="opacity:1;fill:#a6d74f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3132"
+     cx="4.5"
+     cy="4.5"
+     r="1.5" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-bounding-box-corners.svg
+++ b/icons/Suru/16x16/legacy/snap-bounding-box-corners.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-bounding-box-corners.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="false"
+     inkscape:zoom="0.99999996"
+     inkscape:cx="9.7957758"
+     inkscape:cy="10.260733"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1716"
+     width="2"
+     height="1"
+     x="12"
+     y="13" />
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718"
+     width="1"
+     height="2"
+     x="13"
+     y="12" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5"
+     width="1"
+     height="2"
+     x="13"
+     y="9" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-3"
+     width="1"
+     height="2"
+     x="13"
+     y="6" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56"
+     width="1"
+     height="2"
+     x="13"
+     y="3" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56-2"
+     width="1"
+     height="2"
+     x="13"
+     y="0" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9"
+     width="1"
+     height="2"
+     x="-14"
+     y="9"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-1"
+     width="1"
+     height="2"
+     x="-14"
+     y="6"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-2"
+     width="1"
+     height="2"
+     x="-14"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-7"
+     width="1"
+     height="2"
+     x="-14"
+     y="0"
+     transform="rotate(-90)" />
+  <path
+     id="rect950-6"
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="m 13,11 2,2 -2,2 -2,-2 z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect950"
+     style="fill:#80a3fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="m 13,11 2,2 -2,2 -2,-2 z"
+     sodipodi:nodetypes="ccccc" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-bounding-box-edges.svg
+++ b/icons/Suru/16x16/legacy/snap-bounding-box-edges.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-bounding-box-edges.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="false"
+     inkscape:zoom="1.4142135"
+     inkscape:cx="60.96989"
+     inkscape:cy="34.615878"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1716"
+     width="2"
+     height="1"
+     x="12"
+     y="13" />
+  <rect
+     style="opacity:1;fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718"
+     width="1"
+     height="2"
+     x="13"
+     y="12" />
+  <rect
+     style="fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5"
+     width="1"
+     height="2"
+     x="13"
+     y="9" />
+  <rect
+     style="fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-3"
+     width="1"
+     height="2"
+     x="13"
+     y="6" />
+  <rect
+     style="fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56"
+     width="1"
+     height="2"
+     x="13"
+     y="3" />
+  <rect
+     style="fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56-2"
+     width="1"
+     height="2"
+     x="13"
+     y="0" />
+  <rect
+     style="fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9"
+     width="1"
+     height="2"
+     x="-14"
+     y="9"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-1"
+     width="1"
+     height="2"
+     x="-14"
+     y="6"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-2"
+     width="1"
+     height="2"
+     x="-14"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-7"
+     width="1"
+     height="2"
+     x="-14"
+     y="0"
+     transform="rotate(-90)" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-bounding-box-midpoints.svg
+++ b/icons/Suru/16x16/legacy/snap-bounding-box-midpoints.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-bounding-box-midpoints.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="true"
+     inkscape:zoom="15.999999"
+     inkscape:cx="9.7957758"
+     inkscape:cy="10.260733"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1716"
+     width="2"
+     height="1"
+     x="12"
+     y="13" />
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718"
+     width="1"
+     height="2"
+     x="13"
+     y="12" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5"
+     width="1"
+     height="2"
+     x="13"
+     y="9" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-3"
+     width="1"
+     height="2"
+     x="13"
+     y="6" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56"
+     width="1"
+     height="2"
+     x="13"
+     y="3" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56-2"
+     width="1"
+     height="2"
+     x="13"
+     y="0" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9"
+     width="1"
+     height="2"
+     x="-14"
+     y="9"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-1"
+     width="1"
+     height="2"
+     x="-14"
+     y="6"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-2"
+     width="1"
+     height="2"
+     x="-14"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-7"
+     width="1"
+     height="2"
+     x="-14"
+     y="0"
+     transform="rotate(-90)" />
+  <circle
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3130"
+     cx="13.5"
+     cy="4.5"
+     r="2.5" />
+  <circle
+     style="opacity:1;fill:#80a3fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3132"
+     cx="13.5"
+     cy="4.5"
+     r="1.5" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-bounding-box.svg
+++ b/icons/Suru/16x16/legacy/snap-bounding-box.svg
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-bounding-box.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="false"
+     inkscape:zoom="7.9999997"
+     inkscape:cx="9.7957758"
+     inkscape:cy="10.260733"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1716"
+     width="2"
+     height="1"
+     x="-3.9999585"
+     y="-2.9999585"
+     transform="scale(-1)" />
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718"
+     width="1"
+     height="2"
+     x="-2.9999585"
+     y="-3.9999585"
+     transform="scale(-1)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5"
+     width="1"
+     height="2"
+     x="-2.9999585"
+     y="-6.9999585"
+     transform="scale(-1)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-3"
+     width="1"
+     height="2"
+     x="-2.9999585"
+     y="-9.999959"
+     transform="scale(-1)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56"
+     width="1"
+     height="2"
+     x="-2.9999585"
+     y="-12.999959"
+     transform="scale(-1)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56-2"
+     width="1"
+     height="2"
+     x="-2.9999585"
+     y="-15.999959"
+     transform="scale(-1)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9"
+     width="1"
+     height="2"
+     x="1.9999586"
+     y="-6.9999585"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-1"
+     width="1"
+     height="2"
+     x="1.9999586"
+     y="-9.999959"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-2"
+     width="1"
+     height="2"
+     x="1.9999586"
+     y="-12.999959"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-7"
+     width="1"
+     height="2"
+     x="1.9999586"
+     y="-15.999959"
+     transform="rotate(90)" />
+  <path
+     id="rect950-6"
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="m 2.9999586,4.9999586 -2.00000001,-2 2.00000001,-2.00000001 2,2.00000001 z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect950"
+     style="fill:#80a3fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="m 2.9999586,4.9999586 -2.00000001,-2 2.00000001,-2.00000001 2,2.00000001 z"
+     sodipodi:nodetypes="ccccc" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-grid-guide-intersections.svg
+++ b/icons/Suru/16x16/legacy/snap-grid-guide-intersections.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-grid-guide-intersections.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="false"
+     inkscape:zoom="1.9999999"
+     inkscape:cx="-18.468938"
+     inkscape:cy="120.57292"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <path
+     style="fill:none;stroke:#2daaaa;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 0,7.40625 16,7.487"
+     id="path4380"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#2daaaa;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 4,15.40625 12,0.4870606"
+     id="path4380-3"
+     sodipodi:nodetypes="cc" />
+  <circle
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3130"
+     cx="8.5"
+     cy="7.5"
+     r="2.5" />
+  <circle
+     style="fill:#a6d74f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3132"
+     cx="8.5"
+     cy="7.5"
+     r="1.5" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-nodes-center.svg
+++ b/icons/Suru/16x16/legacy/snap-nodes-center.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-nodes-center.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="true"
+     inkscape:zoom="15.999999"
+     inkscape:cx="9.7957758"
+     inkscape:cy="10.260733"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1716"
+     width="14"
+     height="1"
+     x="0"
+     y="13" />
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718"
+     width="1"
+     height="14"
+     x="13"
+     y="0" />
+  <circle
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3130"
+     cx="4.5"
+     cy="4.5"
+     r="2.5" />
+  <circle
+     style="opacity:1;fill:#a6d74f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3132"
+     cx="4.5"
+     cy="4.5"
+     r="1.5" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-nodes-cusp.svg
+++ b/icons/Suru/16x16/legacy/snap-nodes-cusp.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-nodes-cusp.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="true"
+     inkscape:zoom="15.999999"
+     inkscape:cx="13.157388"
+     inkscape:cy="8.4244706"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <path
+     style="fill:none;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1.0232162,0.49946072 C 1.0232162,0.49946072 12,0 7.4441993,10.467696 3.0653534,20.52881 14.598619,7.5283038 14.598619,7.5283038"
+     id="path4380"
+     sodipodi:nodetypes="csc" />
+  <circle
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3130"
+     cx="6.5"
+     cy="13.5"
+     r="2.5" />
+  <circle
+     style="fill:#a6d74f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3132"
+     cx="6.5"
+     cy="13.5"
+     r="1.5" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-nodes-intersection.svg
+++ b/icons/Suru/16x16/legacy/snap-nodes-intersection.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-nodes-intersection.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="false"
+     inkscape:zoom="15.999999"
+     inkscape:cx="7.6638766"
+     inkscape:cy="8.4244706"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <path
+     style="fill:none;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 0,9.40625 16,6.4870606"
+     id="path4380"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 0,13.40625 16,2.4870606"
+     id="path4380-3"
+     sodipodi:nodetypes="cc" />
+  <circle
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3130"
+     cx="8.5"
+     cy="7.5"
+     r="2.5" />
+  <circle
+     style="fill:#a6d74f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3132"
+     cx="8.5"
+     cy="7.5"
+     r="1.5" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-nodes-midpoint.svg
+++ b/icons/Suru/16x16/legacy/snap-nodes-midpoint.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-nodes-midpoint.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="true"
+     inkscape:zoom="0.99999994"
+     inkscape:cx="4.1654815"
+     inkscape:cy="12.416006"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <path
+     style="fill:none;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 0.5,14.5 14,-14"
+     id="path4380-3"
+     sodipodi:nodetypes="cc" />
+  <circle
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3130"
+     cx="7.5"
+     cy="7.5"
+     r="2.5" />
+  <circle
+     style="fill:#a6d74f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="path3132"
+     cx="7.5"
+     cy="7.5"
+     r="1.5" />
+  <path
+     id="rect3451"
+     style="opacity:1;fill:#f22c42;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     d="M 10,2 V 5 H 10.394531 11 13 V 4 H 11 V 2 Z"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     id="rect3451-3"
+     style="fill:#f22c42;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     d="M 5,13 V 10 H 4.605469 4 2 v 1 h 2 v 2 z"
+     sodipodi:nodetypes="ccccccccc" />
+  <rect
+     style="opacity:1;fill:#f22c42;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3476"
+     width="1"
+     height="1"
+     x="12"
+     y="2" />
+  <rect
+     style="fill:#f22c42;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3476-5"
+     width="1"
+     height="1"
+     x="14"
+     y="0" />
+  <rect
+     style="fill:#f22c42;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3476-6"
+     width="1"
+     height="1"
+     x="2"
+     y="12" />
+  <rect
+     style="fill:#f22c42;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3476-2"
+     width="1"
+     height="1"
+     x="0"
+     y="14" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-nodes-path.svg
+++ b/icons/Suru/16x16/legacy/snap-nodes-path.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-nodes-path.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="true"
+     inkscape:zoom="15.999999"
+     inkscape:cx="13.157388"
+     inkscape:cy="8.4244706"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <path
+     style="fill:none;stroke:#46a926;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1.0232162,0.49946072 C 1.0232162,0.49946072 12,0 7.4441993,10.467696 3.0653534,20.52881 14.598619,7.5283038 14.598619,7.5283038"
+     id="path4380"
+     sodipodi:nodetypes="csc" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-nodes-rotation-center.svg
+++ b/icons/Suru/16x16/legacy/snap-nodes-rotation-center.svg
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-nodes-rotation-center.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="true"
+     inkscape:zoom="15.999999"
+     inkscape:cx="9.7957758"
+     inkscape:cy="10.260733"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1716"
+     width="2"
+     height="1"
+     x="12"
+     y="13" />
+  <rect
+     style="opacity:1;fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718"
+     width="1"
+     height="2"
+     x="13"
+     y="12" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5"
+     width="1"
+     height="2"
+     x="13"
+     y="9" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-3"
+     width="1"
+     height="2"
+     x="13"
+     y="6" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56"
+     width="1"
+     height="2"
+     x="13"
+     y="3" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-56-2"
+     width="1"
+     height="2"
+     x="13"
+     y="0" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9"
+     width="1"
+     height="2"
+     x="-14"
+     y="9"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-1"
+     width="1"
+     height="2"
+     x="-14"
+     y="6"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-2"
+     width="1"
+     height="2"
+     x="-14"
+     y="3"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     id="rect1718-5-9-7"
+     width="1"
+     height="2"
+     x="-14"
+     y="0"
+     transform="rotate(-90)" />
+  <rect
+     style="fill:#808080;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect4145"
+     width="1"
+     height="3"
+     x="4"
+     y="5" />
+  <rect
+     style="fill:#808080;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect4145-9"
+     width="1"
+     height="3"
+     x="4"
+     y="1" />
+  <rect
+     style="fill:#808080;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect4145-1"
+     width="1"
+     height="3"
+     x="4"
+     y="-4"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#808080;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect4145-9-2"
+     width="1"
+     height="3"
+     x="4"
+     y="-8"
+     transform="rotate(90)" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-nodes-smooth.svg
+++ b/icons/Suru/16x16/legacy/snap-nodes-smooth.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap-nodes-smooth.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="true"
+     inkscape:zoom="15.999999"
+     inkscape:cx="13.157388"
+     inkscape:cy="8.4244706"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <path
+     style="fill:none;stroke:#808080;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1.0232162,0.49946072 C 1.0232162,0.49946072 12,0 7.4441993,10.467696 3.0653534,20.52881 14.598619,7.5283038 14.598619,7.5283038"
+     id="path4380"
+     sodipodi:nodetypes="csc" />
+  <rect
+     style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect2100"
+     width="5"
+     height="5"
+     x="6"
+     y="2"
+     rx="1"
+     ry="1" />
+  <rect
+     style="fill:#80a3fa;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round"
+     id="rect2098"
+     width="3"
+     height="3"
+     x="7"
+     y="3" />
+</svg>

--- a/icons/Suru/16x16/legacy/snap-nodes.svg
+++ b/icons/Suru/16x16/legacy/snap-nodes.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://web.resource.org/cc/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg1"
+   width="16"
+   height="16.00057"
+  >
+  <sodipodi:namedview
+     id="base"
+     showgrid="true"
+     gridspacingy="1pt"
+     gridspacingx="1pt"
+     gridoriginy="0pt"
+     gridoriginx="0pt"
+  />
+  <defs id="defs3">
+
+  </defs>
+<g id="snap-nodes" inkscape:label="#toggle_snap_nodes" transform="translate(-692,-30.00057)">
+  <rect height="16" id="rect5385-6-7" style="color:#000000;fill:none;stroke-width:0.1" width="16" x="692" y="30.00057"/>
+  <rect height="16" id="rect5385-6-0-8" style="color:#000000;fill:none;stroke-width:0.1" width="16" x="692" y="30.00114"/>
+  <path d="M 693,38 C 693,38 693,33 700,33 696,38 697.75,41 700.5,42.75 703.25,44.5 707,45 707,45" id="path6308" inkscape:connector-curvature="0" sodipodi:nodetypes="ccsc" style="color:#000000;fill:none;stroke:#646464;stroke-width:1.0000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0"/>
+  <rect height="3.621212" id="rect3224-2-9" style="color:#000000;fill:#6464ff;fill-opacity:0.3921569;fill-rule:evenodd;stroke:#0000ff;stroke-width:0.9051017;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0" transform="rotate(-45)" width="3.584063" x="469.8239" y="516.5415"/>
+</g>
+
+</svg>

--- a/icons/Suru/16x16/legacy/snap-others.svg
+++ b/icons/Suru/16x16/legacy/snap-others.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://web.resource.org/cc/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg1"
+   width="15.504883"
+   height="16.1231"
+  >
+  <sodipodi:namedview
+     id="base"
+     showgrid="true"
+     gridspacingy="1pt"
+     gridspacingx="1pt"
+     gridoriginy="0pt"
+     gridoriginx="0pt"
+  />
+  <defs id="defs3">
+
+  </defs>
+<g id="snap-others" inkscape:label="#toggle_snap_others" transform="translate(-932.49512,-29.6269)">
+  <path d="M 935,31.25 935,39.75" id="path3570-5" inkscape:connector-curvature="0" sodipodi:nodetypes="cc" style="fill:none;stroke:#3c3c3c;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"/>
+  <rect height="4.01786" id="rect3568-1" style="color:#000000;fill:#ffffff;fill-rule:evenodd;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:0" width="4.0099" x="932.9951" y="30.1269"/>
+  <path d="M 939,39 945,30" id="path6498-1-8" inkscape:connector-curvature="0" sodipodi:nodetypes="cc" style="color:#000000;fill:#c00000;stroke:#0065ff;stroke-width:1px"/>
+  <circle cx="753.5" cy="33" id="path6530-3-7-6" r="2" style="color:#000000;fill:#6464ff;fill-opacity:0.3921569;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.1428572;stroke-linecap:round" transform="matrix(0.8749999,0,0,0.875,282.6876,5.625)"/>
+  <g id="g13570" transform="translate(1.5,0.5)">
+    <path d="M 943,37.5 943,40.5" id="path6380-5" inkscape:connector-curvature="0" style="color:#000000;fill:#000000;stroke:#000000;stroke-width:1px"/>
+    <path d="M 943,41.5 943,44.5" id="path6380-4-1" inkscape:connector-curvature="0" style="color:#000000;fill:#000000;stroke:#000000;stroke-width:1px"/>
+    <path d="M 939.5,41 942.5,41" id="path6380-8-4" inkscape:connector-curvature="0" style="color:#000000;fill:#000000;stroke:#000000;stroke-width:1px"/>
+    <path d="M 943.5,41 946.5,41" id="path6380-4-0-5" inkscape:connector-curvature="0" style="color:#000000;fill:#000000;stroke:#000000;stroke-width:1px"/>
+  </g>
+  <circle cx="753.5" cy="33" id="path6530-3-7-6-0" r="2" style="color:#000000;fill:#6464ff;fill-opacity:0.3921569;fill-rule:evenodd;stroke:#0000ff;stroke-width:1.1428572;stroke-linecap:round" transform="matrix(0.8749999,0,0,0.875,277.1876,14.625)"/>
+</g>
+
+</svg>

--- a/icons/Suru/16x16/legacy/snap.svg
+++ b/icons/Suru/16x16/legacy/snap.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2041"
+   sodipodi:docname="snap.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata2047">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2045" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview2043"
+     showgrid="false"
+     inkscape:zoom="0.99999996"
+     inkscape:cx="84.532848"
+     inkscape:cy="-41.010556"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2041"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2676" />
+  </sodipodi:namedview>
+  <path
+     id="rect950-6"
+     style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;opacity:0.6"
+     d="M 3,1 5,3 3,5 1,3 Z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect950-3-7"
+     style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;opacity:0.6"
+     d="m 13,11 2,2 -2,2 -2,-2 z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect950"
+     style="opacity:1;fill:#80a3fa;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;fill-opacity:1"
+     d="M 3,1 5,3 3,5 1,3 Z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect950-3"
+     style="opacity:1;fill:#a6d74f;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;fill-opacity:1"
+     d="m 13,11 2,2 -2,2 -2,-2 z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect997"
+     style="opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="M 5.1,5.9 5.9,5.1 10,9.2 V 7 h 1 v 4 H 7 v -1 h 2.2 z"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/icons/Suru/16x16/legacy/zoom-center-page.svg
+++ b/icons/Suru/16x16/legacy/zoom-center-page.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg1067"
+   sodipodi:docname="zoom-center-page.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata1073">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1071" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     id="namedview1069"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="13.234049"
+     inkscape:cy="8.5409884"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1067"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2642" />
+  </sodipodi:namedview>
+  <rect
+     style="opacity:0.6;vector-effect:none;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect2646-6"
+     width="12"
+     height="14"
+     x="-14"
+     y="1"
+     ry="1"
+     rx="1"
+     transform="rotate(-90)" />
+  <rect
+     style="opacity:1;vector-effect:none;fill:#f2f2f2;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect2646"
+     width="12"
+     height="14"
+     x="-14"
+     y="1"
+     ry="1"
+     rx="1"
+     transform="rotate(-90)" />
+  <rect
+     style="opacity:0.6;fill:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round"
+     id="rect973"
+     width="8"
+     height="10"
+     x="4"
+     y="3"
+     rx="1"
+     ry="1" />
+  <rect
+     style="opacity:1;fill:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:round"
+     id="rect975"
+     width="6"
+     height="8"
+     x="5"
+     y="4" />
+  <rect
+     style="vector-effect:none;fill:#a7a7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect912"
+     width="4"
+     height="1"
+     x="6"
+     y="5" />
+  <rect
+     style="vector-effect:none;fill:#a7a7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect914"
+     width="4"
+     height="1"
+     x="6"
+     y="7" />
+  <rect
+     style="vector-effect:none;fill:#a7a7f1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect914-3"
+     width="3"
+     height="1"
+     x="6"
+     y="9" />
+</svg>


### PR DESCRIPTION
Closes #2895 

![image](https://user-images.githubusercontent.com/38893390/121806266-14e18380-cc47-11eb-9966-8489c5276363.png)

And while I'm doing missing icons, I added one for the selectors dialog:

![image](https://user-images.githubusercontent.com/38893390/121806256-0abf8500-cc47-11eb-9488-a8fa1d68efc4.png)

