### PR TITLE
Fix padlock-open-symbolic icon

### DIFF
--- a/icons/Yaru/scalable/emblems/padlock-open-symbolic.svg
+++ b/icons/Yaru/scalable/emblems/padlock-open-symbolic.svg
@@ -1,3 +1,3 @@
-<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
- <path d="m12.5 2c-1.385 0-2.5 1.115-2.5 2.5v2.5h-7c-0.55469 0-1 0.44531-1 1v6h12v-6c0-0.55469-0.44531-1-1-1h-2v-2.5c0-0.831 0.669-1.5 1.5-1.5s1.5 0.669 1.5 1.5v0.5h1v-0.5c0-1.385-1.115-2.5-2.5-2.5z" fill="#808080"/>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="M8 0a4 4 0 0 0-4 4v4H3v8h10V8H5V4c0-1.67 1.33-3 3-3s3 1.33 3 3v2h1V4a4 4 0 0 0-4-4z" fill="gray" font-family="sans-serif" font-weight="400" overflow="visible" style="isolation:auto;mix-blend-mode:normal;shape-padding:0;text-decoration-color:#000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-transform:none" white-space="normal"/>
 </svg>

--- a/icons/src/scalable/emblems/padlock-open-symbolic.svg
+++ b/icons/src/scalable/emblems/padlock-open-symbolic.svg
@@ -1,3 +1,3 @@
-<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
- <path d="m12.5 2c-1.385 0-2.5 1.115-2.5 2.5v2.5h-7c-0.55469 0-1 0.44531-1 1v6h12v-6c0-0.55469-0.44531-1-1-1h-2v-2.5c0-0.831 0.669-1.5 1.5-1.5s1.5 0.669 1.5 1.5v0.5h1v-0.5c0-1.385-1.115-2.5-2.5-2.5z" fill="#808080"/>
+<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg">
+    <path d="M8 0a4 4 0 0 0-4 4v4H3v8h10V8H5V4c0-1.67 1.33-3 3-3s3 1.33 3 3v2h1V4a4 4 0 0 0-4-4z" fill="gray" font-family="sans-serif" font-weight="400" overflow="visible" style="line-height:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000;text-transform:none;shape-padding:0;isolation:auto;mix-blend-mode:normal;marker:none" white-space="normal" color="#000"/>
 </svg>


### PR DESCRIPTION
Fix `padlock-open-symbolic` icon, which was using Adwaita look.

**Before:**

![Capture d’écran du 2022-02-01 21-20-03](https://user-images.githubusercontent.com/36476595/152044877-f92568db-de47-485f-bc3b-56906ba881f0.png)

**After:**

![Capture d’écran du 2022-02-01 21-18-42](https://user-images.githubusercontent.com/36476595/152044890-dbb15467-9b54-46b9-9cff-7efe93db4392.png)
