### PR TITLE
Symlink ups to uninterruptible-power-supply (symbolic)

### DIFF
--- a/icons/Yaru/scalable/devices/ups-symbolic.svg
+++ b/icons/Yaru/scalable/devices/ups-symbolic.svg
@@ -1,0 +1,1 @@
+uninterruptible-power-supply-symbolic.svg

--- a/icons/src/symlinks/symbolic/devices.list
+++ b/icons/src/symlinks/symbolic/devices.list
@@ -16,4 +16,5 @@ smartphone-symbolic.svg phone-htc-g1-white-symbolic.svg
 smartphone-symbolic.svg phone-palm-pre-symbolic.svg
 smartphone-symbolic.svg phone-samsung-galaxy-s-symbolic.svg
 tablet-symbolic.svg computer-apple-ipad-symbolic.svg
+uninterruptible-power-supply-symbolic.svg ups-symbolic.svg
 video-display-symbolic.svg display-symbolic.svg


### PR DESCRIPTION
Symlink **ups-symbolic** to **uninterruptible-power-supply-symbolic**.

![Capture d’écran du 2022-01-12 10-30-03](https://user-images.githubusercontent.com/36476595/149105299-2be3bc4e-168a-42a9-a48c-35c3344312af.png)

Related to #3298 (all other icons was already here)