### PR TITLE
Fix transparent guake notebook headerbar

### DIFF
--- a/gtk/src/default/gtk-3.20/_apps.scss
+++ b/gtk/src/default/gtk-3.20/_apps.scss
@@ -700,3 +700,12 @@ UnityPanelWidget, .unity-panel {
 }
 
 SheetStyleDialog.unity-force-quit { background-color: $bg_color; }
+
+/********
+* Guake *
+*********/
+
+// Fix bugged transparent headerbar background
+window#guake-terminal notebook header {
+    background: $bg-color;
+}


### PR DESCRIPTION
Same as #3218 but for the `ubuntu/focal` branch.

Closes #2149