### PR TITLE
Fix apps_label color in light theme

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -89,6 +89,7 @@ stage {
   border: 2px solid transparent;
   transition-duration: 100ms;
   text-align: center;
+  color: $osd_fg_color; // Yaru change: fix for light theme
 }
 
 // dialogs


### PR DESCRIPTION
**Before:**

![VirtualBox_Fedora 36_28_02_2022_18_31_04](https://user-images.githubusercontent.com/36476595/156030516-2ca4fcc8-292b-4337-9983-2f0cd36fc98b.png)

**After:**

![VirtualBox_Fedora 36_28_02_2022_18_27_45](https://user-images.githubusercontent.com/36476595/156030527-0c7ec3bf-aee7-48b6-805e-74b7c261bec4.png)

Related to #3407