### PR TITLE
Fix search entry margin-top

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
@@ -11,7 +11,7 @@ $search_entry_height: 36px;
   color: transparentize($fg_color,0.3);
   background-color: if($variant == 'light', $bg_color, $dash_background_color); // Yaru: use same background as dash for dark theme
   border-color: $borders_color;
-  margin-top: $base_spacing * 4;
+  margin-top: $base_spacing * 4; // Yaru change: increase margin-top due to fixed panel opacity
   margin-bottom: $base_spacing;
 
   &:hover {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
@@ -11,7 +11,7 @@ $search_entry_height: 36px;
   color: transparentize($fg_color,0.3);
   background-color: if($variant == 'light', $bg_color, $dash_background_color); // Yaru: use same background as dash for dark theme
   border-color: $borders_color;
-  margin-top: $base_spacing * 2;
+  margin-top: $base_spacing * 4;
   margin-bottom: $base_spacing;
 
   &:hover {


### PR DESCRIPTION
Due to fixed panel opacity, the search entry looks too close from it.

**Before:**

![Capture d’écran de 2021-07-27 16-55-03](https://user-images.githubusercontent.com/36476595/127178491-9c448a8b-b0de-4f0d-9e89-673a51396d5d.png)

**After:**

![Capture d’écran de 2021-07-27 16-54-41](https://user-images.githubusercontent.com/36476595/127178535-5917657a-4c6a-4af0-b563-392144494374.png)
