### PR TITLE
Dash to dock updates for GNOME 41 (and dash-to-dock 71+)

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -1,15 +1,29 @@
-/* Default Ubuntu Dock styling, append !important to any changed rules */
+/* Default Ubuntu Dock styling, append !important to any changed rules
+   This must be in sync with
+   - https://github.com/micheleg/dash-to-dock/blob/ubuntu-dock/_stylesheet.scss
+ */
+
+$dash_bottom_margin: $base_margin * 4;
+$dash_spacing: round($base_padding / 4);
 
 // Stock
-$dash_spacing: $base_padding / 4;
-$dash_bottom_margin: $base_margin * 4;
-$dock_side_margin: $dash_bottom_margin / 4;
+$dash_edge_items_padding: $dash_padding - $dash_spacing;
+$dock_start_margin: $dash_bottom_margin;
+$dock_side_margin: $dock_start_margin / 4;
 $dock_fixed_inner_margin: $dock_side_margin;
 
 // Adapted to $dock_bottom_margin
 
 @function shrink($val) {
     @return round($val / 4);
+}
+
+@function shrink_light($val) {
+    @return round($val * 0.75);
+}
+
+@function is_horizontal($side) {
+    @return $side == top or $side == bottom;
 }
 
 @function opposite($val) {
@@ -39,12 +53,12 @@ $osd_fg_color: #eeeeec;
             }
 
             .dash-separator {
-                @if $side == top or $side == bottom {
+                background-color: transparentize($osd_fg_color, 0.7);
+                @if is_horizontal($side) {
                     margin-bottom: 0;
                 } @else {
                     height: 1px;
                     margin: ($dash_spacing + ($dash_padding / 2)) 0;
-                    background-color: transparentize($osd_fg_color, 0.7);
                 }
             }
 
@@ -61,15 +75,29 @@ $osd_fg_color: #eeeeec;
                     padding-#{$side}: $dash_padding + $dock_side_margin;
                     padding-#{opposite($side)}: $dash_padding;
                 }
+
+                .app-well-app {
+                    &.running .overview-icon {
+                        background-image: none;
+                    }
+                    &.focused .overview-icon {
+                        background-color: rgba(238, 238, 236, 0.2);
+                    }
+                }
+
+                > StButton {
+                    transition-duration: 250;
+                    background-size: contain;
+                }
             }
         }
 
         &.shrink {
             #dash {
                 .dash-background {
-                    margin-#{$side}: shrink($dock_side_margin);
+                    margin-#{$side}: $dock_side_margin;
                     padding: shrink($dash_padding);
-                    border-radius: $dash_border_radius / 2;
+                    border-radius: shrink_light($dash_border_radius);
                 }
 
                 #dashtodockDashContainer {
@@ -80,7 +108,7 @@ $osd_fg_color: #eeeeec;
                     .app-well-app,
                     .show-apps {
                         padding: shrink($dash_spacing);
-                        padding-#{$side}: shrink($dash_padding + $dock_side_margin);
+                        padding-#{$side}: shrink($dash_padding) + $dock_side_margin;
                         padding-#{opposite($side)}: shrink($dash_padding);
                     }
                 }
@@ -119,25 +147,68 @@ $osd_fg_color: #eeeeec;
     }
 }
 
+@mixin padded-edge-child($chid, $side, $padding) {
+    @if $chid == first {
+        @if is_horizontal($side) {
+            padding-left: $padding;
+        } @else {
+            padding-top: $padding;
+        }
+    } @else if $chid == last {
+        @if is_horizontal($side) {
+            padding-right: $padding;
+        } @else {
+            padding-bottom: $padding;
+        }
+    } @else {
+        @error "Invalid rule";
+    }
+}
+
+/* In extended mode we need to use the first and last .dash-item-container's
+ * to apply the padding on the dock, to ensure that the actual first or last
+ * child show-apps item will actually include the padding area so that it will
+ * be clickable up to the dock edge, and make Fitts happy.
+ * I don't think the same should happen for normal icons, so in the other side
+ * the padding will be applied via the scrolled area, given we can't get the
+ * parent of the first/last app-well-app icon to apply a rule there.
+ */
+@mixin padded-dash-edge-items($side, $padding) {
+    @each $child_pos in first, last {
+        > :#{$child_pos}-child {
+            /* Use this instead of #dashtodockDashScrollview rule to apply the
+             * padding via the last app-icon item */
+            // .dash-item-container:#{$child_pos}-child .app-well-app,
+            .show-apps {
+                @include padded-edge-child($child_pos, $side, $padding);
+            }
+        }
+
+        #dashtodockDashScrollview:#{$child_pos}-child {
+            @include padded-edge-child($child_pos, $side, $padding);
+        }
+    }
+}
+
 @each $side in bottom, top, left, right {
     #dashtodockContainer.extended.#{$side} {
         #dash {
             .dash-background {
                 margin: 0;
-                padding: 0;
                 border-radius: 0;
             }
 
             #dashtodockDashContainer {
-                padding: $dash_padding - $dash_spacing;
+                padding: 0;
                 padding-#{$side}: 0;
                 padding-#{opposite($side)}: 0;
+
+                @include padded-dash-edge-items($side, $dash_edge_items_padding);
             }
 
             .dash-item-container {
                 .app-well-app,
                 .show-apps {
-                    padding: $dash_spacing;
                     padding-#{$side}: $dash_padding;
                     padding-#{opposite($side)}: $dash_padding;
                 }
@@ -147,15 +218,14 @@ $osd_fg_color: #eeeeec;
         &.shrink {
             #dash {
                 #dashtodockDashContainer {
-                    padding: shrink($dash_padding - $dash_spacing);
-                    padding-#{$side}: 0;
-                    padding-#{opposite($side)}: 0;
+                    padding: 0;
+
+                    @include padded-dash-edge-items($side, $dash_edge_items_padding);
                 }
 
                 .dash-item-container {
                     .app-well-app,
                     .show-apps {
-                        padding: shrink($dash_spacing);
                         padding-#{$side}: shrink($dash_padding);
                         padding-#{opposite($side)}: shrink($dash_padding);
                     }
@@ -192,24 +262,6 @@ $osd_fg_color: #eeeeec;
 .left #dashtodockDashScrollview,
 .right #dashtodockDashScrollview {
     -st-vfade-offset: 24px;
-}
-
-#dashtodockContainer.running-dots .dash-item-container > StButton,
-#dashtodockContainer.dashtodock .dash-item-container > StButton {
-    transition-duration: 250;
-    background-size: contain;
-}
-
-/* Running and focused application style */
-
-#dashtodockContainer.running-dots .app-well-app.running > .overview-icon,
-#dashtodockContainer.dashtodock .app-well-app.running > .overview-icon {
-    background-image: none;
-}
-
-#dashtodockContainer.running-dots .app-well-app.focused .overview-icon,
-#dashtodockContainer.dashtodock .app-well-app.focused .overview-icon {
-    background-color: rgba(238, 238, 236, 0.2);
 }
 
 #dashtodockContainer.dashtodock #dash .dash-background {
@@ -280,56 +332,80 @@ $osd_fg_color: #eeeeec;
     border-radius: 0px;
 }
 
+@for $i from 2 through 4 {
+    #dashtodockContainer.bottom .metro.running#{$i}.focused,
+    #dashtodockContainer.top .metro.running#{$i}.focused {
+        background-image: url("./media/highlight_stacked_bg.svg");
+        background-position: 0px 0px;
+        background-size: contain;
+    }
+
+    #dashtodockContainer.left .metro.running#{$i}.focused,
+    #dashtodockContainer.right .metro.running#{$i}.focused {
+        background-image: url("./media/highlight_stacked_bg_h.svg");
+        background-position: 0px 0px;
+        background-size: contain;
+    }
+}
+
 /* Yaru Dock styling */
+
+$dock_color: $panel_bg_color;
 
 @each $side in bottom, top, left, right {
     #dashtodockContainer.#{$side} {
+        #dash,
         &.dashtodock #dash,
         &.shrink #dash {
-            // without "border: none", there is a 1px gap between windows and the dock
-            border: none !important;
-            box-shadow: inset 0 1px 2px -1px rgba(0, 0, 0, 0.4) !important;
-            background: transparent; // Will render half dark transparent - we need to understand why
+            margin: 0px;
+            padding: 0px;
 
-            @if $side == left or $side == right {
-                // don't let the first icon be too close to the shadow + panel
-                #dashtodockDashScrollview {
-                padding-top: 2px;
-                padding-bottom: 2px;
+            .dash-background {
+                background: transparentize($dock_color, 0.25);
+                transition-duration: $panel_transition_duration;
+            }
+
+            .dash-separator {
+                background: transparentize($osd_fg_color, 0.7);
+            }
+        }
+
+        &.overview {
+            #dash,
+            &.dashtodock #dash,
+            &.shrink #dash {
+                .dash-background {
+                    background-color: $dock_color;
                 }
             }
         }
 
-        .show-apps {
-            .overview-icon {
-                border-radius: $base_border_radius;
+        &.extended {
+            #dash,
+            &.dashtodock #dash,
+            &.shrink #dash {
+                .dash-background {
+                    // Yaru: remove the border we apply to the upstream dock
+                    border: none;
+                }
             }
-            &:active, &:checked {
+
+            &.shrink #dash #dashtodockDashContainer {
+                // Yaru: do not shrink start/end padding in shrink mode
+                @include padded-dash-edge-items($side, $dash_edge_items_padding);
+            }
+        }
+
+        .dash-item-container {
+            .show-apps, .app-well-app {
                 .overview-icon {
-                    background-color: $base_active_color; box-shadow: none;
+                    border-radius: $base_border_radius;
                 }
-            }
-        }
-
-        .app-well-app {
-            // regular app icons
-            &, & .overview-icon {
-                // normal
-            }
-
-            &:active .overview-icon,
-            &:checked .overview-icon {
-                background-color: $base_active_color; box-shadow: none;
-            }
-
-            &.focused .overview-icon {
-                // when an app is focused
-            }
-
-            &:hover .overview-icon,
-            &:focus .overview-icon,
-            &:selected .overview-icon {
-                // when hovering over an app
+                &:active, &:checked {
+                    .overview-icon {
+                        background-color: $base_active_color; box-shadow: none;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Update dash-to-dock base CSS to respect latest upstream changes, fixing
the padding for edge icons.

Moved the logic to handle most of style such as color and transparency
of the dock here, as it's something we'd prefer not to change through
settings overrides.

Fixes #3111
Fixes #3327
LP: #1942702

---

There's some results, this requires also some dash-to-dock changes in order not to define colors via settings overrides anymore.

![Screenshot from 2022-01-26 04-48-37](https://user-images.githubusercontent.com/345675/151101057-6a9f899a-5d6a-43c0-848b-9f8fb15991df.png)

![Screenshot from 2022-01-26 04-49-01](https://user-images.githubusercontent.com/345675/151101059-0f6b7872-cb08-42b9-8c37-08ee801883e5.png)

I'm also wondering if we could do something like this when the applications are showing as IMHO the show-apps button is easy to confuse with applications when it's checked:

```diff
diff --git a/gnome-shell/src/gnome-shell-sass/_dock.scss b/gnome-shell/src/gnome-shell-sass/_dock.scss
index 969d22d47..4975662b5 100644
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -383,6 +383,14 @@ $dock_color: $panel_bg_color;
                     }
                 }
             }
+
+            .show-apps {
+                &:active, &:checked {
+                    .overview-icon {
+                        background-color: $accent_bg_color;
+                    }
+                }
+            }
         }
 
         .notification-badge {
```

Which leads to:

![Screenshot from 2022-01-26 04-52-04](https://user-images.githubusercontent.com/345675/151101366-37900dd5-47fc-4cea-9d8a-9ef68ae9f464.png)

