### PR TITLE
Fix close button hover bg

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_window-picker.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_window-picker.scss
@@ -38,7 +38,7 @@ $window_close_button_padding: 3px;
   & StIcon { icon-size: 24px; } // uses non standard icon size
 
   &:hover {
-    background-color: lighten($window_close_button_color, 15%); // Yaru: lighter close button because of our darker overview bg
+    background-color: lighten($window_close_button_color, 5%); // Yaru: lighter close button because of our darker overview bg
   }
 
   &:active {


### PR DESCRIPTION
Fix over bright hover close button.

**Before:**

![Capture d’écran du 2022-03-03 09-25-12](https://user-images.githubusercontent.com/36476595/156526095-76d145b8-7ff1-4076-b276-4e47152c465f.png)

**After:**

![Capture d’écran du 2022-03-03 09-20-28](https://user-images.githubusercontent.com/36476595/156526128-d911fe42-19cb-4316-9fdf-e2d92762caa8.png)

### Explanation

Before the sync with GS42, the default state was using 10% lighten of `$osd_bg_color` and hover 15% (so it's 5% lighter than normal state).
With the GS42 sync, there's a new var `$window_close_button_color` with the same value as normal state (10%). But the hover state is lighten this var to 15% again (so 25% which is really too bright).
So to fix that, I decreased the hover state lighten to 5%, so it looks like before.