### PR TITLE
update session overrides

### DIFF
--- a/sessions/THEMENAME.gschema.override.in
+++ b/sessions/THEMENAME.gschema.override.in
@@ -7,9 +7,15 @@ cursor-theme = "@ThemeName@"
 icon-theme = "@ThemeName@"
 gtk-theme = "@ThemeName@"
 
+[org.gnome.gedit.preferences.editor:@ThemeName@]
+scheme = "@ThemeName@"
+
 [org.gnome.desktop.sound:@ThemeName@]
 theme-name = "@ThemeName@"
 input-feedback-sounds = true
 
 [org.gnome.mutter:@ThemeName@]
 center-new-windows = true
+
+[org.gnome.desktop.wm.preferences:@ThemeName@]
+button-layout = ':minimize,maximize,close'

--- a/sessions/mode.json.in
+++ b/sessions/mode.json.in
@@ -2,5 +2,9 @@
     "parentMode": "user",
     "stylesheetName": "@ThemeName@/gnome-shell.css",
     "themeResourceName": "@ThemeResourcePath@gnome-shell-theme.gresource",
-    "enabledExtensions": ["ubuntu-dock@ubuntu.com", "ubuntu-appindicators@ubuntu.com"]
+    "enabledExtensions": [
+        "ubuntu-dock@ubuntu.com",
+        "ubuntu-appindicators@ubuntu.com",
+        "ding@rastersoft.com",
+    ]
 }


### PR DESCRIPTION
- sync `enabledExtensions` offered in session with ubuntu-sessions's `enabledExtensions`
- sync `button-layout` offered in session with ubuntu-sessions's `button-layout`  (_will be helpful to testers who are  on different distribution ex: Fedora, Pop! OS_)
- add gedit preferences scheme for overriding to `@ThemeName@`