### PR TITLE
Fix dock and panel look

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -51,7 +51,7 @@ $base_active_color: transparentize(white, 0.75);
 $hover_fg_color: lighten($selected_fg_color, .25);
 $active_fg_color: transparentize($selected_fg_color, .5);
 
-$panel_bg_color: lighten($jet, 2%);
+$panel_bg_color: darken($jet, 2%);
 $panel_fg_color: darken($porcelain, 2%);
 $dash_background_color: $panel_bg_color;
 $panel-alpha-value: 0.6;

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -287,7 +287,7 @@ $osd_fg_color: #eeeeec;
             // without "border: none", there is a 1px gap between windows and the dock
             border: none !important;
             box-shadow: inset 0 1px 2px -1px rgba(0, 0, 0, 0.4) !important;
-            background: $dash_background_color;
+            background: transparent; // Will render half dark transparent - we need to understand why
 
             @if $side == left or $side == right {
                 // don't let the first icon be too close to the shadow + panel

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -16,8 +16,8 @@ $panel_transition_duration: 250ms; // same as the overview transition duration
 
   // transparent panel on lock & login screens
   &.unlock-screen,
-  &.login-screen,
-  &:overview {
+  &.login-screen {
+  // &:overview { Yaru change: static background into overview
     background-color: transparent;
 
     .panel-corner {


### PR DESCRIPTION
- Make panel background static into the overview ;
- Use a 2% darken `jet` as panel background ;
- Define dock background as transparent (will render half dark transparent, we need to understand why).

![VirtualBox_Ubuntu 21 10_11_07_2021_17_15_20](https://user-images.githubusercontent.com/36476595/125201195-4d887300-e26e-11eb-8160-a7f19ac4a95f.png)
![VirtualBox_Ubuntu 21 10_11_07_2021_17_15_49](https://user-images.githubusercontent.com/36476595/125201203-52e5bd80-e26e-11eb-8c52-359c1999a715.png)
