### PR TITLE
update debian/yaru-theme-gtk.install

### DIFF
--- a/debian/yaru-theme-gtk.install
+++ b/debian/yaru-theme-gtk.install
@@ -11,9 +11,3 @@ usr/share/themes/Yaru-dark/gtk-3.20/
 usr/share/themes/Yaru-dark/gtk-4.0/
 usr/share/themes/Yaru-dark/metacity-1
 usr/share/themes/Yaru-dark/index.theme
-usr/share/themes/Yaru-light/gtk-2.0/
-usr/share/themes/Yaru-light/gtk-3.0/
-usr/share/themes/Yaru-light/gtk-3.20/
-usr/share/themes/Yaru-light/gtk-4.0/
-usr/share/themes/Yaru-light/metacity-1
-usr/share/themes/Yaru-light/index.theme


### PR DESCRIPTION
Hi,

This PR reflects the removal of Standard -theme and removes all **_Yaru-light_** entries under `debian/yaru-theme-gtk.install`