### PR TITLE
Fix broken duplicated config-users icon symlink

### DIFF
--- a/icons/Yaru/16x16/apps/config-users.png
+++ b/icons/Yaru/16x16/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png

--- a/icons/Yaru/16x16@2x/apps/config-users.png
+++ b/icons/Yaru/16x16@2x/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png

--- a/icons/Yaru/24x24/apps/config-users.png
+++ b/icons/Yaru/24x24/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png

--- a/icons/Yaru/24x24@2x/apps/config-users.png
+++ b/icons/Yaru/24x24@2x/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png

--- a/icons/Yaru/256x256/apps/config-users.png
+++ b/icons/Yaru/256x256/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png

--- a/icons/Yaru/256x256@2x/apps/config-users.png
+++ b/icons/Yaru/256x256@2x/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png

--- a/icons/Yaru/32x32/apps/config-users.png
+++ b/icons/Yaru/32x32/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png

--- a/icons/Yaru/32x32@2x/apps/config-users.png
+++ b/icons/Yaru/32x32@2x/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png

--- a/icons/Yaru/48x48/apps/config-users.png
+++ b/icons/Yaru/48x48/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png

--- a/icons/Yaru/48x48@2x/apps/config-users.png
+++ b/icons/Yaru/48x48@2x/apps/config-users.png
@@ -1,1 +1,0 @@
-system-users.png


### PR DESCRIPTION
The fullcolor `config-users` icon is duplicated with a broken symlink and it makes the installation fails.