### PR TITLE
Add dock styles to GS hc variant

### DIFF
--- a/gnome-shell/src/gnome-shell-high-contrast.scss
+++ b/gnome-shell/src/gnome-shell-high-contrast.scss
@@ -4,6 +4,7 @@ $variant: 'dark';
 @import "gnome-shell-sass/_drawing";
 @import "gnome-shell-sass/_common";
 @import "gnome-shell-sass/_widgets";
+@import "gnome-shell-sass/_dock";
 
 //force symbolic icons
 stage {


### PR DESCRIPTION
Backport of #3089 for `focal`