### PR TITLE
Change symbolic icon for mail app

### DIFF
--- a/icons/Suru/scalable/apps/mail-app-symbolic.svg
+++ b/icons/Suru/scalable/apps/mail-app-symbolic.svg
@@ -1,7 +1,50 @@
-<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:osb="http://www.openswatchbook.org/uri/2009/osb">
- <g transform="translate(-572 -260)" fill="#808080">
-  <path d="m572.39 265.89-0.38837 0.59584 7 5.0123-2 2s2.7241-1.2291 4-2c2.4598-1.4863 7-5.0336 7-5.0336l-0.38837-0.57457-7.613 4.5938z"/>
-  <path d="m575.99 262c-1.2582 0.0145-2.1789-0.0306-2.9316 0.38477-0.37637 0.20766-0.67323 0.55938-0.83789 0.99804-0.16467 0.43867-0.22461 0.95959-0.22461 1.6172v7.0005c0 0.65761 0.0599 1.1786 0.22461 1.6172 0.16468 0.43861 0.46153 0.78852 0.83789 0.99609 0.75272 0.41513 1.6735 0.37165 2.9316 0.38672h2e-3 8.0059 4e-3c1.2582-0.0145 2.1789 0.0306 2.9316-0.38477 0.37637-0.20766 0.67322-0.55938 0.83789-0.99804 0.16453-0.43867 0.22447-0.95958 0.22447-1.6172v-7.0005c0-0.6576-0.0599-1.1786-0.22461-1.6172-0.16468-0.4386-0.46153-0.78852-0.83789-0.99608-0.75272-0.41513-1.6736-0.37165-2.9316-0.38673h-2e-3 -8.0059zm6e-3 1h8c1.2586 0.0152 2.0891 0.0599 2.4551 0.26173 0.18342 0.10116 0.28722 0.21285 0.38476 0.47266 0.0974 0.25978 0.16002 0.67322 0.16002 1.2656v7.0005c0 0.59239-0.0626 1.0057-0.16016 1.2656-0.0976 0.25991-0.20135 0.37147-0.38476 0.47266-0.36596 0.20192-1.1966 0.24701-2.4551 0.26172h-7.9941-6e-3c-1.2586-0.0152-2.0891-0.0599-2.4551-0.26172-0.18342-0.10116-0.28722-0.21286-0.38476-0.47266-0.0976-0.25979-0.16016-0.67323-0.16016-1.2656v-7.0005c0-0.59239 0.0626-1.0057 0.16016-1.2656 0.0976-0.25991 0.20135-0.37147 0.38476-0.47266 0.36596-0.20192 1.1966-0.24702 2.4551-0.26172z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-position:normal;isolation:auto;mix-blend-mode:normal;shape-padding:0;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-orientation:mixed;text-transform:none;white-space:normal"/>
-  <path d="m576.99 264c-0.62947 7e-3 -1.1065 9e-3 -1.5059 0.0547-0.39932 0.0458-0.76315 0.14093-1.0371 0.41406-0.27395 0.27313-0.36959 0.63968-0.41211 1.0371-0.0425 0.39741-0.0391 1.3707-0.0391 1.995h1c0-0.62572 9.9e-4 -1.5884 0.0332-1.8895 0.0322-0.30116 0.0892-0.39788 0.125-0.43361 0.0358-0.0357 0.13752-0.0938 0.44336-0.12889 0.30457-0.0349 0.77106-0.0416 1.3984-0.0488h5c0.62741 8e-3 2.0917 0.0139 2.3963 0.0488 0.30591 0.0351 0.40951 0.0932 0.44532 0.12889 0.0358 0.0357 0.0928 0.13255 0.125 0.43361 0.0321 0.30108 0.0332 1.2638 0.0332 1.8895h1c0-0.62428 3e-3 -1.5976-0.0391-1.995-0.0425-0.39736-0.13813-0.76407-0.41211-1.0371-0.27398-0.27303-0.63785-0.36822-1.0371-0.41406-0.39926-0.0458-1.8762-0.0471-2.5057-0.0547h-2e-3 -5.0058z" color="#000000" color-rendering="auto" dominant-baseline="auto" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-position:normal;isolation:auto;mix-blend-mode:normal;shape-padding:0;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-orientation:mixed;text-transform:none;white-space:normal"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 16 16"
+   id="svg10"
+   sodipodi:docname="mail-app-symbolic.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     id="namedview12"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     showborder="true"
+     inkscape:zoom="16"
+     inkscape:cx="6.0625"
+     inkscape:cy="8.34375"
+     inkscape:window-width="1298"
+     inkscape:window-height="704"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg10">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1128" />
+  </sodipodi:namedview>
+  <g
+     id="g930">
+    <path
+       d="M 2,2 C 1.562,2 1.214,2.039 0.922,2.148 0.63,2.258 0.396,2.458 0.258,2.709 -0.019,3.211 0.01,3.823 0,4.662 v 6.676 c 0.01,0.839 -0.019,1.451 0.258,1.953 0.138,0.251 0.372,0.45 0.664,0.56 C 1.214,13.961 1.562,14 2,14 h 12 c 0.439,0 0.786,-0.039 1.078,-0.148 0.293,-0.11 0.528,-0.31 0.666,-0.561 C 16.021,12.789 15.99,12.177 16,11.338 V 4.662 C 15.99,3.823 16.021,3.211 15.744,2.709 A 1.258,1.258 0 0 0 15.078,2.149 C 14.786,2.039 14.438,2 14,2 Z m 0,1 h 12 c 0.38,0 0.606,0.039 0.727,0.084 0.083,0.031 0.127,0.08 0.142,0.107 0.095,0.172 0.12,0.615 0.131,1.473 v 6.674 c -0.01,0.855 -0.036,1.299 -0.13,1.47 a 0.27,0.27 0 0 1 -0.143,0.108 C 14.606,12.961 14.38,13 14,13 H 2 C 1.62,13 1.394,12.961 1.274,12.916 A 0.257,0.257 0 0 1 1.133,12.809 C 1.037,12.635 1.01,12.192 1,11.338 V 4.664 C 1.01,3.808 1.037,3.365 1.133,3.191 A 0.257,0.257 0 0 1 1.273,3.084 C 1.394,3.039 1.621,3 2,3 Z M 2.537,4.578 2.252,5.016 8.125,9.236 14,5 13.715,4.578 8.125,7.951 Z"
+       fill="#808080"
+       font-family="Ubuntu"
+       font-size="15px"
+       font-weight="400"
+       letter-spacing="0"
+       text-anchor="middle"
+       word-spacing="0"
+       id="path2" />
+  </g>
 </svg>

--- a/icons/src/scalable/apps/mail-app-symbolic.svg
+++ b/icons/src/scalable/apps/mail-app-symbolic.svg
@@ -1,37 +1,50 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata20854'>
-    <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:title/>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient4526' osb:paint='solid'>
-      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
-      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
-      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
-    </linearGradient>
-  </defs>
-  <g id='layer9' label='status' style='display:inline' transform='translate(-813.00024,107)'/>
-  <g id='layer2' style='display:inline' transform='translate(-572.00004,-260)'/>
-  <g id='layer4' style='display:inline' transform='translate(-572.00004,-260)'/>
-  <g id='g1812' style='display:inline' transform='translate(-572.00004,-260)'/>
-  <g id='g6217' style='display:inline' transform='translate(-572.00004,-260)'/>
-  <g id='layer3' style='display:inline' transform='translate(-572.00004,-260)'/>
-  <g id='g1833' style='display:inline' transform='translate(-572.00004,-260)'>
-    <path d='m 572.38841,265.89185 -0.38837,0.59584 7,5.01231 -2,2 c 0,0 2.72412,-1.22906 4,-2 2.45979,-1.48631 7,-5.03358 7,-5.03358 l -0.38837,-0.57457 -7.61296,4.59385 z' id='path4237-1' style='font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;display:inline;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.99980211'/>
-    
-    <path d='m 575.99418,261.9995 c -1.2582,0.0145 -2.17889,-0.0306 -2.93164,0.38477 -0.37637,0.20766 -0.67323,0.55938 -0.83789,0.99804 -0.16467,0.43867 -0.22461,0.95959 -0.22461,1.61719 V 272 c 0,0.65761 0.0599,1.17858 0.22461,1.61719 0.16468,0.43861 0.46153,0.78852 0.83789,0.99609 0.75272,0.41513 1.67354,0.37165 2.93164,0.38672 h 0.002 8.00586 0.004 c 1.25819,-0.0145 2.17889,0.0306 2.93164,-0.38477 0.37637,-0.20766 0.67322,-0.55938 0.83789,-0.99804 0.16453,-0.43867 0.22447,-0.95958 0.22447,-1.61719 v -7.0005 c 0,-0.6576 -0.0599,-1.17858 -0.22461,-1.61719 -0.16468,-0.4386 -0.46153,-0.78852 -0.83789,-0.99608 -0.75272,-0.41513 -1.67355,-0.37165 -2.93164,-0.38673 h -0.002 -8.00586 z m 0.006,1 h 8 c 1.25862,0.0152 2.0891,0.0599 2.45508,0.26173 0.18342,0.10116 0.28722,0.21285 0.38476,0.47266 0.0974,0.25978 0.16002,0.67322 0.16002,1.26561 V 272 c 0,0.59239 -0.0626,1.00572 -0.16016,1.26562 -0.0976,0.25991 -0.20135,0.37147 -0.38476,0.47266 -0.36596,0.20192 -1.19656,0.24701 -2.45508,0.26172 h -7.99414 -0.006 c -1.25863,-0.0152 -2.0891,-0.0599 -2.45508,-0.26172 -0.18342,-0.10116 -0.28722,-0.21286 -0.38476,-0.47266 -0.0976,-0.25979 -0.16016,-0.67323 -0.16016,-1.26562 v -7.0005 c 0,-0.59239 0.0626,-1.00572 0.16016,-1.26562 0.0976,-0.25991 0.20135,-0.37147 0.38476,-0.47266 0.36596,-0.20192 1.19655,-0.24702 2.45508,-0.26172 z' id='path2732-8-1-32' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
-    <path d='m 576.99422,263.99916 c -0.62947,0.007 -1.10654,0.009 -1.50586,0.0547 -0.39932,0.0458 -0.76315,0.14093 -1.03711,0.41406 -0.27395,0.27313 -0.36959,0.63968 -0.41211,1.03711 -0.0425,0.39741 -0.0391,1.37069 -0.0391,1.99497 h 1 c 0,-0.62572 9.9e-4,-1.58835 0.0332,-1.8895 0.0322,-0.30116 0.0892,-0.39788 0.125,-0.43361 0.0358,-0.0357 0.13752,-0.0938 0.44336,-0.12889 0.30457,-0.0349 0.77106,-0.0416 1.39844,-0.0488 H 582 c 0.62741,0.008 2.09166,0.0139 2.39628,0.0488 0.30591,0.0351 0.40951,0.0932 0.44532,0.12889 0.0358,0.0357 0.0928,0.13255 0.125,0.43361 0.0321,0.30108 0.0332,1.26378 0.0332,1.8895 h 1 c 0,-0.62428 0.003,-1.59763 -0.0391,-1.99498 -0.0425,-0.39736 -0.13813,-0.76407 -0.41211,-1.03711 -0.27398,-0.27303 -0.63785,-0.36822 -1.03711,-0.41406 -0.39926,-0.0458 -1.87622,-0.0471 -2.50566,-0.0547 h -0.002 -5.00582 z' id='path2732-8-1-36' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 16 16"
+   id="svg10"
+   sodipodi:docname="mail-app-symbolic.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     id="namedview12"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="true"
+     showborder="true"
+     inkscape:zoom="16"
+     inkscape:cx="6.0625"
+     inkscape:cy="8.34375"
+     inkscape:window-width="1298"
+     inkscape:window-height="704"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg10">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1128" />
+  </sodipodi:namedview>
+  <g
+     id="g930">
+    <path
+       d="M 2,2 C 1.562,2 1.214,2.039 0.922,2.148 0.63,2.258 0.396,2.458 0.258,2.709 -0.019,3.211 0.01,3.823 0,4.662 v 6.676 c 0.01,0.839 -0.019,1.451 0.258,1.953 0.138,0.251 0.372,0.45 0.664,0.56 C 1.214,13.961 1.562,14 2,14 h 12 c 0.439,0 0.786,-0.039 1.078,-0.148 0.293,-0.11 0.528,-0.31 0.666,-0.561 C 16.021,12.789 15.99,12.177 16,11.338 V 4.662 C 15.99,3.823 16.021,3.211 15.744,2.709 A 1.258,1.258 0 0 0 15.078,2.149 C 14.786,2.039 14.438,2 14,2 Z m 0,1 h 12 c 0.38,0 0.606,0.039 0.727,0.084 0.083,0.031 0.127,0.08 0.142,0.107 0.095,0.172 0.12,0.615 0.131,1.473 v 6.674 c -0.01,0.855 -0.036,1.299 -0.13,1.47 a 0.27,0.27 0 0 1 -0.143,0.108 C 14.606,12.961 14.38,13 14,13 H 2 C 1.62,13 1.394,12.961 1.274,12.916 A 0.257,0.257 0 0 1 1.133,12.809 C 1.037,12.635 1.01,12.192 1,11.338 V 4.664 C 1.01,3.808 1.037,3.365 1.133,3.191 A 0.257,0.257 0 0 1 1.273,3.084 C 1.394,3.039 1.621,3 2,3 Z M 2.537,4.578 2.252,5.016 8.125,9.236 14,5 13.715,4.578 8.125,7.951 Z"
+       fill="#808080"
+       font-family="Ubuntu"
+       font-size="15px"
+       font-weight="400"
+       letter-spacing="0"
+       text-anchor="middle"
+       word-spacing="0"
+       id="path2" />
   </g>
-  <g id='layer1' style='display:inline' transform='translate(-572.00004,-260)'/>
 </svg>


### PR DESCRIPTION
Just an idea - I use Evolution a lot and had tried to draw a small version of the app icon for the symbolic.  It's not my finest work and the e-mail symbolic we inherited from Suru (still used elsewhere) is nicer IMO.

Current:

![image](https://user-images.githubusercontent.com/38893390/138587737-54bfda88-7464-4f3d-bd12-4bd51fbe9cbd.png)

In this PR:

![image](https://user-images.githubusercontent.com/38893390/138587751-c9b02dd5-333d-404e-ab31-879ab08eba2b.png)
