### PR TITLE
update debian/yaru-theme-icon.install

### DIFF
--- a/debian/yaru-theme-icon.install
+++ b/debian/yaru-theme-icon.install
@@ -17,7 +17,9 @@ usr/share/icons/Yaru/16x16@2x/emblems
 usr/share/icons/Yaru/16x16@2x/mimetypes
 usr/share/icons/Yaru/16x16@2x/places
 usr/share/icons/Yaru/16x16@2x/status
+usr/share/icons/Yaru/22x22/actions
 usr/share/icons/Yaru/22x22/legacy
+usr/share/icons/Yaru/22x22@2x/actions
 usr/share/icons/Yaru/24x24/actions
 usr/share/icons/Yaru/24x24/apps
 usr/share/icons/Yaru/24x24/categories
@@ -40,7 +42,6 @@ usr/share/icons/Yaru/32x32/apps
 usr/share/icons/Yaru/32x32/categories
 usr/share/icons/Yaru/32x32/devices
 usr/share/icons/Yaru/32x32/emblems
-usr/share/icons/Yaru/32x32/legacy
 usr/share/icons/Yaru/32x32/mimetypes
 usr/share/icons/Yaru/32x32/places
 usr/share/icons/Yaru/32x32/status
@@ -69,8 +70,6 @@ usr/share/icons/Yaru/48x48@2x/emblems
 usr/share/icons/Yaru/48x48@2x/mimetypes
 usr/share/icons/Yaru/48x48@2x/places
 usr/share/icons/Yaru/48x48@2x/status
-usr/share/icons/Yaru/64x64/legacy
-usr/share/icons/Yaru/128x128/legacy
 usr/share/icons/Yaru/256x256/actions
 usr/share/icons/Yaru/256x256/apps
 usr/share/icons/Yaru/256x256/categories


### PR DESCRIPTION
- updated `yaru-theme-icon.install` since #2673 is merged as it is necessary for building the `yaru-theme-icon.deb`