### PR TITLE
Fix transparent guake notebook headerbar

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -8,6 +8,7 @@
 @import 'apps/nemo';
 @import 'apps/not-csd';
 @import 'apps/gnome-todo';
+@import 'apps/guake';
 @import 'apps/firefox';
 @import 'apps/ubiquity';
 @import 'apps/geary';

--- a/gtk/src/default/gtk-3.20/apps/_guake.scss
+++ b/gtk/src/default/gtk-3.20/apps/_guake.scss
@@ -1,0 +1,4 @@
+// Fix bugged transparent headerbar background
+window#guake-terminal notebook header {
+    background: $bg-color;
+}


### PR DESCRIPTION
![Capture d’écran de 2021-11-11 12-37-16](https://user-images.githubusercontent.com/36476595/141291910-a35e2e82-2ef7-4ea4-931d-e778dc5c7186.png)

This will need a backport to `21.10`, `20.04`.

Closes #2149