### PR TITLE
Fix GH actions branches

### DIFF
--- a/.github/workflows/open-pr-on-icons-changes.yaml
+++ b/.github/workflows/open-pr-on-icons-changes.yaml
@@ -25,7 +25,7 @@ jobs:
           {
             project: Libhandy symbolics,
             repo: "https://gitlab.gnome.org/GNOME/libhandy.git",
-            upstreambranch: master,
+            upstreambranch: main,
             localbranch: libhandy-symbolics,
             projectdir: libhandy,
             src: src/icons/scalable,


### PR DESCRIPTION
Fix GH actions branches.

Libhandy now use `main` as default master branch.