### PR TITLE
symlink for multitasking-panel

### DIFF
--- a/icons/Suru/scalable/apps/org.gnome.Settings-multitasking-symbolic.svg
+++ b/icons/Suru/scalable/apps/org.gnome.Settings-multitasking-symbolic.svg
@@ -1,0 +1,1 @@
+session-properties-symbolic.svg

--- a/icons/src/scalable/apps/org.gnome.Settings-multitasking-symbolic.svg
+++ b/icons/src/scalable/apps/org.gnome.Settings-multitasking-symbolic.svg
@@ -1,0 +1,1 @@
+session-properties-symbolic.svg

--- a/icons/src/symlinks/symbolic/apps.list
+++ b/icons/src/symlinks/symbolic/apps.list
@@ -79,6 +79,7 @@ rhythmbox-symbolic.svg org.gnome.Rhythmbox-symbolic.svg
 root-terminal-app-symbolic.svg gksu-root-terminal-symbolic.svg
 screenshot-app-symbolic.svg applets-screenshooter-symbolic.svg
 screenshot-app-symbolic.svg gnome-screenshot-symbolic.svg
+session-properties-symbolic.svg org.gnome.Settings-multitasking-symbolic.svg
 scanner-symbolic.svg org.gnome.SimpleScan-symbolic.svg
 software-properties-symbolic.svg software-properties-gtk-symbolic.svg
 software-store-symbolic.svg software-center-symbolic.svg


### PR DESCRIPTION
Multitasking-panel has been introduced into Settings (see: [!729](https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/729) ) and requires the symbolic with name: `org.gnome.Settings-multitasking-symbolic.svg` this PR symlinks it to `session-properties-symbolic`

### screenshot:Adwaita
![2021-08-22_19-54](https://user-images.githubusercontent.com/54065734/130359016-765f394d-fa85-47d9-9b20-4260b40694d4.png)

### screenshot: Yaru
![2021-08-22_19-55](https://user-images.githubusercontent.com/54065734/130359034-4dc93c57-7da6-4ee0-b4c2-7078962d2123.png)

Thanks!