### PR TITLE
Add support for GS42 - upstream sync

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -1,36 +1,39 @@
 // When color definition differs for dark and light variant,
-// it gets @if ed depending on $variant
+// it gets @if-ed depending on $variant
 @import 'palette';
 
-$base_color: if($variant == 'light', #ffffff, lighten($jet, 4%));
-$bg_color: if($variant == 'light', #FAFAFA, lighten($jet, 6%));
-$fg_color: if($variant == 'light', $inkstone, $porcelain);
+$base_color: if($variant=='light', #ffffff, lighten($jet, 4%));
+$bg_color: if($variant=='light', #FAFAFA, lighten($jet, 6%));
+$fg_color: if($variant=='light', $inkstone, $porcelain);
 
 $selected_fg_color: $accent_fg_color;
-$selected_bg_color: if($variant == 'light', $accent_bg_color, darken($accent_bg_color, 4%));
-$selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
+$selected_bg_color: if($variant=='light', $accent_bg_color, darken($accent_bg_color, 4%));
+$selected_borders_color: if($variant=='light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
+
 $borders_color_dark: lighten(desaturate(lighten($jet, 4%), 100%), 14%); // Yaru: used for dash and other dark elements on light theme
-$borders_color: if($variant == 'light', darken($bg_color, 20%), $borders_color_dark);
-$alt_borders_color: if($variant == 'light', darken($bg_color, 24%), darken($bg_color, 10%));
-$borders_edge: if($variant == 'light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
-$link_color: if($variant == 'light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
-$link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
+$borders_color: if($variant=='light', darken($bg_color, 20%), $borders_color_dark);
+$alt_borders_color: if($variant=='light', darken($bg_color, 24%), darken($bg_color, 10%));
+$borders_edge: if($variant=='light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
+
+$link_color: if($variant=='light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
+$link_visited_color: if($variant=='light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
 $top_hilight: $borders_edge;
 
 $warning_color: $yellow;
 $error_color: $red;
 $success_color: lighten($green, 5%);
-$destructive_color: if($variant == 'light', $red, darken($red, 10%));
+$destructive_color: if($variant=='light', $red, darken($red, 10%));
 
 $osd_fg_color: #eeeeec;
-$osd_text_color: white;
-$osd_bg_color: transparentize(lighten($jet, 2%),0.025);
+$osd_bg_color: transparentize(lighten($jet, 2%), 0.025);
 $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_color, 1), 10%), 0.5);
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 $osd_borders_color: transparentize(black, 0.3);
 $osd_outer_borders_color: transparentize(white, 0.84);
 
 $shadow_color: transparentize(black, 0.9);
+
+// overview background color
 $system_bg_color: lighten($jet, 4%); // Lighten than dash but darken than bg-color
 
 //insensitive state derived colors
@@ -39,12 +42,12 @@ $insensitive_bg_color: mix($bg_color, $base_color, 60%);
 $insensitive_borders_color: $borders_color;
 
 //colors for the backdrop state, derived from the main colors.
-$backdrop_base_color: if($variant =='light', darken($base_color,1%), lighten($base_color,1%));
+$backdrop_base_color: if($variant=='light', darken($base_color, 1%), lighten($base_color, 1%));
 $backdrop_bg_color: $bg_color;
 $backdrop_fg_color: mix($fg_color, $backdrop_bg_color, 80%);
-$backdrop_insensitive_color: if($variant =='light', darken($backdrop_bg_color,15%), lighten($backdrop_bg_color,15%));
+$backdrop_insensitive_color: if($variant=='light', darken($backdrop_bg_color, 15%), lighten($backdrop_bg_color, 15%));
 $backdrop_borders_color: mix($borders_color, $bg_color, 90%);
-$backdrop_dark_fill: mix($backdrop_borders_color,$backdrop_bg_color, 35%);
+$backdrop_dark_fill: mix($backdrop_borders_color, $backdrop_bg_color, 35%);
 
 $base_hover_color: transparentize(white, 0.8);
 $base_active_color: transparentize(white, 0.75);
@@ -61,10 +64,9 @@ $dash-alpha-value: 0.6;
 $dash-opaque-alpha-value: 0.0;
 
 //special cased widget colors
-$suggested_bg_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%));
+$suggested_bg_color: if($variant=='light', lighten($green, 5%), darken($green, 5%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 5%), darken($suggested_bg_color, 10%));
-$progress_bg_color: if($variant== 'light', lighten($accent_bg_color, 10%), lighten($accent_bg_color, 5%));
-$progress_border_color: if($variant== 'light', darken($progress_bg_color, 5%), darken($borders_color, 5%));
+$progress_bg_color: if($variant=='light', lighten($accent_bg_color, 10%), lighten($accent_bg_color, 5%));
 $checkradio_bg_color: if($variant=='light', $accent_bg_color, darken($accent_bg_color, 8%));
 $checkradio_fg_color: $accent_fg_color;
 $switch_bg_color: if($variant=='light', $accent_bg_color, darken($accent_bg_color, 8%));

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -151,7 +151,7 @@ $bubble_button_radius:$base_border_radius*1.25;
 
 // styling for elements within popovers that look like notifications
 @mixin notification_bubble($flat: false) {
-  border-width: 0px;
+  border-width: 1px; // Yaru: keep borders
   border-style: solid;
   border-radius: $base_border_radius;
   margin: $base_margin;

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -33,25 +33,26 @@ $base_spacing: 6px;
 // border radii
 $base_border_radius: 4px; // Yaru: we want a smaller border-radius
 
-$modal_radius:$base_border_radius + 2; // Yaru: we want a smaller border-radius
+// radii of things that display over other things, e.g. popovers
+$modal_radius: $base_border_radius+2; // Yaru: we want a smaller border-radius
 
 // non-standard colors
 $bubble_borders_color: lighten($borders_color, if($variant=='light', 0%, 5%));
+$bubble_buttons_color: if($variant=='light', darken($bg_color, 12%), lighten($bg_color, 4%));
 // $bubble_borders_color: if($variant == 'light', rgba(255,255,255,0.1), rgba(0,0,0,0.3));
 
-// hover Yaru: we want the hover bg to be a visible gray for dark and light shell themes
+// derived hover colors - Yaru: we want the hover bg to be a visible gray for dark and light shell themes
 $hover_bg_color: transparentize($fg_color, 0.9);
 $hover_fg_color: $fg_color;
 $hover_borders_color: lighten($borders_color,if($variant=='light', 5%, 5%));
 
-// active Yaru: we want the active bg to be a visible gray for dark and light shell themes
+// derived active colors - Yaru: we want the active bg to be a visible gray for dark and light shell themes
 $active_bg_color: transparentize($fg_color, 0.8);
-$active_fg_color: darken($fg_color,if($variant=='light', 5%, 3%));
-$active_borders_color: darken($borders_color,if($variant=='light', 5%, 3%));
+$active_fg_color: darken($fg_color, if($variant=='light', 5%, 3%));
 
 // fonts
 $base_font_size: 11;
-$text_shadow_color: if($variant == 'light', rgba(255,255,255,0.3), rgba(0,0,0,0.2));
+$text_shadow_color: if($variant=='light', rgba(255, 255, 255, 0.3), rgba(0, 0, 0, 0.2));
 
 // icons
 $base_icon_size: 1.09em;
@@ -76,8 +77,8 @@ stage {
 %osd_panel {
   color: $osd_fg_color;
   background-color: $osd_bg_color;
-  border: 1px solid $borders_color_dark; // Yaru: add border
-  border-radius: $base_border_radius * 2 + 4px;
+  border: 1px solid $borders_color_dark; // Yaru: use our border
+  border-radius: $modal_radius;
   padding: $base_padding * 2;
   box-shadow: 0 3px 9px 1px transparentize(black, 0.5); // Yaru: OSDs need to be visible on dark backgrounds
 }
@@ -98,16 +99,9 @@ stage {
   text-align: center;
 }
 
-// dialogs
-%bubble_panel {
-  color: $fg_color;
-  background-color: $bg_color;
-  border: 1px solid if($variant=='light', rgba(0,0,0, 0.6), $borders_color);
-}
-
 // button styling
 %button {
-  border-radius: $base_border_radius;
+  border-radius: $base_border_radius; // Yaru: use our own border-radius
   border-style: solid;
   border-width: 1px;
   min-height: 22px;
@@ -120,41 +114,46 @@ stage {
   &:active, &:checked { @include button(active);}
 }
 
+// dialogs
+%bubble_panel {
+  color: $fg_color;
+  background-color: $bg_color;
+  border-radius: $base_border_radius*1.25 + 1px;
+  border: 1px solid $borders_edge;
+}
+
+// buttons in dialogs/notifications
+// styled to have no shadow and be lighter in color
+$bubble_button_radius:$base_border_radius*1.25;
+
 // buttons in dialogs
 %bubble_button {
-  @include button(normal, $shadow: none);
   padding: $base_padding * 2;
-  border-style: solid;
-  border-width: 1px;
-  border-left-width: 0;
-  border-bottom-width: 0;
+  border: 0 solid $bg_color !important; 
+  border-radius: 0;
+  border-right-width: 1px !important; 
 
+  @include button(normal, $bubble_buttons_color, $shadow: none);
   &:insensitive { @include button(insensitive, $shadow: none); }
   &:focus { @include button(focus, $shadow: none); }
   &:hover { background-color: $hover_bg_color; } // Yaru: notification buttons should work like dialog buttons ( gray hover ) 
   &:active { background-color: $active_bg_color; } // Yaru: notification buttons should work like dialog buttons ( dark gray active ) 
-
-  // radius is 2 pixel less to fit in bubble
+  
   &:first-child {
-    border-radius: 0 0 0 $modal_radius - 2px;
+    border-radius: 0 0 0 $bubble_button_radius; 
   }
 
   &:last-child {
-    border-right-width: 0;
-    border-radius: 0 0 $modal_radius - 2px 0;
-  }
-
-  &:first-child:last-child {
-    border-radius: 0 0 $modal_radius - 2px $modal_radius - 2px;
+    border-radius: 0 0 $bubble_button_radius 0;
+    border-right-width: 0 !important;
   }
 }
 
-
-// notification styling
+// styling for elements within popovers that look like notifications
 @mixin notification_bubble($flat: false) {
-  border-width: 1px;
+  border-width: 0px;
   border-style: solid;
-  border-radius: $base_border_radius + 2px;
+  border-radius: $base_border_radius;
   margin: $base_margin;
 
   @if $flat {

--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -136,37 +136,37 @@
   @if $t==normal {
     color: $tc;
     background-color: lighten($c, 3%);
-    border-color: draw_border_color($c);
+    border-color: lighten($c, 3%);
     @include draw_shadows($button_shadow);
     // box-shadow: 0 1px 1px 0 rgba(0,0,0,0.1);
-    text-shadow: 0 1px $text_shadow_color;
-    icon-shadow: 0 1px $text_shadow_color;
+    text-shadow: none;
+    icon-shadow: none;
   }
 
   // focused button
   @if $t==focus {
     color: $tc;
-    text-shadow: 0 1px $text_shadow_color;
-    icon-shadow: 0 1px $text_shadow_color;
+    background-color: mix(lighten($c, 3%), $selected_bg_color, 90%);
     box-shadow: inset 0 0 0 2px $focus_border_color; // Yaru: we detached focus from selected
-    //border-color: $selected_bg_color;
+    text-shadow: none;
+    icon-shadow: none;
   }
 
   // hover button
   @else if $t==hover {
     color: $tc;
     background-color: lighten($c, if($variant == 'light', 8%, 5%));
-    border-color: if($variant == 'light', draw_border_color(lighten($c, 7%)), draw_border_color($c));
+    border-color: lighten($c, if($variant == 'light', 8%, 5%));
     @include draw_shadows(0 1px opacify($shadow_color, 0.05)); // Yaru: adapt shell to gtk buttons (paper effect)
-    text-shadow: 0 1px $text_shadow_color;
-    icon-shadow: 0 1px $text_shadow_color;
+    text-shadow: none;
+    icon-shadow: none;
   }
 
   // active button
   @else if $t==active {
     color: $tc;
     background-color: darken($c,3%);
-    border-color: draw_border_color(if($variant == 'light', $c, darken($c,7%)));
+    border-color: darken($c,3%);
     text-shadow: none;
     icon-shadow: none;
     box-shadow: none;
@@ -175,7 +175,7 @@
   // insensitive button
   @else if $t==insensitive {
     color: $insensitive_fg_color;
-    border-color: if($variant=='light', $insensitive_borders_color, darken($c, 5%)); // Yaru change: dark buttons need a dark border
+    border-color: if($variant=='light', $insensitive_bg_color, darken($c, 5%)); // Yaru change: dark buttons need a dark border
     background-color: $insensitive_bg_color;
     box-shadow: none;
     text-shadow: none;
@@ -194,7 +194,7 @@
 }
 
 // overview icons
-@mixin overview-icon($color) {
+@mixin overview_icon($color) {
   .overview-icon {
     @extend %icon_tile;
     color: $color;
@@ -221,6 +221,7 @@
     }
   }
 
+  &:focus,
   &:active,
   &:checked {
     .overview-icon {

--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -146,7 +146,7 @@
   // focused button
   @if $t==focus {
     color: $tc;
-    background-color: mix(lighten($c, 3%), $selected_bg_color, 90%);
+    background-color: lighten($c, 3%); // Yaru: keep regular bg on focused buttons
     box-shadow: inset 0 0 0 2px $focus_border_color; // Yaru: we detached focus from selected
     text-shadow: none;
     icon-shadow: none;

--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -136,7 +136,7 @@
   @if $t==normal {
     color: $tc;
     background-color: lighten($c, 3%);
-    border-color: lighten($c, 3%);
+    border-color: draw_border_color($c); // Yaru: keep borders
     @include draw_shadows($button_shadow);
     // box-shadow: 0 1px 1px 0 rgba(0,0,0,0.1);
     text-shadow: none;
@@ -156,7 +156,7 @@
   @else if $t==hover {
     color: $tc;
     background-color: lighten($c, if($variant == 'light', 8%, 5%));
-    border-color: lighten($c, if($variant == 'light', 8%, 5%));
+    border-color: if($variant == 'light', draw_border_color(lighten($c, 7%)), draw_border_color($c)); // Yaru: keep borders
     @include draw_shadows(0 1px opacify($shadow_color, 0.05)); // Yaru: adapt shell to gtk buttons (paper effect)
     text-shadow: none;
     icon-shadow: none;
@@ -166,7 +166,7 @@
   @else if $t==active {
     color: $tc;
     background-color: darken($c,3%);
-    border-color: darken($c,3%);
+    border-color: draw_border_color(if($variant == 'light', $c, darken($c,7%))); // Yaru: keep borders
     text-shadow: none;
     icon-shadow: none;
     box-shadow: none;
@@ -175,7 +175,7 @@
   // insensitive button
   @else if $t==insensitive {
     color: $insensitive_fg_color;
-    border-color: if($variant=='light', $insensitive_bg_color, darken($c, 5%)); // Yaru change: dark buttons need a dark border
+    border-color: if($variant=='light', $insensitive_borders_color, darken($c, 5%)); // Yaru change: dark buttons need a dark border
     background-color: $insensitive_bg_color;
     box-shadow: none;
     text-shadow: none;

--- a/gnome-shell/src/gnome-shell-sass/_high-contrast-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_high-contrast-colors.scss
@@ -24,6 +24,8 @@ $osd_fg_color: #eeeeec;
 $osd_bg_color: #2e3436;
 $osd_borders_color: rgba(0,0,0, 0.7);
 $osd_outer_borders_color: rgba(255,255,255, 0.1);
+$osd_insensitive_bg_color: mix($osd_fg_color, $osd_bg_color, 10%);
+$osd_insensitive_fg_color: if($variant == 'light', mix($osd_fg_color, $osd_bg_color, 80%),  mix($osd_fg_color, $osd_bg_color, 70%));
 
 $shadow_color: rgba(0,0,0, 0.1);
 $system_bg_color: desaturate(#241f31,100%); //neutralize the HIG color

--- a/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
@@ -20,7 +20,7 @@ $app_grid_fg_color: #fff;
 
 // Icon tiles in the app grid
 .app-well-app,
-%app-well-app {
+%app_well_app {
   @include overview-icon($app_grid_fg_color);
 
   .overview-icon.overview-icon-with-label {
@@ -52,7 +52,7 @@ $app_grid_fg_color: #fff;
     & .folder-name-label,
     & .folder-name-entry {
       font-size: 18pt;
-      font-weight: 800;
+      font-weight: 1000;
       color: $osd_fg_color; // Yaru change: needed for light theme, otherwise invisible text
     }
     // Yaru change: needed for the light theme, otherwise dark text in orange selection, can't set selected-color here
@@ -62,14 +62,17 @@ $app_grid_fg_color: #fff;
     & .folder-name-label { padding: 5px 7px; color: $osd_fg_color; }
 
     & .edit-folder-button {
-      @extend %button;
-
+      @include button(undecorated, $shadow: none);
       padding: 0;
       width: 36px;
       height: 36px;
       border-radius: 18px;
 
-      & > StIcon { icon-size: 16px }
+      &:focus {@include button(focus);}
+      &:hover {@include button(hover);}
+      &:active {@include button(active);}
+
+      & > StIcon { icon-size: $base_icon_size }
     }
   }
 
@@ -86,8 +89,9 @@ $app_grid_fg_color: #fff;
     margin-bottom: 18px;
   }
 }
+
 .app-folder-dialog-container {
-  padding: 12px;
+  padding: $base_padding*2;
   width: 620px;
   height: 620px;
 }
@@ -98,7 +102,7 @@ $app_grid_fg_color: #fff;
   width: 5px;
   border-radius:5px;
   background-color: $selected_bg_color; // Yaru: we want an orange dot
-  margin-bottom: 1px;
+  margin-bottom: 2px;
 }
 
 // Rename popup for app folders

--- a/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
@@ -1,14 +1,5 @@
 /* Date/Time Menu */
 
-.clock-display-box {
-  spacing: 2px;
-
-  .clock {
-    padding-left: $base_padding * 2;
-    padding-right: $base_padding * 2;
-  }
-}
-
 // overall menu
 #calendarArea {
   padding:0;
@@ -17,11 +8,13 @@
 // Calendar menu side column
 .datemenu-calendar-column {
   spacing: $base_spacing;
-  border: 0 solid if($variant=='light', $bubble_borders_color, darken($bubble_borders_color, 5%));  // Yaru: Dark shell theme: tone down calendar separator
-  padding: 0 $base_padding * 2;
+  border: none;
+  border-style: solid;
+  border-color: $borders_color;
+  padding: 0;
 
-  &:ltr {margin-right: $base_margin * 2; border-left-width: 1px; }
-  &:rtl {margin-left: $base_margin * 2; border-right-width: 1px; }
+  &:ltr {margin-right: 0; margin-left: $base_margin; padding-left: $base_padding; border-left-width: 1px; }
+  &:rtl {margin-left: 0; margin-right: $base_margin; padding-right: $base_padding; border-right-width: 1px; }
 
   .datemenu-displays-section {
   }
@@ -33,7 +26,7 @@
 
 .events-section-title {
   @include notification_bubble($flat: true);
-  color: desaturate(darken($fg_color,40%), 10%);
+  color: $insensitive_fg_color;
   font-weight: bold;
   padding: .4em;
 }
@@ -66,7 +59,6 @@
     color: lighten($fg_color,5%);
     font-weight: bold;
     padding: 8px 0;
-    &:focus {}
   }
 
   // prev/next month icons
@@ -79,24 +71,24 @@
     background-color: transparent;
     height: 32px;
     width: 32px;
-    border-radius: $base_border_radius;
-    &:hover, &:focus { background-color: lighten($hover_bg_color, 5%); }
+    border-radius: $base_border_radius - 2px;
+    &:hover, &:focus { background-color: $hover_bg_color; }
     &:active { background-color: $active_bg_color; }
   }
-
 
   $calendar_day_size: 32px;
 
   .calendar-day-base {
     @include fontsize($base_font_size - 3);
     text-align: center;
-    width: $calendar_day_size;
-    height: $calendar_day_size;
     padding: 0;
     margin: 2px;
+    width: $calendar_day_size;
+    height: $calendar_day_size;
     border-radius: $calendar_day_size * 0.5 + 2px;
     border: 1px solid transparent; //avoid jumparound due to today
     font-feature-settings: "tnum";
+
     &:hover, &:focus { background-color: $hover_bg_color; }
     &:active,&:selected {
       color: lighten($fg_color,10%);
@@ -123,7 +115,8 @@
     border-left-width: 1px;
   }
 
-  .calendar-work-day {}
+  .calendar-work-day {
+  }
 
   .calendar-nonwork-day {
     color: $insensitive_fg_color;
@@ -131,37 +124,38 @@
 
   // Today
   .calendar-today {
-    font-weight: bold;
-    border: 1px solid transparent;
     background-color: $selected_bg_color;
-    color: $selected_fg_color;
+    border: 1px solid transparent;
+    font-weight: bold;
+    color: $selected_fg_color !important;
 
     &:hover,&:focus {
       background-color:lighten($selected_bg_color, 3%);
-      color: $selected_fg_color;
+      color: inherit;
     }
 
     &:active,&:selected {
       background-color: $selected_bg_color;
-      color: $selected_fg_color;
+      color: inherit;
 
       &:hover,&:focus {
         background-color:lighten($selected_bg_color, 3%);
-        color: $selected_fg_color;
+        color: inherit;
       }
     }
   }
 
   .calendar-day-with-events {
-    background-image: url("resource:///org/gnome/shell/theme/calendar-today.svg");
-    &.calendar-work-day:not(.calendar-other-month-day) {  // Yaru: calendar-other-month-day color shall not change if the day has an event
-       color: lighten($fg_color,10%);
-       font-weight: bold;
+    background-image: if($variant == 'light', url("resource:///org/gnome/shell/theme/calendar-today.svg"), url("resource:///org/gnome/shell/theme/calendar-today-dark.svg"));
+    background-size: contain;
+    &.calendar-work-day {
+      color: lighten($fg_color,10%);
+      font-weight: bold;
     }
   }
 
   .calendar-other-month-day {
-    color: transparentize($fg_color ,0.5);
+    color: transparentize($fg_color ,0.5) !important;
   }
 
   .calendar-week-number {
@@ -190,13 +184,13 @@
   }
 
   .events-title {
-    color: desaturate(darken($fg_color,40%), 10%);
+    color: $insensitive_fg_color;
     font-weight: bold;
     margin-bottom: $base_margin;
   }
 
   .event-time {
-    color: darken($fg_color,20%);
+    color: $insensitive_fg_color;
     font-feature-settings: "tnum";
     @include fontsize($base_font_size - 1);
   }
@@ -214,7 +208,7 @@
 
   // title
   .world-clocks-header {
-    color: desaturate(darken($fg_color,40%), 10%);
+    color: $insensitive_fg_color;
     font-weight: bold;
   }
 
@@ -238,7 +232,7 @@
 
   // timezone offset label
   .world-clocks-timezone {
-    color: darken($fg_color,20%);
+    color: $insensitive_fg_color;
     font-feature-settings: "tnum";
     @include fontsize($base_font_size - 1);
   }
@@ -258,7 +252,7 @@
   }
 
   .weather-header {
-    color: desaturate(darken($fg_color,40%), 10%);
+    color: $insensitive_fg_color;
     font-weight: bold;
 
     &.location {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
@@ -1,18 +1,16 @@
 /* Dash */
 
-//$dash_background_color: #3b3b3b; // Yaru: we define those colors in _colors.scss for _dock.scss to use it
+//$dash_background_color: lighten($system_bg_color, 5%); // Yaru: we define those colors in _colors.scss for _dock.scss to use it
 $dash_placeholder_size: 32px;
 $dash_padding: $base_padding + 4px; // 10px
 $dash_spacing: $base_padding / 4;
-
 $dash_bottom_margin: $base_margin * 4;
-
-$dash_border_radius: $modal_radius * 1.5;
+$dash_border_radius: $modal_radius + 8px;
 
 #dash {
   @include fontsize($base_font_size - 2);
-  margin-top: $base_spacing * 3;
-  padding: 0 $dash_padding;
+  margin-top: $base_margin * 3;
+  padding: $dash_padding;
 
   .placeholder {
     // background-image: url("resource:///org/gnome/shell/theme/dash-placeholder.svg");
@@ -26,28 +24,51 @@ $dash_border_radius: $modal_radius * 1.5;
     height: $dash_placeholder_size;
   }
 
+  // icon on the dash
   .overview-icon {
-    padding: $dash_padding / 2;
+    padding: $base_padding+2px;
+  }
+
+  // Running app indicator (also shown in app grid)
+  .app-well-app-running-dot {
+    height: 5px;
+    width: 5px;
+    border-radius:5px;
+    background-color: $osd_fg_color;
+    margin-bottom: 12px;
   }
 }
 
 .dash-background {
   background-color: $dash_background_color;
-  margin-bottom: $dash_bottom_margin;
-  padding: $dash_padding;
   border-radius: $dash_border_radius;
+  margin-bottom: 0; // this keeps things vertically centered
+  padding: $dash_padding;
   border: 1px solid $borders_color_dark; // Yaru: add border
 }
 
-// Dash Items
-.dash-item-container .app-well-app, .show-apps {
-  padding: $dash_padding $dash_spacing $dash_padding + $dash_bottom_margin;
+// items on the dash
+.dash-item-container {
+
+  // each app item on the dash
+  .app-well-app {
+    padding:0;
+    margin: 2px;
+  }
+
+  // show apps button
+  .show-apps {
+    @include overview_icon($osd_fg_color);
+    margin: 2px;
+    padding: 0;
+  }
 }
 
+// separator between favourites and running apps
 .dash-separator {
   width: 1px;
-  margin: 0 ($dash_spacing + ($dash_padding / 2)) $dash_bottom_margin;
-  background-color: transparentize($osd_fg_color,0.7);
+  margin: 0 $base_margin*2;
+  background-color: transparentize($borders_color,0.5);
 }
 
 // OSD Tooltip
@@ -57,18 +78,5 @@ $dash_border_radius: $modal_radius * 1.5;
   border-radius: 99px;
   padding: $base_padding $base_padding * 2;
   text-align: center;
-  -y-offset: $base_margin * 3; // distance from the dash edge
-}
-
-// Show apps button
-.show-apps {
-  @include overview-icon($osd_fg_color);
-
-  &:focus,
-  &:checked {
-    .overview-icon { // Yaru: we want the app grid icon to feel like everything else on the dock
-      // background-color: darken($osd_bg_color,10%);
-      color: $osd_fg_color;
-    }
-  }
+  -y-offset: $base_margin * 2; // distance from the dash edge
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
@@ -34,7 +34,7 @@ $dash_border_radius: $modal_radius + 8px;
     height: 5px;
     width: 5px;
     border-radius:5px;
-    background-color: $osd_fg_color;
+    background-color: $selected_bg_color; // Yaru: we want an orange dot
     margin-bottom: 12px;
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
@@ -5,7 +5,6 @@
 }
 
 .modal-dialog {
-  border-radius: $modal_radius;
   @extend %bubble_panel;
 
   .modal-dialog-content-box {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_keyboard.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_keyboard.scss
@@ -1,7 +1,7 @@
 /* On-screen Keyboard */
 
 $key_size: 1.2em;
-$key_border_radius: $base_border_radius + 3px;
+$key_border_radius: $base_border_radius + 4px; // 12px
 $key_bg_color: if(variant=='light', $bg_color, darken($bg_color, 1%)); // Yaru: Make keyboard buttons work on both variants
 $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on both variants
 // $default_key_bg_color: if($variant=='light', darken($osd_bg_color, 11%), lighten($osd_bg_color, 2%));
@@ -9,7 +9,8 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
 
 // draw keys using button function
 #keyboard { // Yaru: Make keyboard work on both variants
-  background-color: if($variant=='light', transparentize(darken($bg_color, 5%), 0.1), $base_color);
+  // background-color: transparentize(if($variant=='light', darken($bg_color, 5%), darken($bg_color, 8%)), 0.1);
+  background-color: $osd_bg_color;
   // box-shadow: inset 0 1px 0 0 $osd_outer_borders_color;
 
   .page-indicator {
@@ -31,13 +32,14 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
 // the keys
 .keyboard-key {
 
-  @include button(normal, $c:$key_bg_color);
+  @include button(normal, $c:$key_bg_color, $tc:$osd_fg_color);
 
   &:focus { @include button(focus);}
-  &:hover, &:checked { @include button(hover, $c: $key_bg_color);}
-  &:active { @include button(active, $c: $key_bg_color); }
+  &:hover, &:checked { @include button(hover, $c: $key_bg_color, $tc:$osd_fg_color);}
+  &:active { @include button(active, $c: $key_bg_color, $tc:$osd_fg_color); }
 
   @include fontsize($base_font_size + 5);
+  font-weight: bold;
   min-height: $key_size;
   min-width: $key_size;
   border-width: 1px;
@@ -52,42 +54,56 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
 
   // non-character keys
   &.default-key {
-    @include button(normal, $c:$default_key_bg_color);
-    &:hover, &:checked {@include button(hover, $c: $default_key_bg_color);}
-    &:active { @include button(active, $c: $default_key_bg_color);}
+    @include button(normal, $c:$default_key_bg_color, $tc:$osd_fg_color);
+    &:hover, &:checked {@include button(hover, $c: $default_key_bg_color, $tc:$osd_fg_color);}
+    &:active { @include button(active, $c: $default_key_bg_color, $tc:$osd_fg_color);}
+    border-radius: $key_border_radius;
   }
 
   // enter key is suggested-action
   &.enter-key { // Yaru: our suggested action color is green
     @include button(normal, $c:$suggested_bg_color, $tc:$selected_fg_color);
-    &:hover, &:checked { @include button(hover, $c: lighten($suggested_bg_color, 3%));}
-    &:active {@include button(active, $c: darken($suggested_bg_color, 2%));}
+    &:hover, &:checked { @include button(hover, $c: lighten($suggested_bg_color, 3%), $tc:$selected_fg_color);}
+    &:active {@include button(active, $c: darken($suggested_bg_color, 2%), $tc:$selected_fg_color);}
+    border-radius: $key_border_radius;
+    color: $osd_fg_color;
   }
 
-  &.shift-key-uppercase { &, &:hover { color: $suggested_bg_color } } // Yaru: our suggested action color is green
+  &.shift-key-lowercase {}
+  
+  // pressed shift has different style
+  &.shift-key-uppercase { 
+    background-color: lighten($key_bg_color, 20%);
+    color: $osd_bg_color;
+    &:hover {
+      background-color: lighten($key_bg_color, 25%);
+      color: lighten($osd_bg_color, 5%);
+    }
+  }
 
-  StIcon { icon-size: 1.125em; }
+  // size of icons on keys
+  StIcon { icon-size: 24px; }
 }
 
 // long press on a key popup
 .keyboard-subkeys { // Yaru: Make keyboard popups work on both variants
-  color: $osd_fg_color;
-  -arrow-border-radius: $modal_radius;
+  -arrow-border-radius: $base_border_radius*2;
   -arrow-background-color: transparentize(if($variant=='light', darken($bg_color, 5%), darken($bg_color, 8%)), 0.1);
   -arrow-border-width: 1px;
   -arrow-border-color: $borders_color;
   -arrow-base: 20px;
   -arrow-rise: 10px;
   -boxpointer-gap: $base_spacing;
+  padding: $base_padding;
 
   .keyboard-key {
-    @include button(normal, $c:$key_bg_color);
+    @include button(normal, $c:$key_bg_color, $tc:$osd_fg_color);
 
     &:focus { @include button(focus);}
-    &:hover, &:checked { @include button(hover, $c: $key_bg_color);}
-    &:active { @include button(active, $c: $key_bg_color); }
+    &:hover, &:checked { @include button(hover, $c: $key_bg_color, $tc:$osd_fg_color);}
+    &:active { @include button(active, $c: $key_bg_color, $tc:$osd_fg_color); }
 
-    border-radius:$base_border_radius;
+    border-radius:$key_border_radius;
   }
 }
 
@@ -112,4 +128,20 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
   @include fontsize($base_font_size + 3);
   spacing: 12px;
   min-height: 20pt;
+  padding: $base_padding*2;
+  color: $osd_fg_color;
+
+  // each suggestion
+  StButton {
+    margin: 0 3px;
+    min-width: 32px;
+    border-radius: $base_border_radius - 2px;
+    padding: $base_padding $base_padding*3;
+
+    @include button(undecorated, $c:$key_bg_color, $tc:$osd_fg_color);
+
+    &:focus { @include button(focus);}
+    &:hover, &:checked { @include button(hover, $c: $key_bg_color, $tc:$osd_fg_color);}
+    &:active { @include button(active, $c: $key_bg_color, $tc:$osd_fg_color); }
+  }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_keyboard.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_keyboard.scss
@@ -9,8 +9,8 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
 
 // draw keys using button function
 #keyboard { // Yaru: Make keyboard work on both variants
-  // background-color: transparentize(if($variant=='light', darken($bg_color, 5%), darken($bg_color, 8%)), 0.1);
-  background-color: $osd_bg_color;
+  background-color: transparentize(if($variant=='light', darken($bg_color, 5%), darken($bg_color, 8%)), 0.1);
+  // background-color: $osd_bg_color;
   // box-shadow: inset 0 1px 0 0 $osd_outer_borders_color;
 
   .page-indicator {
@@ -32,11 +32,11 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
 // the keys
 .keyboard-key {
 
-  @include button(normal, $c:$key_bg_color, $tc:$osd_fg_color);
+  @include button(normal, $c:$key_bg_color); // Yaru: make keyboard work on both variants
 
   &:focus { @include button(focus);}
-  &:hover, &:checked { @include button(hover, $c: $key_bg_color, $tc:$osd_fg_color);}
-  &:active { @include button(active, $c: $key_bg_color, $tc:$osd_fg_color); }
+  &:hover, &:checked { @include button(hover, $c: $key_bg_color);} // Yaru: make keyboard work on both variants
+  &:active { @include button(active, $c: $key_bg_color); } // Yaru: make keyboard work on both variants
 
   @include fontsize($base_font_size + 5);
   font-weight: bold;
@@ -54,9 +54,9 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
 
   // non-character keys
   &.default-key {
-    @include button(normal, $c:$default_key_bg_color, $tc:$osd_fg_color);
-    &:hover, &:checked {@include button(hover, $c: $default_key_bg_color, $tc:$osd_fg_color);}
-    &:active { @include button(active, $c: $default_key_bg_color, $tc:$osd_fg_color);}
+    @include button(normal, $c:$default_key_bg_color); // Yaru: make keyboard work on both variants
+    &:hover, &:checked {@include button(hover, $c: $default_key_bg_color);} // Yaru: make keyboard work on both variants
+    &:active { @include button(active, $c: $default_key_bg_color);} // Yaru: make keyboard work on both variants
     border-radius: $key_border_radius;
   }
 
@@ -97,11 +97,11 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
   padding: $base_padding;
 
   .keyboard-key {
-    @include button(normal, $c:$key_bg_color, $tc:$osd_fg_color);
+    @include button(normal, $c:$key_bg_color); // Yaru: make keyboard work on both variants
 
     &:focus { @include button(focus);}
-    &:hover, &:checked { @include button(hover, $c: $key_bg_color, $tc:$osd_fg_color);}
-    &:active { @include button(active, $c: $key_bg_color, $tc:$osd_fg_color); }
+    &:hover, &:checked { @include button(hover, $c: $key_bg_color);} // Yaru: make keyboard work on both variants
+    &:active { @include button(active, $c: $key_bg_color); } // Yaru: make keyboard work on both variants
 
     border-radius:$key_border_radius;
   }
@@ -138,10 +138,10 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
     border-radius: $base_border_radius - 2px;
     padding: $base_padding $base_padding*3;
 
-    @include button(undecorated, $c:$key_bg_color, $tc:$osd_fg_color);
+    @include button(undecorated, $c:$key_bg_color); // Yaru: make keyboard work on both variants
 
     &:focus { @include button(focus);}
-    &:hover, &:checked { @include button(hover, $c: $key_bg_color, $tc:$osd_fg_color);}
-    &:active { @include button(active, $c: $key_bg_color, $tc:$osd_fg_color); }
+    &:hover, &:checked { @include button(hover, $c: $key_bg_color);} // Yaru: make keyboard work on both variants
+    &:active { @include button(active, $c: $key_bg_color); } // Yaru: make keyboard work on both variants
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_looking-glass.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_looking-glass.scss
@@ -1,43 +1,52 @@
 /* Looking Glass */
 
-$text_fg_color: #ccc;
-
 // Dialog
 #LookingGlassDialog {
   background-color: $osd_bg_color;
-  spacing: $base_spacing;
-  padding: 4px;
-  border: 1px solid transparentize($osd_fg_color, 0.8);
-  border-radius: $base_border_radius;
+  border-radius: 0 0 $base_border_radius $base_border_radius;
+  border-top-width: 0;
+  border: 1px solid $osd_outer_borders_color;
   color: $osd_fg_color;
+  padding: $base_padding;
+  spacing: $base_spacing;
 
   & > #Toolbar {
     border: none;
-    border-radius: $base_border_radius;
-    background-color: $osd_bg_color;
+    padding: $base_padding;
+    border-radius: 0;
+    background-color: transparent;
   }
 
-  .labels { spacing: $base_spacing; }
+  .labels { 
+    spacing: $base_spacing;
+  }
+
   .notebook-tab {
-    -natural-hpadding: $base_padding * 2;
-    -minimum-hpadding: 6px;
+    -natural-hpadding: $base_padding*2;
+    -minimum-hpadding: $base_padding*2;
+
     font-weight: bold;
+    padding: $base_padding $base_padding*2;
     color: darken($osd_fg_color, 15%);
     transition-duration: 100ms;
-    padding-left: .3em;
-    padding-right: .3em;
-    border-bottom-width: 2px;
+    box-shadow:none;
+    border:none;
+    border-radius: $base_border_radius - 2px;
+    background-color: transparent;
+
     &:hover {
       color: $osd_fg_color;
+      background-color: transparentize($osd_fg_color, 0.95);
     }
+
     &:selected {
-      border-bottom-width: 2px;
-      box-shadow: inset 0 -2px 0 0 lighten($selected_bg_color, 5%);
       color: $osd_fg_color;
+      background-color: transparentize($osd_fg_color, 0.9);
     }
   }
-  StBoxLayout#EvalBox { padding: 4px; spacing: $base_spacing; }
-  StBoxLayout#ResultsArea { spacing: $base_spacing; }
+
+  StBoxLayout#EvalBox { padding: 4px; spacing: $base_spacing; padding: $base_padding; }
+  StBoxLayout#ResultsArea { spacing: $base_spacing; padding: $base_padding; }
 }
 
 .lg-dialog {
@@ -50,58 +59,58 @@ $text_fg_color: #ccc;
     selection-background-color: $selected_bg_color;
     selected-color: $selected_fg_color;
   }
+
   .shell-link {
     color: $link_color;
     &:hover { color: lighten($link_color, 10%); }
     &:active { color: darken($link_color, 10%); }
    }
+
   .actor-link {
-    color: $text_fg_color;
-    &:hover { color: lighten($text_fg_color, 20%); }
-    &:active { color: darken($text_fg_color, 20%); }
+    color: $insensitive_fg_color;
+    &:hover { color: lighten($insensitive_fg_color, 20%); }
+    &:active { color: darken($insensitive_fg_color, 20%); }
    }
 }
 
 .lg-completions-text {
-    font-size: .9em;
-    font-style: italic;
-    color: $osd_fg_color; // Yaru: needed for the light theme
+  font-size: .9em;
+  font-style: italic;
+  color: $osd_fg_color; // Yaru: needed for the light theme
 }
 
 .lg-obj-inspector-title {
-    spacing: $base_spacing;
-    color: $osd_fg_color; // Yaru: needed for the light theme
+  spacing: $base_spacing;
+  color: $osd_fg_color; // Yaru: needed for the light theme
 }
 
 .lg-obj-inspector-button {
-    border: 1px solid $osd_borders_color;
-    padding: 4px;
-    border-radius: $base_border_radius;
-    &:hover { border: 1px solid #ffffff; }
-    color: $osd_fg_color; // Yaru: needed for the light theme
+  border: 1px solid $osd_borders_color;
+  padding: 4px;
+  border-radius: $base_border_radius;
+  &:hover { border: 1px solid #ffffff; }
+  color: $osd_fg_color; // Yaru: needed for the light theme
 }
 
 // Extensions
-#lookingGlassExtensions { padding: 4px; }
+#lookingGlassExtensions { padding: $base_padding; }
 
 .lg-extensions-list {
-    padding: 4px;
-    spacing: 6px;
+  padding: $base_padding;
+  spacing: $base_spacing;
 }
 
 .lg-extension {
-    border: 1px solid lighten($osd_borders_color, 5%);
-    background-color: lighten($osd_bg_color, 5%);
-    border-radius: $base_border_radius;
-    padding: 4px;
+  padding: $base_padding*2;
+  @include notification_bubble;
 }
 
 .lg-extension-name {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .lg-extension-meta {
-    spacing: 6px;
+  spacing: $base_spacing;
 }
 
 // Inspector
@@ -109,19 +118,20 @@ $text_fg_color: #ccc;
   background: $osd_bg_color;
   border: 1px solid $osd_borders_color;
   border-radius: $base_border_radius;
-  padding: 6px;
+  padding: $base_padding;
 }
 
 .lg-debug-flag-button {
   StLabel { padding: $base_spacing, 2 * $base_spacing; }
 
-  color: $text_fg_color;
-  &:hover { color: lighten($text_fg_color, 20%); }
-  &:active { color: darken($text_fg_color, 20%); }
+  color: $fg_color;
+  &:hover { color: lighten($fg_color, 20%); }
+  &:active { color: darken($fg_color, 20%); }
 }
 
 .lg-debug-flags-header {
   padding-top: 2 * $base_spacing;
   font-size: 120%;
   font-weight: bold;
+  padding: $base_padding;
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_message-list.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_message-list.scss
@@ -3,15 +3,32 @@
 
 // main list
 .message-list {
-  width: 31.5em;
-  padding: 0 $base_padding * 2;
+  width: 32em;
+  padding: 0;
 
-  .message-list-placeholder { spacing: 12px; }
+  .message-list-placeholder { 
+    font-weight:1000; 
+    font-size: 18pt;
+    color: transparentize($fg_color, 0.7);
+    spacing: 12px;
+
+    // icon size and color
+    > StIcon {
+      icon-size: $base_icon_size*4; // 32px
+      -st-icon-style: symbolic;
+    }
+  }
 }
+
 
 .message-list-sections {
   spacing: $base_spacing;
-  margin: 0 $base_margin * 4; // to account for scrollbar
+  margin: 0; 
+  padding-bottom: $base_padding;
+
+  // to account for scrollbar
+  &:ltr {margin-right: $base_margin * 4; }
+  &:rtl {margin-left: $base_margin * 4;}
 }
 
 .message-list-section,
@@ -21,10 +38,10 @@
 
 // do-not-disturb + clear button
 .message-list-controls {
-  margin: ($base_margin * 2) ($base_margin * 4) 0;
   // NOTE: remove the padding if notification_bubble could remove margin for drop shadow
-  padding: $base_margin;
-  spacing: $base_spacing * 2;
+  padding: $base_padding;
+  margin: 0;
+  spacing: $base_spacing;
 
   .dnd-button {
     // We need this because the focus outline isn't inset like for the buttons
@@ -32,7 +49,7 @@
     // its color when focusing.
     border-width: 2px;
     border-color: transparent;
-    border-radius: 99px;
+    border-radius: 32px;
     border-style: solid;
 
     &:focus {
@@ -47,10 +64,11 @@
 
   // icon container
   .message-icon-bin {
-    padding: ($base_padding * 3) 0 ($base_padding * 3) ($base_padding * 2);
+    padding: ($base_padding * 3);
+    padding-right:$base_padding;
 
     &:rtl {
-      padding: ($base_padding * 3) ($base_padding * 2) ($base_padding * 3) 0;
+      padding-right:$base_padding;
     }
 
     // icon size and color
@@ -68,13 +86,16 @@
 
   // content
   .message-content {
-    padding: $base_padding + $base_margin * 2;
     spacing: 4px;
+    padding: ($base_padding*1.5);
+    margin-bottom: $base_margin*2;
   }
 
   // title
   .message-title {
     font-weight: bold;
+    /* HACK: the label should be baseline-aligned with a 1em label, fake this with some bottom padding */
+    padding-top: 0.57em;
   }
 
   // secondary container in title box
@@ -95,9 +116,17 @@
 
   // close button
   .message-close-button {
-    color: lighten($fg_color, 15%);
-    &:hover { color: if($variant=='light', lighten($fg_color, 30%), darken($fg_color, 10%)); }
-    &:active { color: if($variant=='light', lighten($fg_color, 40%), darken($fg_color, 20%)); }
+    color: $fg_color;
+    background-color: transparentize($fg_color, 0.9);
+    border-radius: 99px;
+    padding: $base_padding;
+    margin: 0;
+    &:hover { 
+      background-color: transparentize($fg_color, 0.8);
+    }
+    &:active {
+      background-color: transparentize($fg_color, 0.9);
+    }
   }
 
   // body
@@ -113,10 +142,12 @@
 
 /* Media Controls */
 .message-media-control {
-  padding: $base_padding * 2 1.64em; // $base_padding * 4 = 24px
-  color: darken($fg_color, 15%);
+  padding: 0 $base_padding*2;
+  margin: $base_padding*2 0;
+  border-radius: $base_border_radius;
+  color: $fg_color;
 
-  // uses $hover_bg_color since the media controls are in a notification_bubble
+  // colors are lightened since the media controls are in a notification_bubble
   &:hover {
     background-color: lighten($hover_bg_color, 5%);
     color: $fg_color;
@@ -127,16 +158,16 @@
     color: $fg_color;
   }
 
-  &:insensitive { color: darken($fg_color,40%); }
+  &:insensitive { color: lighten($insensitive_fg_color, 5%); }
   
   // fix border-radius for last button
-  &:last-child:ltr { border-radius: 0 $base_border_radius+2 $base_border_radius+2 0; }
-  &:last-child:rtl { border-radius: $base_border_radius+2 0 0 $base_border_radius+2; }
+  &:last-child:ltr { margin-right: $base_margin*3; }
+  &:last-child:rtl { margin-left: $base_margin*3; }
 }
 
 // album-art
 .media-message-cover-icon {
-  icon-size: $base_icon_size*2 !important; // 48px
+  icon-size: $base_icon_size*3 !important; // 48px
   border-radius: $base_border_radius;
 
   // when there is no artwork
@@ -145,6 +176,7 @@
     background-color: $bg_color;
     border: 1px solid transparent;
     border-radius: $base_border_radius;
-    icon-size: $base_icon_size * 2 !important;
+    icon-size: $base_icon_size * 2 !important; // 32px
+    padding: ($base_padding*2 + 2); // 16px
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_network-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_network-dialog.scss
@@ -23,27 +23,50 @@
 .nm-dialog-header {
   font-weight: bold;
 }
+.nm-dialog-subheader {
+  color: $insensitive_fg_color;
+}
+
 .nm-dialog-header-icon {
   icon-size: $base_icon_size * 2;
 }
 .nm-dialog-header-hbox { spacing: 10px; }
 
+// airplane mode
+.nm-dialog-airplane-headline {
+  font-weight: bold;
+}
+
+.nm-dialog-airplane-text {
+  color: $insensitive_fg_color;
+}
+
 // list of networks
 .nm-dialog-scroll-view {
-  border: 1px solid $borders_color;
-  padding:0;
+  border: none;
+  padding:$base_padding;
+  border-radius: $base_border_radius;
   background-color: darken($bg_color, 3%);
 }
 
 // list item
 .nm-dialog-item {
   @include fontsize($base_font_size);
-  border-bottom: 1px solid $borders_color;
+  border: none;
   padding: $base_padding * 2;
   spacing: 0px;
+  text-shadow: none;
+  icon-shadow: none;
+
   &:selected {
     background-color: $selected_bg_color;
     color: $selected_fg_color;
+
+    border-radius: $base_border_radius - 3px;
+  }
+
+  &:hover {
+    background-color:$hover_bg_color;
   }
 }
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_notifications.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_notifications.scss
@@ -2,11 +2,18 @@
 
 $notification_banner_height: 64px;
 $notification_banner_width: 34em;
+$notification_banner_radius: $base_border_radius*1.5;
+
+// make radius of buttons fit in bubble corner (banner radius - width of focus ring)
+$notification_button_radius: ($notification_banner_radius - 2px);
 
 // Banner notifications
 .notification-banner {
   min-height: $notification_banner_height;
   width: $notification_banner_width;
+  box-shadow: 0 2px 4px 2px rgba(0,0,0,0.1);
+  border-radius: $notification_banner_radius;
+  margin: $base_margin;
 
   .notification-actions {
     spacing: 0;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -53,8 +53,8 @@ $panel_transition_duration: 250ms; // same as the overview transition duration
       }
     }
 
-    &:hover, &:active, &:overview, &:focus, &:checked {
-      box-shadow: inset 0 0 0 100px rgba(255, 255, 255, 0.15); // Yaru change: downcrease hover background intensity
+    &:active, &:overview, &:focus, &:checked {
+      box-shadow: inset 0 0 0 100px transparentize($panel_fg_color, 0.8);
 
       // The clock display needs to have the background on .clock because
       // we want to exclude the do-not-disturb indicator from the background
@@ -62,7 +62,27 @@ $panel_transition_duration: 250ms; // same as the overview transition duration
         box-shadow: none;
 
         .clock {
-          box-shadow: inset 0 0 0 100px rgba(255, 255, 255, 0.15); // Yaru change: downcrease hover background intensity
+          box-shadow: inset 0 0 0 100px transparentize($panel_fg_color, 0.8);
+        }
+      }
+    }
+
+    &:hover {
+      box-shadow: inset 0 0 0 100px transparentize($panel_fg_color, 0.85);
+      &.clock-display {
+        box-shadow: none;
+        .clock {
+          box-shadow: inset 0 0 0 100px transparentize($panel_fg_color, 0.85);
+        }
+      }
+    }
+    
+    &:active:hover, &:overview:hover, &:focus:hover, &:checked:hover {
+      box-shadow: inset 0 0 0 100px transparentize($panel_fg_color, 0.75);
+      &.clock-display {
+        box-shadow: none;
+        .clock {
+          box-shadow: inset 0 0 0 100px transparentize($panel_fg_color, 0.75);
         }
       }
     }
@@ -94,14 +114,34 @@ $panel_transition_duration: 250ms; // same as the overview transition duration
   &.login-screen,
   &:overview {
     .panel-button {
-      &:hover, &:active, &:overview, &:focus, &:checked {
-        box-shadow: inset 0 0 0 100px rgba(255, 255, 255, 0.15);
+      &:active, &:overview, &:focus, &:checked {
+        box-shadow: inset 0 0 0 100px rgba(255,255,255, 0.15);
 
         &.clock-display {
           box-shadow: none;
 
           .clock {
-            box-shadow: inset 0 0 0 100px rgba(255, 255, 255, 0.15);
+            box-shadow: inset 0 0 0 100px rgba(255,255,255, 0.15);
+          }
+        }
+      }
+
+      &:hover {
+        box-shadow: inset 0 0 0 100px rgba(255,255,255, 0.10);
+        &.clock-display {
+          box-shadow: none;
+          .clock {
+            box-shadow: inset 0 0 0 100px rgba(255,255,255, 0.10);
+          }
+        }
+      }
+      
+      &:active:hover, &:overview:hover, &:focus:hover, &:checked:hover {
+        box-shadow: inset 0 0 0 100px rgba(255,255,255, 0.2);
+        &.clock-display {
+          box-shadow: none;
+          .clock {
+            box-shadow: inset 0 0 0 100px rgba(255,255,255, 0.2);
           }
         }
       }
@@ -132,4 +172,16 @@ $panel_transition_duration: 250ms; // same as the overview transition duration
 #appMenu .panel-status-menu-box {
   padding: 0 $base_padding;
   spacing: $base_spacing;
+}
+
+
+// Clock
+
+.clock-display-box {
+  spacing: 2px;
+
+  .clock {
+    padding-left: $base_padding * 2;
+    padding-right: $base_padding * 2;
+  }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
@@ -1,16 +1,15 @@
 /* Popovers/Menus */
 
-$popover_arrow_height: 12px;
-
-//.the popover itself
+// the popover itself
 .popup-menu-boxpointer {
-  -arrow-border-radius: $base_border_radius + 2; // Yaru: we have less round popovers
+  -arrow-border-radius: $modal_radius;
   -arrow-background-color: $bg_color;
-  -arrow-border-width: 1px;
   -arrow-border-color: if($variant=='light', transparentize(black, 0.65), $borders_color); // Yaru: we need a black-based border for the light theme
-  -arrow-base: $popover_arrow_height * 2;
-  -arrow-rise: $popover_arrow_height;
-  -arrow-box-shadow: 0 1px 3px rgba(0,0,0,0.5); // dreaming bugzilla #689995
+  -arrow-border-width: 1px;
+  -arrow-base: 24px;
+  -arrow-rise: 12px; 
+  -arrow-box-shadow: none; // dreaming bugzilla #689995
+  margin: $base_margin; // used as distance from the screen edge
 }
 
 // container of the popover menu
@@ -20,36 +19,74 @@ $popover_arrow_height: 12px;
 
   //.popup-status-menu-item { font-weight: normal;  color: pink; } //dunno what that is
   &.panel-menu {
-    -boxpointer-gap: $base_margin; // distance from the panel
-    margin-bottom: 1.75em;
+    -boxpointer-gap: $base_margin+2px; // distance from the panel
+    
+    // override popover styles for panel menus so
+    // we can draw a box shadow and no arrow
+    -arrow-border-radius: $modal_radius;
+    -arrow-background-color: transparent;
+    -arrow-border-color: transparent;
+    -arrow-border-width: 0;
+    -arrow-base: 0;
+    -arrow-rise: $base_margin; // use this as top margin
+    -arrow-box-shadow: none; // dreaming bugzilla #689995
+    
+    margin-bottom: 1.75em; // so it doesn't touch the bottom of the screen
+
+    // style the menu content instead
+    .popup-menu-content {
+      border-radius: $modal_radius;
+      border: 1px solid $borders_color; 
+      box-shadow: 0 2px 4px 0 rgba(0,0,0,0.1);
+      background-color: $bg_color;
+      padding: $base_padding * 2;
+    }
+
+    .popup-menu-item {}
   }
 }
 
+// popover content;
 .popup-menu-content {
-  padding: $base_padding * 2 + $base_margin 0;
+  padding: $base_padding;
 }
 
 // menu items
 .popup-menu-item {
-  spacing: $base_padding;
-  padding: $base_padding;
+  spacing: $base_spacing;
+  padding: $base_padding*2;
+  margin: 2px 0;
+  border-radius: $base_border_radius;
+  transition: 0.2s all ease;
 
   &:ltr { padding-right:1.75em; padding-left: 0; }
   &:rtl { padding-right: 0; padding-left:1.75em; }
 
-  &:checked { // Yaru: sub menus need to be more visible
-    background-color: $bg_color,;
-    box-shadow: none;
-  }
-
-  &.selected { // Yaru: we want shell popups to feeld like menus -> gray hover
+  &:hover {
     background-color: $hover_bg_color;
+  }
+
+  &:checked {
+    background-color: $hover_bg_color;
+    font-weight: bold;
+
+    margin-bottom: 0;
+    box-shadow: inset 0 -1px 0 0 darken($hover_bg_color, 5%);
+    border-radius: $base_border_radius $base_border_radius 0 0;
+    
+    &:hover {
+      background-color: darken($hover_bg_color, 4%);
+    }
+  }
+
+  &.selected {
+    background-color: transparentize($fg_color, if($variant=='light', 0.7, 0.9));
     color: $fg_color;
   }
 
-  &:active { // Yaru: we want shell popups to feeld like menus -> no orange
+  &:active { 
     background-color: $active_bg_color;
-    color: $fg_color;
+    color: $active_fg_color;
   }
 
   &:insensitive { color: transparentize($fg_color,0.5);}
@@ -59,27 +96,65 @@ $popover_arrow_height: 12px;
 .popup-inactive-menu-item {
   color: $fg_color;
 
-  &:insensitive { color: transparentize($fg_color,0.5); }
+  // "Open Windows" label
+  font-weight: bold;
+  font-size: smaller;
+
+  &:insensitive { color: $insensitive_fg_color; }
 }
 
 // symbolic icons in popover
 .popup-menu-arrow,
-.popup-menu-icon { icon-size: $base_icon_size; }
+.popup-menu-icon { 
+  margin: 0;
+  padding:0;
+  icon-size: 16px !important;
+}
+
+.popup-menu-arrow {
+  margin-right: $base_margin;
+}
 
 // popover submenus
 .popup-sub-menu {
-  background-color: darken($bg_color, 3%);
-  box-shadow: none;
-  border-top: 1px solid transparentize($borders_color, 0.2);
-  border-bottom: 1px solid transparentize($borders_color, 0.2);
+  background-color: $hover_bg_color;
+  border:none;
+  border-radius: 0 0 $base_border_radius $base_border_radius;
+  padding: 0;
+  margin-top: 0;
+  &:active {
+    background-color: transparent;
+  }
+
+  
+  
+  .popup-menu-ornament {
+    min-width: 14px !important;
+  }
+
+  .popup-menu-item {
+    margin: 0;
+    border-radius: 0;
+    padding: $base_padding*1.5 $base_padding*2;
+
+    &:last-child:hover{
+      border-radius: 0 0 $base_border_radius $base_border_radius;
+    }
+  }
+
+  .popup-separator-menu-item {
+    margin: 0;
+  }
 }
 
 // container for radio and check boxes
 .popup-menu-ornament {
   width: 1.2em;
+  font-weight: bold;
+  font-size: 1em;
 
-  &:ltr { text-align: right };
-  &:rtl { text-align: left };
+  &:ltr { text-align: right; };
+  &:rtl { text-align: left; };
 }
 
 // separator
@@ -89,13 +164,13 @@ $popover_arrow_height: 12px;
   .popup-separator-menu-item-separator {
     //-margin-horizontal: 24px;
     height: 1px; //not really the whole box
-    margin: 6px 64px;
+    margin: $base_margin 4em;
     background-color: lighten($borders_color, 2%);
+
     .popup-sub-menu & { //submenu separators
-      margin: 0 64px 0 32px;
-      @if $variant == 'dark' {
-        background-color: lighten($bg_color,10%);
-      }
+      margin: 0 4em 0 3em; // balance it in the middle
+      padding:0 !important;
+      background-color: darken($hover_bg_color, 5%);
     }
   }
 }
@@ -110,6 +185,14 @@ $popover_arrow_height: 12px;
 .aggregate-menu {
   min-width: 21em;
 
+  // this is unneeded in at the top-level this menu, hide it
+  .popup-menu-ornament {width:0;padding:0;spacing:0;margin:0;}
+
+  .popup-menu-item {
+    &:ltr { padding-left:$base_padding;padding-right:$base_padding*2; }
+    &:rtl { padding-right:$base_padding;padding-left:$base_padding*2; }
+  }
+
   // lock screen, shutdown, etc. buttons
   .popup-menu-icon { 
     padding:0;
@@ -120,11 +203,11 @@ $popover_arrow_height: 12px;
   .popup-sub-menu .popup-menu-item > :first-child {
     // account for icons in submenus with padding
     &:ltr {
-      padding-left: $base_padding + $base_margin * 2; 
+      padding-left: 0;
       margin-left: $base_icon_size;
     }
     &:rtl {
-      padding-right: $base_padding + $base_margin * 2; ;
+      padding-right: 0;
       margin-right: $base_icon_size;
     }
   }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
@@ -5,29 +5,29 @@ $search_entry_height: 36px;
 
 %search_entry,
 .search-entry {
-  width: $search_entry_width;
-  padding: $base_padding+1 $base_padding+3;
-  border-radius: $search_entry_height * 0.5; // half the height
-  color: transparentize($fg_color,0.3);
-  background-color: if($variant == 'light', $bg_color, $dash_background_color); // Yaru: use same background as dash for dark theme
-  margin-top: $base_spacing * 4; // Yaru change: increase margin-top due to fixed panel opacity
-  margin-bottom: $base_spacing;
+  background-color: if($variant == 'light', lighten($bg_color, 5%), $dash_background_color); // Yaru: use same background as dash for dark theme
   // Yaru: we want bordered entries
   // border-width: 2px;
   // border-color: transparent;
   border-color: $borders_color;
-
+  border-radius: $search_entry_height * 0.5; // half the height
+  color: transparentize($fg_color,0.3);
+  margin-top: $base_spacing * 4; // Yaru change: increase margin-top due to fixed panel opacity
+  margin-bottom: $base_spacing;
+  padding: $base_padding+1 $base_padding+3;
+  width: $search_entry_width;
+  
   &:hover {
     // background-color: $hover_bg_color; Yaru: we can't use our hover color here otherwise it becomes transparent
     border-color: $hover_borders_color; // Yaru: we want bordered entries
-    color: $hover_fg_color;
+    color: lighten($hover_fg_color, 5%);
   }
 
   &:focus {
     border-style: solid;
     border-color: $focus_border_color; // Yaru: we detached focus from selected
     color: $fg_color;
-    box-shadow: none; // Yaru: we want a flat search entry
+    box-shadow: none;
     
     // Yaru: we want bordered entries
     padding: $base_padding $base_padding+2; // 1px less to account for wider border
@@ -35,8 +35,9 @@ $search_entry_height: 36px;
   }
 
   .search-entry-icon { 
-    icon-size: $base_icon_size;
-    padding: 0 4px;
     color: inherit;
+    icon-size: $base_icon_size;
+    margin-top: 2px; // center vertically
+    padding: 0 4px;
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_search-results.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_search-results.scss
@@ -11,11 +11,9 @@
   // This should be equal to #searchResultsContent spacing
   spacing: $base_margin * 2;
 
-  // separator
+  // separator (unstyled)
   .search-section-separator { 
-    // height: 1px;
-    // background-color: $osd_outer_borders_color;
-    height: 0;
+    height: $base_margin*2; // use it as a spacer
     background-color: transparent;
   }
 }
@@ -23,18 +21,22 @@
 // content
 .search-section-content {
   background-color: $dash_background_color; // Yaru: use same background as dash
-  border-radius: $modal_radius+3;
+  border-radius: $modal_radius*1.5;
   border: 1px solid $borders_color_dark; // Yaru: use same border-color as dash
-  box-shadow: 0 2px 4px 0 $shadow_color;
-  text-shadow: 0 1px if($variant == 'light', rgba(255,255,255,0.2), rgba(0,0,0,0.2));
+  box-shadow: none;
+  text-shadow: none;
   color: $osd_fg_color;
   padding: $base_padding * 3;
+  margin: $base_margin;
   // This is the space between the provider icon and the results container
-  spacing: $base_margin * 2;
 }
 
-%search-section-content-item {
+%search_section_content_item {
   @extend %icon_tile;
+
+  border-radius: $base_border_radius;
+
+  color: $osd_fg_color;
 
   &:focus,
   &:hover,
@@ -60,12 +62,12 @@
 
 // Search results with icons
 .grid-search-result {
-  @extend %app-well-app;
+  @extend %app_well_app;
 }
 
 // search result provider
 .search-provider-icon {
-  @extend %search-section-content-item;
+  @extend %search_section_content_item;
 
   // content
   .list-search-provider-content {
@@ -74,9 +76,7 @@
     // provider labels
     .list-search-provider-details {
       width: 120px;
-      margin-top: 0;
-      color: darken($osd_fg_color, 8%);
-      // font-weight: bold;
+      color: $osd_fg_color;
     }
   }
 }
@@ -88,7 +88,7 @@
 
 // search result listitem
 .list-search-result {
-  @extend %search-section-content-item;
+  @extend %search_section_content_item;
 
   // content
   .list-search-result-content {
@@ -103,6 +103,6 @@
 
   // list item description
   .list-search-result-description {
-    color: darken($osd_fg_color, 30%);
+    color: $osd_insensitive_fg_color;
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -1,25 +1,26 @@
 /* Slider */
 
-$slider_size: 15px;
+$slider_size: 16px;
 
 .slider {
   height: $slider_size;
   // slider trough
-  -barlevel-height: 3px; // has to be an odd number
-  -barlevel-background-color: $borders_color; //background of the trough
-  -barlevel-border-width: 0px; 
-  -barlevel-border-color: $borders_color; // trough border color
+  -barlevel-height: 4px;
+  -barlevel-background-color: if($variant == 'light', transparentize($fg_color, 0.6), transparentize($fg_color, 0.8)); //background of the trough
+  -barlevel-border-width: 2px; 
+  -barlevel-border-color: transparent; // trough border color
   // fill style
   -barlevel-active-background-color: $progress_bg_color; //active trough fill // Yaru: we detached progress from selected
-  -barlevel-active-border-color: $progress_bg_color; //active trough border // Yaru: we detached progress from selected
+  -barlevel-active-border-color: transparent;
   // overfill style (red in this case)
   -barlevel-overdrive-color: $destructive_color;
-  -barlevel-overdrive-border-color: if($variant == 'light', darken($destructive_color, 4%), lighten($destructive_color, 2%)); //trough border when red;
+  -barlevel-overdrive-border-color: transparent; //trough border when red;
   -barlevel-overdrive-separator-width:1px;
   // slider handler
   -slider-handle-radius: $slider_size * 0.5; // half the size of the size
-  -slider-handle-border-width: if($variant=='light', 1px, 0); // Yaru: remove the border on dark theme
-  -slider-handle-border-color: darken($alt_borders_color, 3%); // Yaru: the handle border needs to be darker for the light theme
+  -slider-handle-border-width: 0;
+  -slider-handle-border-color: transparent; // because 0 width
+  margin: 0 $base_padding;
 
   color: darken(white, 1%); // Yaru: adapt knob to gtk
   &:hover { color: $hover_bg_color; }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -3,7 +3,7 @@
 $slider_size: 16px;
 
 .slider {
-  height: $slider_size;
+  height: if($variant=='light', $slider_size + 2px, $slider_size); // Yaru: fix height for handle border in light theme
   // slider trough
   -barlevel-height: 4px;
   -barlevel-background-color: if($variant == 'light', transparentize($fg_color, 0.6), transparentize($fg_color, 0.8)); //background of the trough
@@ -18,8 +18,8 @@ $slider_size: 16px;
   -barlevel-overdrive-separator-width:1px;
   // slider handler
   -slider-handle-radius: $slider_size * 0.5; // half the size of the size
-  -slider-handle-border-width: 0;
-  -slider-handle-border-color: transparent; // because 0 width
+  -slider-handle-border-width: if($variant=='light', 1px, 0); // Yaru: add border on light theme
+  -slider-handle-border-color: darken($alt_borders_color, 3%); // Yaru: the handle border needs to be darker for the light theme
   margin: 0 $base_padding;
 
   color: darken(white, 1%); // Yaru: adapt knob to gtk

--- a/gnome-shell/src/gnome-shell-sass/widgets/_switcher-popup.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_switcher-popup.scss
@@ -1,37 +1,51 @@
 /* App Switcher */
 
+// same as dash
+$switcher_padding: $base_padding + 4px; // 10px
+$switcher_border_radius: $modal_radius + 8px;
+
+
+// the full screen container of the switcher
 .switcher-popup {
-  padding: 8px;
+  padding: 0;
   spacing: $base_spacing * 4;
 }
 
 // switcher onscreen panel
 .switcher-list {
   @extend %osd_panel;
+  padding: $switcher_padding;
+  border-radius: $switcher_border_radius;
+  box-shadow: 0 8px 8px 0 rgba(0,0,0,0.1);
 
+  // container for items in list
+  .switcher-list-item-container {
+    spacing: $base_spacing * 2;
+  }
+
+  // each item in the list
   .item-box {
-    padding: 8px;
-    border-radius: $base_border_radius + 1px;
-    border: 1px solid transparent;
+    @extend %icon_tile;
 
     &:outlined {
       background-color: transparentize($osd_fg_color, 0.7);
     }
 
+    &:hover,
     &:selected {
       background-color: transparentize($osd_fg_color, 0.8); // Yaru: make selected apps more visible in alt+tab
-      color: $osd_fg_color;
     }
-  }
 
-  // window thumbnails
-  .thumbnail-box {
-    padding: 2px;
-    spacing: $base_spacing;
-  }
+    &:focus {
+      background-color: transparentize($osd_fg_color, .7);
+      // border-color: $selected_bg_color;
+    }
 
-  .thumbnail {
-    width: 256px;
+    &:focus,
+    &:active,
+    &:checked {
+      background-color: transparentize(darken($osd_bg_color, 10%), .5);
+    }
   }
 
   .separator {
@@ -39,15 +53,25 @@
     background: $borders_color;
   }
 
-  .switcher-list-item-container {
-    spacing: $base_spacing * 2;
+  // container of thumbnails
+  .thumbnail-box {
+    padding: 2px;
+    spacing: $base_spacing;
+  }
+
+  // window thumbnail itself
+  .thumbnail {
+    width: 256px; // equal to THUMBNAIL_DEFAULT_SIZE in altTab.js
+    border-radius:$base_border_radius;
   }
 }
 
 .switcher-arrow { // Yaru: make arrow visible in the light theme, should be ported to upstream
   border-color: rgba(0,0,0,0);
   color: transparentize($osd_fg_color,0.2);
+
   &:highlighted {
+    border-color: $osd_fg_color;
     color: $osd_fg_color;
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_switches.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_switches.scss
@@ -1,8 +1,8 @@
 /* Switches */
 
 // these are equal to the size of the SVG assets
-$switch_height: 26px; // Yaru: Increase size for our icons
-$switch_width: 48px;  // Yaru: Increase size for our icons
+$switch_height: 26px;
+$switch_width: 48px;
 
 .toggle-switch {
   color: $fg_color;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_workspace-switcher.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_workspace-switcher.scss
@@ -1,17 +1,23 @@
 /* Workspace Switcher */
+
+$ws_padding: $base_padding*2;
+$ws_border_radius: $modal_radius + 8px;
+
 .workspace-switcher-group {
   padding: $base_padding * 2;
 }
 
 .workspace-switcher-container {
   @extend %osd_panel;
+  padding: $ws_padding;
+  border-radius: $ws_border_radius;
+  box-shadow: 0 8px 8px 0 rgba(0,0,0,0.1);
 }
 
 .workspace-switcher {
   background: transparent;
   border: none;
   border-radius: 0;
-  padding: 0;
   spacing: $base_spacing * 2;
 }
 


### PR DESCRIPTION
Add support for **Gnome Shell 42** _- still compatible with 40_.

Please test this and report your comments here.
The most noticeable change is an _huge increase_ of padding...

![Capture d’écran de 2022-01-16 11-40-27](https://user-images.githubusercontent.com/36476595/149656690-e1afd685-a3f1-41d1-9ba5-59ae9dbdbf54.png)

Related to #3311