### PR TITLE
Fix gnome terminal notebook header bg

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -223,6 +223,11 @@ terminal-window {
     }
 
     notebook {
+        // Fix bugged transparent headerbar background
+        > header {
+          &, &:backdrop { background: $bg_color; }
+        }
+
         scrollbar {
             // inherits from scrollbar
             background-color: transparent;


### PR DESCRIPTION
As gnome-terminal (3.36) doesn't support transparent notebook background, I just re-overwritten it to use `$bg_color`.
So it isn't transparent, but it looks just like if it was. To avoid any cascading effect I only targeted `gnome-terminal`

Closes #2481

@Feichtmeier This PR will be merged to `ubuntu/focal` but I have no idea of how make a patch to yaru deb package. Can you help me?