### PR TITLE
Fix search entry alignement

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
@@ -8,7 +8,7 @@ $search_entry_height: 36px;
   border-radius: $search_entry_height * 0.5; // half the height
 
   margin-top: $base_padding * 4; // Yaru change: realign search entry due to fixed panel opacity
-  margin-bottom: 0; // Yaru change: realign search entry due to fixed panel opacity
+  margin-bottom: $base_padding * 2; // Yaru change: realign search entry due to fixed panel opacity
   padding: $base_padding+1 $base_padding+3;
   width: $search_entry_width;
 
@@ -22,5 +22,9 @@ $search_entry_height: 36px;
     icon-size: $base_icon_size;
     margin-top: 2px; // center vertically
     padding: 0 4px;
+  }
+
+  &:selected {
+    color: red!important;
   }
 }


### PR DESCRIPTION
Increase search entry margin bottom because the entry was too close from workspaces thumbnails.

**Before:**

![Capture d’écran du 2022-03-04 11-40-08](https://user-images.githubusercontent.com/36476595/156748471-8b51cb79-396f-4d7b-b374-56ecc5fe67be.png)

**After:**

![Capture d’écran du 2022-03-04 11-37-06](https://user-images.githubusercontent.com/36476595/156748498-5c87ebcf-bcb1-4f05-824a-3a5937c3f696.png)
