### PR TITLE
Sync GTK4 with upstream (remove old color vars)

### DIFF
--- a/gtk/src/default/gtk-4.0/_colors-yaru.scss
+++ b/gtk/src/default/gtk-4.0/_colors-yaru.scss
@@ -12,9 +12,6 @@ $suggested_bg_color: gtkcolor(suggested_bg_color);
 $suggested_fg_color: gtkcolor(suggested_fg_color);
 $suggested_color: gtkcolor(suggested_color);
 
-$borders_color: if($variant == 'light', darken($bg_color, 20%), darken($bg_color, 8%));
-$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 8%));
-
 $fill_color: $fill_bg_color;
 $fill_text_color: $fill_fg_color;
 $fill_hover_color: gtkmix($fill_color, currentColor, 90%);


### PR DESCRIPTION
They did so much change that I can't tell if we want all of them.
Fortunately, thanks to the symlink system, I didn't have to do anything but delete unnecessary variables in our overwrite color file.

![Capture d’écran du 2021-09-06 14-44-37](https://user-images.githubusercontent.com/36476595/132219643-b08565e7-978d-41cf-aad0-455a03c97793.png)

![Capture d’écran du 2021-09-06 14-43-58](https://user-images.githubusercontent.com/36476595/132219637-6c241bfd-4825-4967-ab16-f29918ad1af8.png)
