### PR TITLE
Fix transparent guake notebook headerbar

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -8,6 +8,7 @@
 @import 'apps/nemo';
 @import 'apps/not-csd';
 @import 'apps/gnome-todo';
+@import 'apps/guake';
 @import 'apps/firefox';
 @import 'apps/ubiquity';
 @import 'apps/geary';

--- a/gtk/src/default/gtk-3.20/apps/_guake.scss
+++ b/gtk/src/default/gtk-3.20/apps/_guake.scss
@@ -1,0 +1,4 @@
+// Fix bugged transparent headerbar background
+window#guake-terminal notebook header {
+    background: $bg-color;
+}


### PR DESCRIPTION
Same as #3218 but for the `ubuntu/impish` branch.

Closes #2149