### PR TITLE
Sort symbolic action listing

### DIFF
--- a/.github/workflows/open-pr-on-icons-changes.yaml
+++ b/.github/workflows/open-pr-on-icons-changes.yaml
@@ -180,7 +180,7 @@ jobs:
           popd
           rm -f ${DEST}
           cd /tmp/${PROJECT_DIR}/${SRC}
-          find . -name "*-symbolic.svg" > list.list
+          find . -name "*-symbolic.svg" | sort > list.list
           cd ~/work/yaru/yaru
           cp /tmp/${PROJECT_DIR}/${SRC}/list.list ${DEST}
           MODIFIED=$(git status --porcelain)


### PR DESCRIPTION
I noticed we have a problem with the current listing command `find . -name "*-symbolic.svg"`, because it sometimes randomly change the listing sort, and so create a lot of spamming and useless PRs.

So I added a piped `sort` instruction to stabilize the output.
@clobrano do you think this will solve the problem?