### PR TITLE
Add preferences-desktop-keyboard icon

### DIFF
--- a/icons/Yaru/16x16/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/16x16/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/Yaru/16x16@2x/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/16x16@2x/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/Yaru/24x24/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/24x24/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/Yaru/24x24@2x/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/24x24@2x/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/Yaru/256x256/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/256x256/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/Yaru/256x256@2x/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/256x256@2x/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/Yaru/32x32/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/32x32/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/Yaru/32x32@2x/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/32x32@2x/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/Yaru/48x48/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/48x48/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/Yaru/48x48@2x/categories/preferences-desktop-keyboard.png
+++ b/icons/Yaru/48x48@2x/categories/preferences-desktop-keyboard.png
@@ -1,0 +1,1 @@
+../devices/input-keyboard.png

--- a/icons/src/symlinks/fullcolor/categories.list
+++ b/icons/src/symlinks/fullcolor/categories.list
@@ -1,3 +1,4 @@
+../devices/input-keyboard.png preferences-desktop-keyboard.png
 preferences-color.png gnome-color-manager.png
 preferences-color.png gtk-select-color.png
 preferences-color.png unity-color-panel.png


### PR DESCRIPTION
Symlink **preferences-desktop-keyboard** to **input-keyboard**.

![Capture d’écran de 2022-01-01 21-45-46](https://user-images.githubusercontent.com/36476595/147859890-c73f7666-bdcb-4329-a8a7-af9a40f4d00f.png)

Closes #3284