### PR TITLE
Add border and focus ring on GDM buttons

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
@@ -25,17 +25,23 @@
   .modal-dialog-button {
     padding: 4px 18px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.2);
-    background-color: darken($_gdm_bg, 3%); // Yaru change: use $_gdm_bg
-    border-color: darken($_gdm_bg, 3%); // Yaru change: use $_gdm_bg
+    background-color: $_gdm_bg; // Yaru change: use $_gdm_bg
+    border-color: $borders_color; // Yaru change: use $borders_color
     color: $fg_color; // Yaru change: use $fg_color for dark/light theme
 
     $_hover_c: if($variant == 'light', darken($_gdm_bg, 15%), lighten($_gdm_bg, 5%)); // Yaru change: use $_gdm_bg and modify light theme background
-    &:hover, &:focus {
+
+    // &:hover, &:focus { // Yaru: no need to change background on focus thanks to focus ring
+    &:hover {
       background-color: $_hover_c;
-      border-color: $_hover_c;
+      // border-color: $_hover_c; // Yaru: don't overwrite border on hover
+    }
+    &:focus { // Yaru: add focus ring
+      border-color: $focus_border_color;
+      box-shadow: inset 0 0 0 1px $focus_border_color;
     }
     &:active {
-      $_active_c: darken($_gdm_bg, 5%);
+      $_active_c: if($variant == 'light', darken($_gdm_bg, 25%), darken($_gdm_bg, 5%)); // Yaru: adapt active color
       box-shadow: none;
       background-color: $_active_c;
       border-color: $_active_c;
@@ -77,8 +83,8 @@
     border-radius: 99px;
     width: $base_icon_size * 2;
     height: $base_icon_size * 2;
-    border-color: darken($_gdm_bg, 3%); // Yaru change: use $_gdm_bg
-    background-color: darken($_gdm_bg, 3%); // Yaru change: use $_gdm_bg
+    // border-color: $borders_color; // Yaru change: don't overwrite button look
+    // background-color: darken($_gdm_bg, 3%); // Yaru change: don't overwrite button look
 
     StIcon { icon-size: $base_icon_size; }
   }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
@@ -48,9 +48,9 @@
     }
     &:insensitive {
       @include button(insensitive);
-      border-color: darken($focus_border_color, 5%);
-      background-color: darken($_gdm_bg, 5%);
-      color: transparentize($fg_color, 0.3); // Yaru change: use $fg_color for dark/light theme
+      border-color: $insensitive_bg_color; // Yaru: use same style as entries
+      // background-color: darken($_gdm_bg, 5%); // Yaru: use same style as entries
+      color: $insensitive_fg_color;  // Yaru: use same style as entries
     }
     &:default { // Yaru: our suggested action color is green
       @include button(normal, $c:$suggested_bg_color, $tc:$selected_fg_color);

--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
@@ -48,7 +48,7 @@
     }
     &:insensitive {
       @include button(insensitive);
-      border-color: darken($_gdm_bg, 5%);
+      border-color: darken($focus_border_color, 5%);
       background-color: darken($_gdm_bg, 5%);
       color: transparentize($fg_color, 0.3); // Yaru change: use $fg_color for dark/light theme
     }


### PR DESCRIPTION
I added border on GDM/lock screen buttons, and updated background colors.
In bonus, I added a focus ring on focused buttons (using `tab`).

@Feichtmeier can you post a screenshot for me here, I don't have a VM within easy reach. Also tell me if you don't like the focus ring :)

Closes #3012 