### PR TITLE
Fix mate-dark gtk4 variant

### DIFF
--- a/gtk/src/mate-dark/gtk-4.0/gtk-dark.scss
+++ b/gtk/src/mate-dark/gtk-4.0/gtk-dark.scss
@@ -1,1 +1,1 @@
-gtk.scss
+../../dark/gtk-4.0/gtk-dark.scss

--- a/gtk/src/mate-dark/gtk-4.0/gtk.scss
+++ b/gtk/src/mate-dark/gtk-4.0/gtk.scss
@@ -1,1 +1,1 @@
-../../default/gtk-4.0/gtk.scss
+../../dark/gtk-4.0/gtk.scss


### PR DESCRIPTION
Fix mate-dark gtk4 variant (was using light version of `gtk.scss`).