### PR TITLE
add 22x22/categories to yaru-theme-icon.install

### DIFF
--- a/debian/yaru-theme-icon.install
+++ b/debian/yaru-theme-icon.install
@@ -18,8 +18,10 @@ usr/share/icons/Yaru/16x16@2x/mimetypes
 usr/share/icons/Yaru/16x16@2x/places
 usr/share/icons/Yaru/16x16@2x/status
 usr/share/icons/Yaru/22x22/actions
+usr/share/icons/Yaru/22x22/categories
 usr/share/icons/Yaru/22x22/legacy
 usr/share/icons/Yaru/22x22@2x/actions
+usr/share/icons/Yaru/22x22@2x/categories
 usr/share/icons/Yaru/24x24/actions
 usr/share/icons/Yaru/24x24/apps
 usr/share/icons/Yaru/24x24/categories


### PR DESCRIPTION
was added when `mate` variants were merged into `master`