### PR TITLE
Use exported accent for red close button

### DIFF
--- a/gtk/src/default/gtk-4.0/_tweaks.scss
+++ b/gtk/src/default/gtk-4.0/_tweaks.scss
@@ -23,19 +23,19 @@ windowcontrols {
         
         &.close {
             > image {
-                color: $light_2;
-                background: $orange_5;
+                color: $accent_fg_color;
+                background: $accent_bg_color;
 
                 &:hover {
-                    background: lighten($orange_5, 5%);
+                    background: gtkmix($accent_bg_color, "#fff", 90%);
                 }
 
                 &:active {
-                    background: darken($orange_5, 5%);
+                    background: gtkmix($accent_bg_color, "#000", 90%);
                 }
 
                 &:backdrop {
-                    background: desaturate($orange_5, 100%);
+                    filter: saturate(0);
                 }
             }
         }


### PR DESCRIPTION
Use exported accent color for the red close button instead of hardcoded orange color var.
This allows to not have to modify the `_tweaks` hardcoded value for the `mate` branch.