### PR TITLE
Add symlinked rtl variants for show-sidebar

### DIFF
--- a/icons/Suru/scalable/actions/sidebar-show-right-rtl-symbolic.svg
+++ b/icons/Suru/scalable/actions/sidebar-show-right-rtl-symbolic.svg
@@ -1,0 +1,1 @@
+sidebar-show-symbolic.svg

--- a/icons/Suru/scalable/actions/sidebar-show-rtl-symbolic.svg
+++ b/icons/Suru/scalable/actions/sidebar-show-rtl-symbolic.svg
@@ -1,0 +1,1 @@
+sidebar-show-right-symbolic.svg

--- a/icons/src/symlinks/symbolic/actions.list
+++ b/icons/src/symlinks/symbolic/actions.list
@@ -44,6 +44,8 @@ pan-end-symbolic.svg pan-start-symbolic-rtl.svg
 pan-start-symbolic.svg pan-end-symbolic-rtl.svg
 selection-end-symbolic.svg selection-start-symbolic-rtl.svg
 selection-start-symbolic.svg selection-end-symbolic-rtl.svg
+sidebar-show-right-symbolic.svg sidebar-show-rtl-symbolic.svg
+sidebar-show-symbolic.svg sidebar-show-right-rtl-symbolic.svg
 system-reboot-symbolic.svg system-restart-symbolic.svg
 view-layout-symbolic.svg view-reveal-symbolic.svg
 view-list-symbolic.svg view-list-bullet-symbolic.svg


### PR DESCRIPTION
Add symlinked rtl variants for `show-sidebar` symbolic icons.

See: https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/commit/33ebc3988db722775830ff7676b7798e4830ade2