### PR TITLE
Revert close button to upstream look

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_window-picker.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_window-picker.scss
@@ -5,7 +5,7 @@ $window_picker_padding: $base_padding * 2; // 12px
 
 $window_thumbnail_label_color: transparentize($osd_bg_color, 0.4);
 
-$window_close_button_size: 24px; // Yaru: reduce close button size
+$window_close_button_size: 30px;
 $window_close_button_padding: 3px;
 
 // Window picker
@@ -25,7 +25,7 @@ $window_close_button_padding: 3px;
 
 // Close button
 .window-close {
-  background-color: $selected_bg_color;
+  background-color: lighten($osd_bg_color, 10%); // Yaru: lighter close button because of our darker overview bg
   color: $osd_fg_color;
   border-radius: $window_close_button_size * 0.5 + $window_close_button_padding * 2;
   padding: $window_close_button_padding;
@@ -37,12 +37,12 @@ $window_close_button_padding: 3px;
   & StIcon { icon-size: 24px; }
 
   &:hover {
-    background-color: lighten($selected_bg_color, 5%);
+    background-color: lighten($osd_bg_color, 15%); // Yaru: lighter close button because of our darker overview bg
   }
 
   &:active {
     // color: transparentize($osd_fg_color, 0.2); // Yaru: don't change icon color when :active
-    background-color: darken($selected_bg_color, 5%);
+    background-color: lighten($osd_bg_color, 5%);  // Yaru: lighter close button because of our darker overview bg
   }
 }
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_window-picker.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_window-picker.scss
@@ -33,6 +33,7 @@ $window_close_button_padding: 3px;
   width: $window_close_button_size;
   box-shadow: -1px 1px 5px 0px rgba(0,0,0,0.5);
   transition-duration: 300ms;
+  border: 1px solid $borders_color_dark; // Yaru: add border
 
   & StIcon { icon-size: 24px; }
 


### PR DESCRIPTION
As we dropped the orange close button in Gtk, I think we should also revert our change of orange close for Gnome Shell, so it looks consistent.

![Capture d’écran de 2022-01-19 13-39-06](https://user-images.githubusercontent.com/36476595/150132865-39210318-2b18-498a-ab2c-fd1bb19468db.png)

What do you think of?