### PR TITLE
Add selection-mode-symbolic icon

### DIFF
--- a/icons/Yaru/scalable/actions/selection-mode-symbolic.svg
+++ b/icons/Yaru/scalable/actions/selection-mode-symbolic.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <g fill="gray">
+  <path d="M14.422 4.516L8.5 10.438l-2.969-2.97L4.47 8.532l4.031 4.03 6.984-6.983z" font-family="sans-serif" font-weight="400" overflow="visible" style="font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-position:normal;isolation:auto;mix-blend-mode:normal;shape-padding:0;text-decoration-color:#000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-orientation:mixed;text-transform:none" white-space="normal"/>
+  <path d="m8 0a8 8 0 0 0-8 8 8 8 0 0 0 8 8 8 8 0 0 0 8-8 8 8 0 0 0-8-8zm0 1a7 7 0 0 1 7 7 7 7 0 0 1-7 7 7 7 0 0 1-7-7 7 7 0 0 1 7-7z"/>
+ </g>
+</svg>

--- a/icons/src/scalable/actions/selection-mode-symbolic.svg
+++ b/icons/src/scalable/actions/selection-mode-symbolic.svg
@@ -1,0 +1,1 @@
+../emblems/emblem-default-symbolic.svg


### PR DESCRIPTION
Added new `selection-mode-symbolic` icon:

![Capture d’écran du 2021-10-30 11-02-33](https://user-images.githubusercontent.com/36476595/139526947-8278a80f-7e68-4236-a15a-e669207835cc.png)

See: #3155 and https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/blob/master/Adwaita/scalable/actions/selection-mode-symbolic.svg