### PR TITLE
Revert to lighten dash background

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -53,7 +53,7 @@ $active_fg_color: transparentize($selected_fg_color, .5);
 
 $panel_bg_color: darken($jet, 2%);
 $panel_fg_color: darken($porcelain, 2%);
-$dash_background_color: $panel_bg_color;
+$dash_background_color: lighten($jet, 2%);
 $panel-alpha-value: 0.6;
 $panel_opaque_value: 0.0;
 


### PR DESCRIPTION
Caused by #2948

I didn't noticed that the dash (not the dock) background was based on top panel background var. Into #2948, I've darkened the panel bg. As many components (search entry, search results, app folder, ...) are based on dash bg, it result a too much darker look everywhere.

So this PR revert `$dash_background_color` to old `$panel_bg_color` value: `lighten($jet, 2%)`.