### PR TITLE
Fix popovers menu item states

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
@@ -45,12 +45,12 @@
     margin-bottom: 0;
     box-shadow: inset 0 -1px 0 0 darken($checked_bg_color, 5%);
     border-radius: $base_border_radius $base_border_radius 0 0;
-    &:focus,&:hover { background-color: lighten($checked_bg_color, 3%) !important;}
-    &:active { background-color: lighten($checked_bg_color, 5%) !important;}
+    &:focus,&:hover { background-color: if($variant == 'light', darken($checked_bg_color, 6%), lighten($checked_bg_color, 6%)) !important;} // Yaru change: add support for light theme
+    &:active { background-color: if($variant == 'light', darken($checked_bg_color, 9%), lighten($checked_bg_color, 9%)) !important;} // Yaru change: ↑↑↑
   }
 
   &:active {
-    background-color: lighten($active_bg_color, 5%);
+    background-color: if($variant == 'light', darken($checked_bg_color, 9%), lighten($checked_bg_color, 9%)); // Yaru change: ↑↑↑
     color: $active_fg_color;
   }
 


### PR DESCRIPTION
Fix popovers menu item states: it shouldn't lighten the bg on hover and active in light theme.

**Before:**


https://user-images.githubusercontent.com/36476595/156554388-420aa767-63cc-4b86-8380-2b355a7fbaed.mp4

**After:**


https://user-images.githubusercontent.com/36476595/156554404-ea578b2a-9153-4842-b26e-e2c7f0b5f505.mp4

Related to #3407