### PR TITLE
Fix deprecated :insensitive pseudo-class

### DIFF
--- a/gtk/src/default/gtk-3.20/_tweaks.scss
+++ b/gtk/src/default/gtk-3.20/_tweaks.scss
@@ -421,7 +421,7 @@ list row, placessidebar row, sidebar row, .sidebar row, treeview.view {
         background: $_backdrop_row_selection_bg;
       }
 
-      &:insensitive {
+      &:disabled {
         &, &:backdrop {
           &, button, button image { color: $insensitive_fg_color; }
         }


### PR DESCRIPTION
Use `:disabled` instead of deprecated :insensitive pseudo-class.

Closes #3028 