### PR TITLE
Remove shadow on normal buttons

### DIFF
--- a/gtk/src/default/gtk-3.0/_drawing.scss
+++ b/gtk/src/default/gtk-3.0/_drawing.scss
@@ -200,7 +200,7 @@
     $button_fill: if($c == $bg_color, if($variant == 'light', image(lighten($c, 2%)), image(lighten($c, 4%))), image(lighten($c, 2%))) !global;
     background-image: $button_fill;
     @include _button_text_shadow($tc, $c);
-    @include _shadows(0 1px transparentize(black, 0.95)); // Yaru change: stronger shadows for flatter buttons
+    @include _shadows(none); // Yaru change: drop shadow
   }
 
   @else if $t==hover {
@@ -221,8 +221,8 @@
       @include _button_text_shadow($tc,lighten($c, 6%));
       @include _shadows(inset 0 1px _button_hilight_color(darken($c, 2%)), $_button_edge, $_button_shadow);
     }
-    box-shadow: 0 1px transparentize(black, if($variant=='light', 0.85, 0.9)); // Yaru change: stronger shadows for flatter buttons
-    background-image: if($c == $bg_color, if($variant == 'light', image(lighten($c, 4%)), image(lighten($c, 6%))), image(lighten($c, 4%)));
+    box-shadow: none; // Yaru change: remove shadow
+    background-image: if($c == $bg_color, if($variant == 'light', image(darken($c, 2%)), image(lighten($c, 6%))), image(lighten($c, 4%))); // Yaru change: darker bg on hover on light theme
   }
 
   @if $t==normal-alt {
@@ -243,7 +243,7 @@
       @include _shadows(inset 0 1px $_hilight_color,
                         $_button_edge, $_button_shadow);
     }
-    @include _shadows(0 1px transparentize(black, 0.95)); // Yaru change: stronger shadows for flatter buttons
+    @include _shadows(none); // Yaru change: remove shadow
     background-image: image(darken(white, 1%)); // Yaru change: brighter alt
     background-clip: padding-box; // Yaru change: fix background overflow
   }
@@ -266,7 +266,7 @@
                         $_button_edge, $_button_shadow);
     }
     background-image: image(white); // Yaru change: brighter alt hover
-    box-shadow: 0 1px transparentize(black, 0.85); // Yaru change: stronger shadows for flatter buttons
+    box-shadow: none; // Yaru change: remove shadow
   }
 
   @else if $t==active {


### PR DESCRIPTION
Test PR for shadow less buttons.
Normal state buttons got no shadow, hover state uses previous normal shadow.

![Capture d’écran du 2022-02-20 12-35-59](https://user-images.githubusercontent.com/36476595/154840777-0ca26c43-8d71-4f8d-affe-df77db07da06.png)

https://user-images.githubusercontent.com/36476595/154840783-8c43ef0c-2adb-4f9e-9d6a-d30d2b901d42.mp4

