### PR TITLE
Sync Gtk3 light headerbar bg with Gtk4

### DIFF
--- a/gtk/src/default/gtk-3.0/_common.scss
+++ b/gtk/src/default/gtk-3.0/_common.scss
@@ -1576,7 +1576,7 @@ headerbar {
   border-color: $alt_borders_color;
   border-radius: 0;
 
-  @include headerbar_fill(darken($bg_color, 10%));
+  @include headerbar_fill(if($variant == 'light', darken($bg_color, 6%), darken($bg_color, 10%))); // Yaru change: sync light headerbar bg color with Gtk4 (a bit lighten)
 
   &:backdrop {
     border-color: $backdrop_borders_color;


### PR DESCRIPTION
Sync Gtk3 light headerbar bg with Gtk4 (use `#ebebeb`).

**Before:**

![Capture d’écran du 2022-02-20 11-27-04](https://user-images.githubusercontent.com/36476595/154838480-c742fe54-2299-4f5f-b6c5-8e070f3259c7.png)

**After:**

![Capture d’écran du 2022-02-20 11-26-48](https://user-images.githubusercontent.com/36476595/154838484-84302fc3-f915-4faa-8a34-f47d5bda7c46.png)
