### PR TITLE
Generate missing mate symlinks

### DIFF
--- a/icons/Yaru-mate/16x16/apps/nautilus.png
+++ b/icons/Yaru-mate/16x16/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/16x16/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/16x16/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/16x16/apps/system-file-manager.png
+++ b/icons/Yaru-mate/16x16/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png

--- a/icons/Yaru-mate/16x16@2x/apps/nautilus.png
+++ b/icons/Yaru-mate/16x16@2x/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/16x16@2x/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/16x16@2x/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/16x16@2x/apps/system-file-manager.png
+++ b/icons/Yaru-mate/16x16@2x/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png

--- a/icons/Yaru-mate/24x24/apps/nautilus.png
+++ b/icons/Yaru-mate/24x24/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/24x24/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/24x24/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/24x24/apps/system-file-manager.png
+++ b/icons/Yaru-mate/24x24/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png

--- a/icons/Yaru-mate/24x24@2x/apps/nautilus.png
+++ b/icons/Yaru-mate/24x24@2x/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/24x24@2x/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/24x24@2x/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/24x24@2x/apps/system-file-manager.png
+++ b/icons/Yaru-mate/24x24@2x/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png

--- a/icons/Yaru-mate/256x256/apps/nautilus.png
+++ b/icons/Yaru-mate/256x256/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/256x256/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/256x256/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/256x256/apps/system-file-manager.png
+++ b/icons/Yaru-mate/256x256/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png

--- a/icons/Yaru-mate/256x256@2x/apps/nautilus.png
+++ b/icons/Yaru-mate/256x256@2x/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/256x256@2x/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/256x256@2x/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/256x256@2x/apps/system-file-manager.png
+++ b/icons/Yaru-mate/256x256@2x/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png

--- a/icons/Yaru-mate/32x32/apps/nautilus.png
+++ b/icons/Yaru-mate/32x32/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/32x32/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/32x32/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/32x32/apps/system-file-manager.png
+++ b/icons/Yaru-mate/32x32/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png

--- a/icons/Yaru-mate/32x32@2x/apps/nautilus.png
+++ b/icons/Yaru-mate/32x32@2x/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/32x32@2x/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/32x32@2x/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/32x32@2x/apps/system-file-manager.png
+++ b/icons/Yaru-mate/32x32@2x/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png

--- a/icons/Yaru-mate/48x48/apps/nautilus.png
+++ b/icons/Yaru-mate/48x48/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/48x48/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/48x48/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/48x48/apps/system-file-manager.png
+++ b/icons/Yaru-mate/48x48/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png

--- a/icons/Yaru-mate/48x48@2x/apps/nautilus.png
+++ b/icons/Yaru-mate/48x48@2x/apps/nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/48x48@2x/apps/org.gnome.Nautilus.png
+++ b/icons/Yaru-mate/48x48@2x/apps/org.gnome.Nautilus.png
@@ -1,0 +1,1 @@
+system-file-manager.png

--- a/icons/Yaru-mate/48x48@2x/apps/system-file-manager.png
+++ b/icons/Yaru-mate/48x48@2x/apps/system-file-manager.png
@@ -1,0 +1,1 @@
+filemanager-app.png


### PR DESCRIPTION
Generate missing mate symlinks for `filemanager` fullcolor icon.