### PR TITLE
Fix G-software unvisible close button

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -99,7 +99,7 @@ button.titlebutton:not(.appmenu) {
   .titlebar &,
   headerbar.selection-mode &,
   & {
-    &.maximize, &.minimize {
+    &.maximize, &.minimize, &.close {
 
       &, &:backdrop {
         &:hover {
@@ -112,7 +112,7 @@ button.titlebutton:not(.appmenu) {
       }
     }
 
-    &.close {
+    window:not(.toolbox) &.close { // Special selector to untarget unified window (see #2980)
       color: $selected_fg_color;
       @include draw_circle($selected_bg_color);
 


### PR DESCRIPTION
The problem come from these lines: https://gitlab.gnome.org/GNOME/gnome-software/-/blob/main/src/gtk-style.css#L812-814

As they use exported color for background, it is impossible to overwrite it. So I used transparent background:

![Capture d’écran du 2021-08-31 20-03-09](https://user-images.githubusercontent.com/36476595/131554181-11403e2a-9bec-4e31-935b-6c8b5ab40d10.png)

Hover state:

![Capture d’écran du 2021-08-31 20-03-34](https://user-images.githubusercontent.com/36476595/131554188-f9b71285-dcb6-47d4-9085-ead5848a1174.png)

Closes #2980

@LinuxLlama @Muqtxdir Can you tell me if it works for you?