### PR TITLE
Add missing GTK3 render-assets script

### DIFF
--- a/gtk/src/default/gtk-3.20/render-assets.sh
+++ b/gtk/src/default/gtk-3.20/render-assets.sh
@@ -1,0 +1,1 @@
+../gtk-4.0/render-assets.sh


### PR DESCRIPTION
`render-assets.sh` was missing in Gtk3 folder, so I symlink it with Gtk4.