### PR TITLE
Improve selected row look

### DIFF
--- a/gtk/src/default/gtk-3.20/_common.scss
+++ b/gtk/src/default/gtk-3.20/_common.scss
@@ -1969,19 +1969,19 @@ treeview.view {
       @extend %selected_items;
     }
 
-    &:backdrop, & {
+    /*&:backdrop, & {  // Yaru change: due to grey row selection background we no more need to modify border-color
       border-left-color: mix($selected_fg_color, $selected_bg_color, 50%);
       border-top-color: transparentize($fg_color, 0.9); // doesn't work unfortunatelly
-    }
+    }*/
   }
 
   &:disabled {
     color: $insensitive_fg_color;
 
-    &:selected {
+    /*&:selected {
       color: mix($selected_fg_color, $selected_bg_color, 40%);
       &:backdrop { color: mix($backdrop_selected_fg_color, $selected_bg_color, 30%); }
-    }
+    }*/
 
     &:backdrop { color: $backdrop_insensitive_color; }
   }
@@ -2016,13 +2016,13 @@ treeview.view {
 
     &:hover { color: $text_color; }
 
-    &:selected {
+    /*&:selected { // Yaru change: due to grey row selection background we no more need to modify expander icon color
       color: mix($selected_fg_color, $selected_bg_color, 70%);
 
       &:hover { color: $selected_fg_color; }
 
       &:backdrop { color: mix($backdrop_selected_fg_color, $selected_bg_color, 70%); }
-    }
+    }*/
 
     &:checked { -gtk-icon-source: -gtk-icontheme('pan-down-symbolic'); }
 
@@ -2036,7 +2036,7 @@ treeview.view {
     background-image: image($progress_bg_color);
     box-shadow: none;
 
-    &:selected {
+    /*&:selected { // Yaru change: due to grey row selection background we no more need to modify selected look
       &:focus, & {
 
         @if $variant == 'light' {
@@ -2055,7 +2055,7 @@ treeview.view {
           background-color: $backdrop_base_color;
         }
       }
-    }
+    }*/
 
     &:backdrop {
       @if $variant == 'light' { color: $backdrop_base_color; }
@@ -2069,14 +2069,14 @@ treeview.view {
   &.trough { // progress bar trough in treeviews
     background-color: transparentize($fg_color,0.9);
 
-    &:selected {
+    /*&:selected { // Yaru change: due to grey row selection background we no more need to modify selected look
       &:focus, & {
         background-color: if($variant == 'light',
                              transparentize($selected_fg_color, 0.7),
                              darken($selected_bg_color, 10%));
 
       }
-    }
+    }*/
   }
 
   header {
@@ -3103,7 +3103,7 @@ menu menuitem {
   }
 }
 
-treeview.view check,
+/*treeview.view check, // Yaru change: due to grey row selection background we no more need to modify selected look
 treeview.view radio {
   &:selected {
     &:focus, & {
@@ -3114,7 +3114,7 @@ treeview.view radio {
   }
 }
 
-treeview.view radio:selected { &:focus, & { @extend %radio; }} // This is a workaround
+treeview.view radio:selected { &:focus, & { @extend %radio; }} // This is a workaround */
 
 
 /************

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -402,10 +402,16 @@ list row, placessidebar row, sidebar row, .sidebar row {
   }
 }
 
-.nautilus-window .sidebar row:selected {
-  background: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
+.nautilus-window .sidebar row {
+  &:selected {
+    &.activatable, & {
+      &, &:hover {
+        background: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
 
-  &:backdrop {
-    background: linear-gradient(to right, $selected_bg_color 4px, $_backdrop_selection_bg 1px );
+        &:backdrop {
+          background: linear-gradient(to right, $selected_bg_color 4px, $_backdrop_selection_bg 1px );
+        }
+      }
+    }
   }
 }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -390,7 +390,7 @@ list row, placessidebar row, sidebar row, .sidebar row {
       &, &:hover {
         background: $_selection_bg;
         &, button, button image { color: $text_color; }
-        button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image {color: white; } } }
+        button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
 
         &:backdrop {
           &, button, button image { color: $backdrop_fg_color; }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -380,25 +380,32 @@ switch {
 
 // Due to the ubuntu orange beeing quiet bright
 // we change the sidebar selection from a full orange
-// row to a thin orange stripe plus a soft gray selection
-$_selection_bg: if($variant=='light', darken($bg_color, 5%), lighten($base_color, 5%));
+// row to a soft gray selection (plus a thin orange stripe on nautilus)
+$_selection_bg: if($variant=='light', darken($bg_color, 7%), lighten($base_color, 7%));
+$_backdrop_selection_bg: if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%));
+
 list row, placessidebar row, sidebar row, .sidebar row {
   &:selected {
     &.activatable, & {
       &, &:hover {
-        background: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
+        background: $_selection_bg;
         &, button, button image { color: $text_color; }
-        button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
+        button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image {color: white; } } }
+
         &:backdrop {
           &, button, button image { color: $backdrop_fg_color; }
           button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
-          background: linear-gradient(
-            to right,
-            $selected_bg_color 4px,
-            if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%)) 1px
-          );
+          background: $_backdrop_selection_bg;
         }    
       }
     }
+  }
+}
+
+.nautilus-window .sidebar row:selected {
+  background: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
+
+  &:backdrop {
+    background: linear-gradient(to right, $selected_bg_color 4px, $_backdrop_selection_bg 1px );
   }
 }

--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -268,10 +268,6 @@ treeview.view radio {
 
 .sidebar { background-color: $bg_color; }
 
-// Treeview items misses a hover, port to upstream
-
-treeview:hover { background: $popover_hover_color; }
-
 scale {
   slider {
     .osd & {
@@ -379,38 +375,36 @@ switch {
 }
 
 // Due to the ubuntu orange beeing quiet bright
-// we change the sidebar selection from a full orange
-// row to a soft gray selection (plus a thin orange stripe on nautilus)
-$_selection_bg: if($variant=='light', darken($bg_color, 7%), lighten($base_color, 7%));
-$_backdrop_selection_bg: if($variant=='light', $_selection_bg, lighten($_selection_bg, 2%));
+// we change the row selection from a full orange
+// row to a soft gray selection
+$_row_hover_bg: if($variant=='light', transparentize(black, 0.96), transparentize(white, 0.96));
+$_row_selection_bg: if($variant=='light', transparentize(black, 0.91), transparentize(white, 0.91));
+$_backdrop_row_selection_bg: if($variant=='light', $_row_selection_bg, lighten($_row_selection_bg, 2%));
 
-list row, placessidebar row, sidebar row, .sidebar row {
-  &:selected {
-    &.activatable, & {
-      &, &:hover {
-        background: $_selection_bg;
-        &, button, button image { color: $text_color; }
-        button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
-
-        &:backdrop {
-          &, button, button image { color: $backdrop_fg_color; }
-          button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
-          background: $_backdrop_selection_bg;
-        }    
-      }
-    }
+list row, placessidebar row, sidebar row, .sidebar row, treeview.view {
+  &:hover:not(:backdrop):not(:selected) {
+    background: $_row_hover_bg;
   }
-}
 
-.nautilus-window .sidebar row {
   &:selected {
     &.activatable, & {
-      &, &:hover {
-        background: linear-gradient(to right, $selected_bg_color 4px, $_selection_bg 1px);
+      &:focus, &:disabled, & {
+        background: $_row_selection_bg;
+      }
 
-        &:backdrop {
-          background: linear-gradient(to right, $selected_bg_color 4px, $_backdrop_selection_bg 1px );
-        }
+      &:disabled {
+        &, button, button image { color: $insensitive_fg_color; }
+      }
+
+      &:focus, & {
+        &, button, button image { color: $text_color; }
+        button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }  
+      }
+
+      &:backdrop {
+        &, button, button image { color: $backdrop_fg_color; }
+        button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
+        background: $_backdrop_row_selection_bg;
       }
     }
   }


### PR DESCRIPTION
Improve selected row look:

- Remove the little orange left stripe (except on Nautilus sidebar) ;
- Increase bg contrast.

![Capture d’écran du 2021-07-20 19-42-49](https://user-images.githubusercontent.com/36476595/126370733-68cd332c-906b-4da6-9149-47cd054a016c.png)

![Capture d’écran du 2021-07-20 19-43-18](https://user-images.githubusercontent.com/36476595/126370793-f1f65450-9fd7-45ad-9427-fa39cfdef75d.png)

Closes #2954 