### PR TITLE
update default and dark gtksourceview styles

### DIFF
--- a/gtksourceview/src/dark.xml.in
+++ b/gtksourceview/src/dark.xml.in
@@ -1,94 +1,148 @@
 <?xml version="1.0" encoding="UTF-8"?>
-    <style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" version="1.0">
-    <author>Martin Wimpress</author>
-    <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
-    <!-- Primary Accent -->
-    <color name="primary" value="#E95420" />
+<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" version="1.0">
+  <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
 
-    <!-- Blacks -->
-    <color name="black" value="#000000" />
-    <color name="jet" value="#181818" />
-    <color name="inkstone" value="#333333" />
-    <color name="slate" value="#5D5D5D" />
-    <color name="graphite" value="#666666" />
-    <!-- Whites -->
-    <color name="white" value="#FFFFFF" />
-    <color name="porcelain" value="#F7F7F7" />
-    <color name="chalk" value="#E5E5E5" />
-    <color name="silk" value="#CDCDCD" />
-    <color name="ash" value="#878787" />
-    <!-- Purples -->
-    <color name="aubergine" value="#924D8B" />
-    <color name="purple" value="#762572" />
-    <color name="light_aubergine" value="#77216F" />
-    <color name="mid_aubergine" value="#5E2750" />
-    <color name="dark_aubergine" value="#2C001E" />
-    <!-- Reds -->
-    <color name="red" value="#c7162b" />
-    <!-- Oranges -->
-    <color name="orange" value="#E95420" />
-    <color name="satsuma" value="#ED764D" />
-    <color name="clementine" value="#F29879" />
-    <!-- Yellows -->
-    <color name="yellow" value="#f99b11" />
-    <!-- Greens -->
-    <color name="green" value="#0e8420" />
-    <!-- Blues -->
-    <color name="blue" value="#19B6EE" />
-    <color name="linkblue" value="#007aa6" />
-    <color name="darkblue" value="#335280" />
+  <!-- Yaru palette -->
+  <color name="blue_1"                     value="#75d3f4"/>
+  <color name="blue_2"                     value="#47c4f1"/>
+  <color name="blue_3"                     value="#19B6EE"/>
+  <color name="blue_4"                     value="#007aa6"/>
+  <color name="blue_5"                     value="#335280"/>
+   
+  <color name="dark_1"                     value="#77767B"/>
+  <color name="dark_2"                     value="#5E5C64"/>
+  <color name="dark_3"                     value="#504E55"/>
+  <color name="dark_4"                     value="#3D3846"/>
+  <color name="dark_5"                     value="#241F31"/>
+  <color name="dark_6"                     value="#000000"/>
+  <color name="libadwaita-dark"            value="#262626"/>
+  <color name="libadwaita-dark-alt"        value="#303030"/>
+  
+  <color name="green_1"                    value="#5AED70"/>
+  <color name="green_2"                    value="#47D35C"/>
+  <color name="green_3"                    value="#34B948"/>
+  <color name="green_4"                    value="#219E34"/>
+  <color name="green_5"                    value="#0e8420"/>
+    
+  <color name="light_1"                    value="#FFFFFF"/>
+  <color name="light_2"                    value="#FCFCFC"/>
+  <color name="light_3"                    value="#F6F5F4"/>
+  <color name="light_4"                    value="#DEDDDA"/>
+  <color name="light_5"                    value="#C0BFBC"/>
+  <color name="light_6"                    value="#B0AFAC"/>
+  <color name="light_7"                    value="#9A9996"/>
+  
+  <color name="orange_1"                   value="#F29879"/>
+  <color name="orange_2"                   value="#F08763"/>
+  <color name="orange_3"                   value="#ED764D"/>
+  <color name="orange_4"                   value="#EB6536"/>
+  <color name="orange_5"                   value="#E95420"/>
+  
+  <color name="purple_1"                   value="#b776b0"/>
+  <color name="purple_2"                   value="#c590bf"/>
+  <color name="purple_3"                   value="#77216F"/>
+  <color name="purple_4"                   value="#5E2750"/>
+  <color name="purple_5"                   value="#2C001E"/>
+  
+  <color name="red_1"                      value="#EA485C"/>
+  <color name="red_2"                      value="#DE374C"/>
+  <color name="red_3"                      value="#D3273B"/>
+  <color name="red_4"                      value="#c7162b"/>
+  <color name="red_5"                      value="#a91224"/>
+  
+  <color name="yellow_1"                   value="#FCCD87"/>
+  <color name="yellow_2"                   value="#FBC16A"/>
+  <color name="yellow_3"                   value="#FBB44C"/>
+  <color name="yellow_4"                   value="#FAA82F"/>
+  <color name="yellow_5"                   value="#F99B11"/>
+  
+  <!-- Global Styles -->
+  <style name="background-pattern"         background="libadwaita-dark-alt"/>
+  <style name="bracket-match"              foreground="green_5" bold="true"/>
+  <style name="current-line"               background="libadwaita-dark-alt"/>
+  <style name="current-line-number"        background="libadwaita-dark-alt" foreground="light_7"/>
+  <style name="cursor"                     foreground="orange_5"/>
+  <style name="draw-spaces"                foreground="dark_3"/>
+  <style name="line-numbers"               background="libadwaita-dark" foreground="dark_2"/>
+  <style name="map-overlay"                background="dark_1"/>
+  <style name="right-margin"               background="dark_1" foreground="dark_1"/>
+  <style name="search-match"               background="green_5" foreground="light_2"/>
+  <style name="text"                       background="libadwaita-dark" foreground="light_5"/>
+  
+   <!-- Defaults -->
+  <style name="def:base-n-integer"         foreground="purple_2"/>
+  <style name="def:boolean"                foreground="purple_2"/>
+  <style name="def:comment"                foreground="purple_1" italic="true"/>
+  <style name="def:constant"               foreground="purple_2"/>
+  <style name="def:decimal"                foreground="purple_2"/>
+  <style name="def:deletion"               strikethrough="true"/>
+  <style name="def:doc-comment-element"    foreground="light_7"/>
+  <style name="def:floating-point"         foreground="purple_2"/>
+  <style name="def:function"               foreground="purple_2" bold="true"/>
+  <style name="def:heading"                foreground="purple_2" bold="true"/>
+  <style name="def:keyword"                foreground="green_5" bold="true"/>
+  <style name="def:link-destination"       foreground="blue_2" italic="true" underline="low"/>
+  <style name="def:link-text"              foreground="red_2"/>
+  <style name="def:list-marker"            foreground="orange_5" bold="true"/>
+  <style name="def:net-address"            foreground="blue_2" underline="low"/>
+  <style name="def:number"                 foreground="blue_2"/>
+  <style name="def:preformatted-section"   foreground="purple_2"/>
+  <style name="def:preprocessor"           foreground="light_2" bold="true"/>
+  <style name="def:shebang"                foreground="purple_1" bold="true"/>
+  <style name="def:special-char"           foreground="red_1" bold="false"/>
+  <style name="def:string"                 foreground="yellow_2"/>
+  <style name="def:strong-emphasis"        bold="true"/>
+  <style name="def:type"                   foreground="blue_2" bold="true"/>
+  <style name="def:underlined"             underline="single"/>
+  <style name="def:warning"                underline="error" underline-color="yellow_4"/>
+  
+  <!-- C# -->
+  <style name="c-sharp:format"             foreground="purple_2"/>
+  <style name="c-sharp:preprocessor"       foreground="light_2" bold="true"/>
+  
+  <!-- C -->
+  <style name="c:printf"                   foreground="purple_2"/>
+  <style name="c:signal-name"              foreground="red_1"/>
+  <style name="c:storage-class"            foreground="orange_3" bold="true"/>
+  <style name="c:type-keyword"             foreground="orange_3" bold="true"/>
 
-    <!-- UI -->
-    <style name="text" foreground="chalk" background="inkstone" />
-    <style name="selection" foreground="white" background="primary" />
-    <style name="selection-unfocused" foreground="silk" background="primary" />
-    <style name="cursor" foreground="orange" />
-    <style name="secondary-cursor" foreground="satsuma" />
-    <style name="current-line" background="jet" />
-    <style name="line-numbers" foreground="silk" background="jet" bold="True" />
-    <style name="current-line-number" background="jet" />
-    <style name="bracket-match" foreground="green" background="inkstone" />
-    <style name="bracket-mismatch" foreground="red" background="inkstone" />
-    <style name="right-margin" foreground="ash" background="black" />
-    <style name="draw-spaces" foreground="ash" background="inkstone" />
-    <style name="search-match" foreground="white" background="green" />
+  <!-- CSS -->
+  <style name="css:id-selector"            foreground="light_2" bold="true"/>
+  <style name="css:property-name"          foreground="light_2" bold="true"/>
+  <style name="css:pseudo-selector"        foreground="purple_2" bold="true"/>
+  <style name="css:selector-symbol"        foreground="orange_3" bold="true"/>
+  <style name="css:type-selector"          foreground="light_2" bold="true"/>
+  <style name="css:vendor-specific"        foreground="yellow_5"/>
 
-    <!-- Comments -->
-    <style name="def:comment" foreground="aubergine" italic="True" />
-    <style name="def:shebang" foreground="aubergine" bold="True" />
-    <style name="def:doc-comment" foreground="aubergine" italic="True" />
-    <style name="def:doc-comment-element" italic="True" />
-    <style name="def:net-address-in-comment" foreground="white" italic="False" underline="True" />
+  <!-- Diff -->
+  <style name="diff:added-line"            foreground="green_5"/>
+  <style name="diff:changed-line"          foreground="orange_3"/>
+  <style name="diff:diff-file"             foreground="blue_2"/>
+  <style name="diff:location"              foreground="yellow_4"/>
+  <style name="diff:removed-line"          foreground="red_1"/>
 
-    <!-- Constants and Variables-->
-    <style name="def:constant" foreground="green" />
-    <style name="def:string" foreground="yellow" />
-    <style name="def:special-char" foreground="green" />
-    <style name="def:special-constant" foreground="green" bold="True" />
-    <style name="def:number" foreground="blue" />
-    <style name="def:complex" foreground="blue" />
-    <style name="def:floating-point" foreground="blue" />
-    <style name="def:decimal" foreground="blue" />
-    <style name="def:keyword" foreground="green" />
-    <style name="def:builtin" foreground="green" bold="True" />
-    <style name="def:variable" foreground="purple"/>
-    <style name="def:preprocessor" foreground="white" bold="True" />
-    <style name="def:operator" foreground="white" bold="True" />
-    <style name="sh:variable-definition" foreground="white" bold="True" />
+  <!-- Go -->
+  <style name="go:printf"                  foreground="purple_2"/>
 
-    <!-- Identifiers -->
-    <style name="def:identifier" foreground="light_aubergine" />
-    <style name="def:function" foreground="light_aubergine" bold="True" />
+  <!-- Python 2 -->
+  <style name="python:builtin-function"    foreground="blue_2"/>
+  <style name="python:class-name"          foreground="light_2" bold="true"/>
+  <style name="python:module-handler"      foreground="red_1"/>
 
-    <!-- Statements -->
-    <style name="def:statement" foreground="satsuma" bold="True" />
+  <!-- Rust -->
+  <style name="rust:attribute"             foreground="purple_2"/>
+  <style name="rust:lifetime"              foreground="orange_2" bold="false" italic="false"/>
+  <style name="rust:macro"                 foreground="purple_2" bold="false"/>
+  <style name="rust:scope"                 foreground="orange_2"/>
 
-    <!-- Types -->
-    <style name="def:type" foreground="linkblue" bold="True" />
+  <!-- Vala -->
+  <style name="vala:attributes"            foreground="light_5" bold="false"/>
 
-    <!-- Annotations -->
-    <style name="def:error" foreground="red" background="jet" bold="True" underline="True" strikethrough="False" />
-    <style name="def:warning" foreground="orange" background="jet" bold="True" underline="True" strikethrough="False" />
-    <style name="def:note" foreground="black" background="clementine" bold="True" italic="False" />
-    <style name="def:underlined" foreground="chalk" underline="True" />
+  <!-- XML -->
+  <style name="xml:attribute-name"         foreground="blue_2" bold="true"/>
+  <style name="xml:attribute-value"        foreground="yellow_4"/>
+  <style name="xml:element-name"           foreground="purple_2"/>
+  <style name="xml:namespace"              foreground="yellow_4"/>
+  <style name="xml:processing-instruction" foreground="yellow_4" bold="true"/>
+
 </style-scheme>

--- a/gtksourceview/src/default.xml.in
+++ b/gtksourceview/src/default.xml.in
@@ -1,94 +1,146 @@
 <?xml version="1.0" encoding="UTF-8"?>
-    <style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" version="1.0">
-    <author>Martin Wimpress</author>
-    <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
-    <!-- Primary Accent -->
-    <color name="primary" value="#E95420" />
+<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" version="1.0">
+  <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
 
-    <!-- Blacks -->
-    <color name="black" value="#000000" />
-    <color name="jet" value="#181818" />
-    <color name="inkstone" value="#333333" />
-    <color name="slate" value="#5D5D5D" />
-    <color name="graphite" value="#666666" />
-    <!-- Whites -->
-    <color name="white" value="#FFFFFF" />
-    <color name="porcelain" value="#F7F7F7" />
-    <color name="chalk" value="#E5E5E5" />
-    <color name="silk" value="#CDCDCD" />
-    <color name="ash" value="#878787" />
-    <!-- Purples -->
-    <color name="aubergine" value="#924D8B" />
-    <color name="purple" value="#762572" />
-    <color name="light_aubergine" value="#77216F" />
-    <color name="mid_aubergine" value="#5E2750" />
-    <color name="dark_aubergine" value="#2C001E" />
-    <!-- Reds -->
-    <color name="red" value="#c7162b" />
-    <!-- Oranges -->
-    <color name="orange" value="#E95420" />
-    <color name="satsuma" value="#ED764D" />
-    <color name="clementine" value="#F29879" />
-    <!-- Yellows -->
-    <color name="yellow" value="#f99b11" />
-    <!-- Greens -->
-    <color name="green" value="#0e8420" />
-    <!-- Blues -->
-    <color name="blue" value="#19B6EE" />
-    <color name="linkblue" value="#007aa6" />
-    <color name="darkblue" value="#335280" />
+  <!-- Yaru palette -->
+  <color name="blue_1"                     value="#75d3f4"/>
+  <color name="blue_2"                     value="#47c4f1"/>
+  <color name="blue_3"                     value="#19B6EE"/>
+  <color name="blue_4"                     value="#007aa6"/>
+  <color name="blue_5"                     value="#335280"/>
+  
+  <color name="dark_1"                     value="#77767B"/>
+  <color name="dark_2"                     value="#5E5C64"/>
+  <color name="dark_3"                     value="#504E55"/>
+  <color name="dark_4"                     value="#3D3846"/>
+  <color name="dark_5"                     value="#241F31"/>
+  <color name="dark_6"                     value="#000000"/>
+  
+  <color name="green_1"                    value="#5AED70"/>
+  <color name="green_2"                    value="#47D35C"/>
+  <color name="green_3"                    value="#34B948"/>
+  <color name="green_4"                    value="#219E34"/>
+  <color name="green_5"                    value="#0e8420"/>
+    
+  <color name="light_1"                    value="#FFFFFF"/>
+  <color name="light_2"                    value="#FCFCFC"/>
+  <color name="light_3"                    value="#F6F5F4"/>
+  <color name="light_4"                    value="#DEDDDA"/>
+  <color name="light_5"                    value="#C0BFBC"/>
+  <color name="light_6"                    value="#B0AFAC"/>
+  <color name="light_7"                    value="#9A9996"/>
+  
+  <color name="orange_1"                   value="#F29879"/>
+  <color name="orange_2"                   value="#F08763"/>
+  <color name="orange_3"                   value="#ED764D"/>
+  <color name="orange_4"                   value="#EB6536"/>
+  <color name="orange_5"                   value="#E95420"/>
+  
+  <color name="purple_1"                   value="#924D8B"/>
+  <color name="purple_2"                   value="#762572"/>
+  <color name="purple_3"                   value="#77216F"/>
+  <color name="purple_4"                   value="#5E2750"/>
+  <color name="purple_5"                   value="#2C001E"/>
+  
+  <color name="red_1"                      value="#EA485C"/>
+  <color name="red_2"                      value="#DE374C"/>
+  <color name="red_3"                      value="#D3273B"/>
+  <color name="red_4"                      value="#c7162b"/>
+  <color name="red_5"                      value="#a91224"/>
+  
+  <color name="yellow_1"                   value="#FCCD87"/>
+  <color name="yellow_2"                   value="#FBC16A"/>
+  <color name="yellow_3"                   value="#FBB44C"/>
+  <color name="yellow_4"                   value="#FAA82F"/>
+  <color name="yellow_5"                   value="#F99B11"/>
 
-    <!-- UI -->
-    <style name="text" foreground="jet" background="white" />
-    <style name="selection" foreground="white" background="primary" />
-    <style name="selection-unfocused" foreground="silk" background="primary" />
-    <style name="cursor" foreground="orange" />
-    <style name="secondary-cursor" foreground="satsuma" />
-    <style name="current-line" background="silk" />
-    <style name="line-numbers" foreground="jet" background="silk" bold="True" />
-    <style name="current-line-number" background="silk" />
-    <style name="bracket-match" foreground="green" background="porcelain" />
-    <style name="bracket-mismatch" foreground="red" background="porcelain" />
-    <style name="right-margin" foreground="slate" background="ash" />
-    <style name="draw-spaces" foreground="graphite" background="white" />
-    <style name="search-match" foreground="white" background="green" />
+  <!-- Global Styles -->
+  <style name="background-pattern"         background="light_3"/>
+  <style name="bracket-match"              foreground="green_5" bold="true"/>
+  <style name="current-line"               background="light_3"/>
+  <style name="current-line-number"        background="light_3" foreground="light_7"/>
+  <style name="cursor"                     foreground="orange_5"/>
+  <style name="draw-spaces"                foreground="light_6"/>
+  <style name="line-numbers"               background="light_2" foreground="light_6"/>
+  <style name="map-overlay"                background="dark_1"/>
+  <style name="right-margin"               background="dark_1" foreground="dark_1"/>
+  <style name="search-match"               background="green_1" foreground="dark_4"/>
+  <style name="text"                       background="light_2" foreground="dark_3"/>
 
-    <!-- Comments -->
-    <style name="def:comment" foreground="aubergine" italic="True" />
-    <style name="def:shebang" foreground="aubergine" bold="True" />
-    <style name="def:doc-comment" foreground="aubergine" italic="True" />
-    <style name="def:doc-comment-element" italic="True" />
-    <style name="def:net-address-in-comment" foreground="black" italic="False" underline="True" />
+  <!-- Defaults -->
+  <style name="def:base-n-integer"         foreground="purple_4"/>
+  <style name="def:boolean"                foreground="purple_4"/>
+  <style name="def:comment"                foreground="purple_1" italic="true"/>
+  <style name="def:constant"               foreground="purple_4"/>
+  <style name="def:decimal"                foreground="purple_4"/>
+  <style name="def:deletion"               strikethrough="true"/>
+  <style name="def:doc-comment-element"    foreground="dark_3"/>
+  <style name="def:floating-point"         foreground="purple_4"/>
+  <style name="def:function"               foreground="purple_3" bold="true"/>
+  <style name="def:heading"                foreground="purple_5" bold="true"/>
+  <style name="def:keyword"                foreground="green_5" bold="true"/>
+  <style name="def:link-destination"       foreground="blue_3" italic="true" underline="low"/>
+  <style name="def:link-text"              foreground="red_3"/>
+  <style name="def:list-marker"            foreground="orange_5" bold="true"/>
+  <style name="def:net-address"            foreground="blue_3" underline="low"/>
+  <style name="def:number"                 foreground="blue_3"/>
+  <style name="def:preformatted-section"   foreground="purple_4"/>
+  <style name="def:preprocessor"           foreground="dark_6" bold="true"/>
+  <style name="def:shebang"                foreground="purple_1" bold="true"/>
+  <style name="def:special-char"           foreground="red_2" bold="false"/>
+  <style name="def:string"                 foreground="yellow_5"/>
+  <style name="def:strong-emphasis"        bold="true"/>
+  <style name="def:type"                   foreground="blue_4" bold="true"/>
+  <style name="def:underlined"             underline="single"/>
+  <style name="def:warning"                underline="error" underline-color="yellow_4"/>
 
-    <!-- Constants and Variables-->
-    <style name="def:constant" foreground="green" />
-    <style name="def:string" foreground="yellow" />
-    <style name="def:special-char" foreground="green" />
-    <style name="def:special-constant" foreground="green" bold="True" />
-    <style name="def:number" foreground="blue" />
-    <style name="def:complex" foreground="blue" />
-    <style name="def:floating-point" foreground="blue" />
-    <style name="def:decimal" foreground="blue" />
-    <style name="def:keyword" foreground="green" />
-    <style name="def:builtin" foreground="green" bold="True" />
-    <style name="def:variable" foreground="purple"/>
-    <style name="def:preprocessor" foreground="black" bold="True" />
-    <style name="def:operator" foreground="black" bold="True" />
-    <style name="sh:variable-definition" foreground="black" bold="True" />
+  <!-- C# -->
+  <style name="c-sharp:format"             foreground="purple_4"/>
+  <style name="c-sharp:preprocessor"       foreground="dark_6" bold="true"/>
 
-    <!-- Identifiers -->
-    <style name="def:identifier" foreground="light_aubergine" />
-    <style name="def:function" foreground="light_aubergine" bold="True" />
+  <!-- C -->
+  <style name="c:printf"                   foreground="purple_4"/>
+  <style name="c:signal-name"              foreground="red_4"/>
+  <style name="c:storage-class"            foreground="orange_5" bold="true"/>
+  <style name="c:type-keyword"             foreground="orange_5" bold="true"/>
 
-    <!-- Statements -->
-    <style name="def:statement" foreground="satsuma" bold="True" />
+  <!-- CSS -->
+  <style name="css:id-selector"            foreground="dark_6" bold="true"/>
+  <style name="css:property-name"          foreground="dark_6" bold="true"/>
+  <style name="css:pseudo-selector"        foreground="purple_4" bold="true"/>
+  <style name="css:selector-symbol"        foreground="orange_5" bold="true"/>
+  <style name="css:type-selector"          foreground="dark_6" bold="true"/>
+  <style name="css:vendor-specific"        foreground="yellow_5"/>
 
-    <!-- Types -->
-    <style name="def:type" foreground="linkblue" bold="True" />
+  <!-- Diff -->
+  <style name="diff:added-line"            foreground="green_5"/>
+  <style name="diff:changed-line"          foreground="orange_4"/>
+  <style name="diff:diff-file"             foreground="blue_4"/>
+  <style name="diff:location"              foreground="yellow_5"/>
+  <style name="diff:removed-line"          foreground="red_1"/>
 
-    <!-- Annotations -->
-    <style name="def:error" foreground="red" background="porcelain" bold="True" underline="True" strikethrough="False" />
-    <style name="def:warning" foreground="orange" background="porcelain" bold="True" underline="True" strikethrough="False" />
-    <style name="def:note" foreground="black" background="clementine" bold="True" italic="False" />
-    <style name="def:underlined" foreground="jet" underline="True" />
+  <!-- Go -->
+  <style name="go:printf"                  foreground="purple_4"/>
+
+  <!-- Python 2 -->
+  <style name="python:builtin-function"    foreground="blue_4"/>
+  <style name="python:class-name"          foreground="dark_6" bold="true"/>
+  <style name="python:module-handler"      foreground="red_3"/>
+
+  <!-- Rust -->
+  <style name="rust:attribute"             foreground="purple_4"/>
+  <style name="rust:lifetime"              foreground="orange_5" bold="false" italic="false"/>
+  <style name="rust:macro"                 foreground="purple_4" bold="false"/>
+  <style name="rust:scope"                 foreground="orange_5"/>
+
+  <!-- Vala -->
+  <style name="vala:attributes"            foreground="dark_2" bold="false"/>
+
+  <!-- XML -->
+  <style name="xml:attribute-name"         foreground="blue_4" bold="true"/>
+  <style name="xml:attribute-value"        foreground="yellow_5"/>
+  <style name="xml:element-name"           foreground="purple_4"/>
+  <style name="xml:namespace"              foreground="yellow_5"/>
+  <style name="xml:processing-instruction" foreground="yellow_5" bold="true"/>
+
 </style-scheme>


### PR DESCRIPTION
- [x] updated `default` and `dark` gtksourceview styles to use `GTK-4` palette.
- [x] improved readability in both `default` and `dark` styles.
- [x] added color-support for common filetypes (_see issue: #3419_).
- [ ] reflect the changes in `mate` variants.

#### screenshots:
| ubuntu 21.10 | PR: |
| ----------------- | ------- |
| ![old-lighty](https://user-images.githubusercontent.com/54065734/156159412-f88a8c94-689a-4d3f-ac1a-454cf26111bd.png) | ![light](https://user-images.githubusercontent.com/54065734/156159454-ffc152ad-aaf7-461f-a330-6d5fbb720f31.png) |
| ![old-darky](https://user-images.githubusercontent.com/54065734/156159525-e475a5d7-5185-4450-9949-bb5028012c20.png) | ![dark](https://user-images.githubusercontent.com/54065734/156159575-71f469f5-4a8f-4fa1-8ef4-f48f8892fb1a.png) |


Closes: #3419 