### PR TITLE
Fix meson warning

### DIFF
--- a/gnome-shell/src/meson.build
+++ b/gnome-shell/src/meson.build
@@ -109,7 +109,7 @@ foreach variant: variants
   gresource_xml = files('data/gnome-shell-theme.gresource.xml')[0]
   data_sources = run_command(
     gresources_xml_parser, [
-      join_paths(meson.source_root(), '@0@'.format(gresource_xml)),
+      join_paths(meson.project_source_root(), '@0@'.format(gresource_xml)),
       '--filter', '*.css',
     ] + ignore_variants,
   ).stdout().strip().split('\n')

--- a/gnome-shell/src/meson.build
+++ b/gnome-shell/src/meson.build
@@ -109,7 +109,7 @@ foreach variant: variants
   gresource_xml = files('data/gnome-shell-theme.gresource.xml')[0]
   data_sources = run_command(
     gresources_xml_parser, [
-      join_paths(meson.project_source_root(), '@0@'.format(gresource_xml)),
+      join_paths(project_source_root, '@0@'.format(gresource_xml)),
       '--filter', '*.css',
     ] + ignore_variants,
   ).stdout().strip().split('\n')

--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,8 @@
 project('Yaru',
         version: '22.04.1',
-        meson_version: '>= 0.51',
+        meson_version: '>= 0.53',
         license : ['GPL3', 'CC BY-SA 4.0'],
         default_options: ['prefix=/usr'])
-
 
 components = ['icons', 'metacity', 'gnome-shell', 'gtk', 'gtksourceview', 'sounds', 'sessions', 'xfwm4', 'cinnamon']
 

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,8 @@ project('Yaru',
         license : ['GPL3', 'CC BY-SA 4.0'],
         default_options: ['prefix=/usr'])
 
+project_source_root = meson.current_source_dir()
+
 components = ['icons', 'metacity', 'gnome-shell', 'gtk', 'gtksourceview', 'sounds', 'sessions', 'xfwm4', 'cinnamon']
 
 foreach component: components


### PR DESCRIPTION
Fix those meson warning messages:

```
WARNING: Project specifies a minimum meson_version '>= 0.51' but uses features which were added in newer versions:
 * 0.53.0: {'Fs Module'}
NOTICE: Future-deprecated features used:
 * 0.56.0: {'meson.source_root'}
```

**Changes:**

- Bump required meson version to `>= 0.53`;
- remove deprecated `meson.source_root` usage.