### PR TITLE
Add missing eog symbolic icon

### DIFF
--- a/icons/Suru/scalable/actions/eog-image-gallery-symbolic.svg
+++ b/icons/Suru/scalable/actions/eog-image-gallery-symbolic.svg
@@ -1,0 +1,1 @@
+view-grid-symbolic.svg

--- a/icons/src/symlinks/symbolic/actions.list
+++ b/icons/src/symlinks/symbolic/actions.list
@@ -55,6 +55,7 @@ tools-check-spelling-symbolic.svg annotations-squiggly-symbolic.svg
 visible-symbolic.svg stock-eye-symbolic.svg
 visible-symbolic.svg view-layout-symbolic.svg
 visible-symbolic.svg view-reveal-symbolic.svg
+view-grid-symbolic.svg eog-image-gallery-symbolic.svg
 view-list-symbolic.svg view-list-bullet-symbolic.svg
 window-pop-out-symbolic.svg detach-symbolic.svg
 window-symbolic.svg yelp-page-ui-symbolic.svg


### PR DESCRIPTION
**eog-image-gallery-symbolic:**
![Capture d’écran du 2021-10-01 12-57-48](https://user-images.githubusercontent.com/36476595/135609034-3ca9c89a-da42-47fe-b8d0-49bfc8e4f17b.png)


Related to #3033 #3064