### PR TITLE
Force meson options to true in build CI

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -13,4 +13,7 @@ jobs:
       run: sudo apt install meson sassc
 
     - name: Build and Install
-      run: meson build && cd build && sudo ninja install
+      run: |
+        meson build -Dgnome-shell-gresource=true -Dmate=true -Dmate-dark=true -Dubuntu-unity=true -Dxfwm4=true
+        cd build
+        sudo ninja install


### PR DESCRIPTION
As some meson options are `false`, the build CI doesn't test every part of the repository.
So I forced here all `false` options to `true`.