### PR TITLE
Fix index.theme flavour overwriting

### DIFF
--- a/icons/meson.build
+++ b/icons/meson.build
@@ -29,10 +29,12 @@ foreach flavour: ['default', 'mate']
     conf_data.set('ThemeName', theme_name)
     foreach theme: themes_f
       if fs.is_file(join_paths(theme_name, theme))
-        configure_file(input : theme_name + '/@0@'.format(theme),
-                      output : '@0@'.format(theme),
-                      configuration : conf_data,
-                      install_dir: theme_dir)
+        file = configure_file(
+          input : join_paths(theme_name, theme),
+          output : flavour + '-@0@'.format(theme),
+          configuration : conf_data
+        )
+        install_data(file, install_dir: theme_dir, rename: theme)
       endif
     endforeach
 


### PR DESCRIPTION
The previous way of installing `index.theme` files was very problematic because the `configure_file` meson function is storing temp files in the same in the same temp folder. As they was using the same name, the last one was overwriting the previous one.
So I had the `index.theme` file of the **mate** flavour in both `/usr/share/icons/Yaru` and `/usr/share/icons/Yaru-mate` folders, with very weird side effects.

This PR solve the problem by prefix the file name, and then by rename it at the installation step.