### PR TITLE
Fix backdrop insensitive selected text color

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -420,6 +420,12 @@ list row, placessidebar row, sidebar row, .sidebar row, treeview.view {
         button.suggested-action, button.destructive-action { &:not(.image-button) { &, & image { color: white; } } }
         background: $_backdrop_row_selection_bg;
       }
+
+      &:insensitive {
+        &, &:backdrop {
+          &, button, button image { color: $insensitive_fg_color; }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
**Before:**

![Capture d’écran de 2021-09-24 13-21-35](https://user-images.githubusercontent.com/36476595/134667581-f8bb1195-4c9c-436f-ac70-ae039efe7d63.png)

**After:**

![Capture d’écran de 2021-09-24 13-28-24](https://user-images.githubusercontent.com/36476595/134667596-bb1aca90-26b3-40d5-9d8f-6b46e3e79f70.png)
