### PR TITLE
Drop GDM purple background

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_screen-shield.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_screen-shield.scss
@@ -66,7 +66,7 @@
 }
 
 #lockDialogGroup {
-  background-color: darken($purple, 10%); // Yaru: purple login screen
+  background-color: $system_bg_color;
 }
 
 #unlockDialogNotifications {


### PR DESCRIPTION
Revert GDM background to upstream (`$system_bg_color` - same as overview) to avoid jarring transition **purple** -> **grey**.

This is just for testing and get opinions, because I can't take screenshot.

Closes #2908 