### PR TITLE
Fix mate-dark Gtk variant

### DIFF
--- a/gtk/src/mate-dark/gtk-3.0/_palette.scss
+++ b/gtk/src/mate-dark/gtk-3.0/_palette.scss
@@ -1,1 +1,1 @@
-../../default/gtk-3.20/_palette.scss
+../../mate/gtk-3.0/_palette.scss

--- a/gtk/src/mate-dark/gtk-3.20/_palette.scss
+++ b/gtk/src/mate-dark/gtk-3.20/_palette.scss
@@ -1,1 +1,1 @@
-../../default/gtk-3.20/_palette.scss
+../../mate/gtk-3.20/_palette.scss

--- a/gtk/src/mate-dark/gtk-4.0/_defaults.scss
+++ b/gtk/src/mate-dark/gtk-4.0/_defaults.scss
@@ -1,1 +1,1 @@
-../../default/gtk-4.0/_defaults.scss
+../../mate/gtk-4.0/_defaults.scss

--- a/gtk/src/mate-dark/gtk-4.0/_palette.scss
+++ b/gtk/src/mate-dark/gtk-4.0/_palette.scss
@@ -1,1 +1,1 @@
-../../default/gtk-4.0/_palette.scss
+../../mate/gtk-4.0/_palette.scss

--- a/gtk/src/mate-dark/gtk-4.0/gtk-dark.scss
+++ b/gtk/src/mate-dark/gtk-4.0/gtk-dark.scss
@@ -1,1 +1,1 @@
-gtk.scss
+../../dark/gtk-4.0/gtk-dark.scss

--- a/gtk/src/mate-dark/gtk-4.0/gtk.scss
+++ b/gtk/src/mate-dark/gtk-4.0/gtk.scss
@@ -1,1 +1,1 @@
-../../default/gtk-4.0/gtk.scss
+../../dark/gtk-4.0/gtk.scss


### PR DESCRIPTION
I did a mistake in the previous PR by symlinking some `mate-dark` files to `default` variant.
This PR fix them.