### PR TITLE
Fix keyboard in light and dark theme

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -102,19 +102,19 @@
   // hover key
   @else if $t==hover {
     color: $tc;
-    background-color: lighten($c, 7%);
+    background-color: if($variant=="light", lighten($c, 1%), lighten($c, 7%)); // Yaru change: Make keyboard work on both variants
   }
 
   // active key
   @else if $t==active {
     color: $tc;
-    background-color: lighten($c, 10%);
+    background-color: if($variant=="light", darken($c, 2%), lighten($c, 10%)); // Yaru change: ↑↑↑
   }
 
   // checked key
   @else if $t==checked {
     color: $tc;
-    background-color: lighten($c, 15%);
+    background-color: if($variant=="light", darken($c, 5%), lighten($c, 15%)); // Yaru change: ↑↑↑
   }
 
   // insensitive key

--- a/gnome-shell/src/gnome-shell-sass/widgets/_keyboard.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_keyboard.scss
@@ -8,8 +8,8 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
 
 
 // draw keys using button function
-#keyboard { // Yaru: Make keyboard work on both variants
-  background-color: transparentize(if($variant=='light', darken($bg_color, 5%), darken($bg_color, 8%)), 0.1);
+#keyboard { // Yaru change: Make keyboard work on both variants
+  background-color: transparentize(if($variant=='light', darken($bg_color, 5%), darken($bg_color, 15%)), 0.1);
   // background-color: $osd_bg_color;
   // box-shadow: inset 0 1px 0 0 $osd_outer_borders_color;
 
@@ -41,25 +41,25 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
   border-radius: $key_border_radius;
   box-shadow: 0 1px 0 0 $shadow_color;
 
-  @include keyboard_key(normal, $key_bg_color, $osd_fg_color);
+  @include keyboard_key(normal, $key_bg_color, $fg_color); // Yaru change: ↑↑↑
 
-  &:focus { @include keyboard_key(focus);}
-  &:hover { @include keyboard_key(hover, $key_bg_color, $osd_fg_color);}
-  &:active { @include keyboard_key(active, $key_bg_color, $osd_fg_color); }
-  &:checked { @include keyboard_key(checked, $key_bg_color, $osd_fg_color); }
+  &:focus { @include keyboard_key(focus, $key_bg_color, $fg_color);} // Yaru change: ↑↑↑
+  &:hover { @include keyboard_key(hover, $key_bg_color, $fg_color);} // Yaru change: ↑↑↑
+  &:active { @include keyboard_key(active, $key_bg_color, $fg_color); } // Yaru change: ↑↑↑
+  &:checked { @include keyboard_key(checked, $key_bg_color, $fg_color); } // Yaru change: ↑↑↑
 
   &:grayed { //FIXMEy
     background-color: darken($bg_color, 3%);
-    color: $osd_fg_color;
+    color: $fg_color; // Yaru change: ↑↑↑
     border-color: $osd_borders_color;
   }
 
   // non-character keys
   &.default-key {
-    @include keyboard_key(normal, $default_key_bg_color, $osd_fg_color);
-    &:hover {@include keyboard_key(hover, $default_key_bg_color, $osd_fg_color);}
-    &:active { @include keyboard_key(active, $default_key_bg_color, $osd_fg_color);}
-    &:checked { @include keyboard_key(checked, $default_key_bg_color, $osd_fg_color);}
+    @include keyboard_key(normal, $default_key_bg_color, $fg_color); // Yaru change: ↑↑↑
+    &:hover {@include keyboard_key(hover, $default_key_bg_color, $fg_color);} // Yaru change: ↑↑↑
+    &:active { @include keyboard_key(active, $default_key_bg_color, $fg_color);} // Yaru change: ↑↑↑
+    &:checked { @include keyboard_key(checked, $default_key_bg_color, $fg_color);} // Yaru change: ↑↑↑
     border-radius: $key_border_radius;
   }
 
@@ -77,11 +77,11 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
   
   // pressed shift has different style
   &.shift-key-uppercase { 
-    background-color: lighten($key_bg_color, 20%);
-    color: $osd_bg_color;
+    background-color: if($variant=="light", darken($key_bg_color, 10%), lighten($key_bg_color, 20%)); // Yaru change: ↑↑↑
+    color: $fg_color; // Yaru change: ↑↑↑
     &:hover {
-      background-color: lighten($key_bg_color, 25%);
-      color: lighten($osd_bg_color, 5%);
+      background-color: if($variant=="light", darken($key_bg_color, 13%), lighten($key_bg_color, 25%)); // Yaru change: ↑↑↑
+      // color: lighten($osd_bg_color, 5%); // Yaru change: ↑↑↑
     }
   }
 
@@ -101,12 +101,12 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
   padding: $base_padding;
 
   .keyboard-key {
-    @include keyboard_key(normal, $key_bg_color, $osd_fg_color);
+    @include keyboard_key(normal, $key_bg_color, $fg_color); // Yaru change: ↑↑↑
 
-    &:focus { @include keyboard_key(focus);}
-    &:hover { @include keyboard_key(hover, $key_bg_color, $osd_fg_color);}
-    &:active { @include keyboard_key(active, $key_bg_color, $osd_fg_color); }
-    &:checked { @include keyboard_key(checked, $key_bg_color, $osd_fg_color); }
+    &:focus { @include keyboard_key(focus, $key_bg_color, $fg_color);} // Yaru change: ↑↑↑
+    &:hover { @include keyboard_key(hover, $key_bg_color, $fg_color);} // Yaru change: ↑↑↑
+    &:active { @include keyboard_key(active, $key_bg_color, $fg_color); } // Yaru change: ↑↑↑
+    &:checked { @include keyboard_key(checked, $key_bg_color, $fg_color); } // Yaru change: ↑↑↑
 
     border-radius:$key_border_radius;
   }
@@ -134,7 +134,7 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
   spacing: 12px;
   min-height: 20pt;
   padding: $base_padding*2;
-  color: $osd_fg_color;
+  color: $fg_color; // Yaru change: ↑↑↑
 
   // each suggestion
   StButton {
@@ -143,11 +143,11 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
     border-radius: $base_border_radius - 2px;
     padding: $base_padding $base_padding*3;
 
-    @include keyboard_key(undecorated, $key_bg_color, $osd_fg_color);
+    @include keyboard_key(undecorated, $key_bg_color, $fg_color); // Yaru change: ↑↑↑
 
-    &:focus { @include keyboard_key(focus);}
-    &:hover { @include keyboard_key(hover, $key_bg_color, $osd_fg_color);}
-    &:active { @include keyboard_key(active, $key_bg_color, $osd_fg_color); }
-    &:checked { @include keyboard_key(checked, $key_bg_color, $osd_fg_color); }
+    &:focus { @include keyboard_key(focus, $key_bg_color, $fg_color);} // Yaru change: ↑↑↑
+    &:hover { @include keyboard_key(hover, $key_bg_color, $fg_color);} // Yaru change: ↑↑↑
+    &:active { @include keyboard_key(active, $key_bg_color, $fg_color); } // Yaru change: ↑↑↑
+    &:checked { @include keyboard_key(checked, $key_bg_color, $fg_color); } // Yaru change: ↑↑↑
   }
 }


### PR DESCRIPTION
Fix keyboard in light and dark theme.

**Before:**

![Capture d’écran du 2022-02-28 21-29-36](https://user-images.githubusercontent.com/36476595/156054195-2a3cc381-8075-458d-b097-13458cd02cbe.png)
![Capture d’écran du 2022-02-28 21-29-50](https://user-images.githubusercontent.com/36476595/156054197-f3d8915e-6d86-4fa4-9e56-85eeac9e79d6.png)


**After:**

![Capture d’écran du 2022-02-28 21-28-44](https://user-images.githubusercontent.com/36476595/156054204-f3c6631f-2db7-444f-b793-cf97ff308243.png)
![Capture d’écran du 2022-02-28 21-29-03](https://user-images.githubusercontent.com/36476595/156054209-0026f77b-463a-4e17-b922-280d6f3aa768.png)

## Video:


https://user-images.githubusercontent.com/36476595/156054455-4e85c13b-f121-452e-8867-161264a7fcc3.mp4

