### PR TITLE
Fix evince branch name

### DIFF
--- a/.github/workflows/open-pr-on-icons-changes.yaml
+++ b/.github/workflows/open-pr-on-icons-changes.yaml
@@ -71,7 +71,7 @@ jobs:
           {
             project: evince symbolics,
             repo: "https://gitlab.gnome.org/GNOME/evince.git",
-            upstreambranch: master,
+            upstreambranch: main,
             localbranch: evince-symbolics,
             projectdir: evince,
             src: .,


### PR DESCRIPTION
**Evince** repository branch name is renamed to `main`.