### PR TITLE
Sync Gtk3 + Libhandy + GS with Gtk4 radii

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -31,7 +31,7 @@ $base_margin: 4px;
 $base_spacing: 6px;
 
 // border radii
-$base_border_radius: 8px;
+$base_border_radius: 6px; // Yaru change: sync radius with Gtk4
 
 // radii of things that display over other things, e.g. popovers
 $modal_radius: $base_border_radius*2; // 24px

--- a/gtk/src/default/gtk-3.0/_common.scss
+++ b/gtk/src/default/gtk-3.0/_common.scss
@@ -6,10 +6,10 @@ $ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);
 $asset_suffix: if($variant=='dark', '-dark', '');
 $backdrop_transition: 200ms ease-out;
 $button_transition: all 200ms $ease-out-quad;
-$button_radius: 5px;
-$menu_radius: 5px;
-$window_radius: $button_radius + 3;
-$popover_radius: $button_radius + 4;
+$button_radius: 6px; // Yaru change: sync radius with Gtk4
+$menu_radius: 6px; // Yaru change: ↑↑↑
+$window_radius: $button_radius + 6; // Yaru change: ↑↑↑
+$popover_radius: $window_radius; // Yaru change: ↑↑↑
 
 // Optional compact sizes for buttons, headerbar and headerbar widgets
 $_sizevariant: 'default'; //compact otherwise

--- a/gtk/src/default/gtk-3.0/libhandy/_Adwaita-base.scss
+++ b/gtk/src/default/gtk-3.0/libhandy/_Adwaita-base.scss
@@ -344,7 +344,7 @@ window.csd.unified:not(.solid-csd):not(.fullscreen) {
     &,
     > decoration,
     > decoration-overlay {
-      border-radius: 8px;
+      border-radius: $window_radius; // Yaru change: sync radius with Gtk4 (use Gtk3 vars instead of hardcode)
     }
   }
 }


### PR DESCRIPTION
Sync Gtk3, Libhandy and Gnome Shell border-radius with Gtk4 one: `6px`.

### Screenshots:

![Capture d’écran de 2022-02-20 11-52-25](https://user-images.githubusercontent.com/36476595/154839372-c4198dbe-27f0-47aa-bfc9-4778ff4b6831.png)
![Capture d’écran du 2022-02-20 11-49-15](https://user-images.githubusercontent.com/36476595/154839384-25fa91d0-9b6f-48c1-8801-4c6cf6d494ce.png)
![Capture d’écran du 2022-02-20 12-01-26](https://user-images.githubusercontent.com/36476595/154839385-b74a8849-1b6f-4a87-8fdb-12e16ae535bf.png)
