### PR TITLE
Fix focused unlock-dialog entry

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-dialog.scss
@@ -188,6 +188,7 @@
     border:none !important;
     &:focus { 
       background-color: transparentize($fg_color, 0.9);
+      box-shadow: none; // Yaru change: remove box-shadow because of ugly render
     }
     &:insensitive { 
       color: transparentize($fg_color, 0.5);


### PR DESCRIPTION
As the lock screen entry is transparent and as we are using a box-shadow for focused entries, it result a very weird effect of ugly background.

**Before:**

![Capture d’écran du 2022-03-04 12-09-49](https://user-images.githubusercontent.com/36476595/156753156-067f38bf-4d32-434e-8ec4-4acfbc0c0f75.png)

**After:**

![Capture d’écran du 2022-03-04 11-58-48](https://user-images.githubusercontent.com/36476595/156753171-ec6cd2e8-7241-4328-b72a-1769558fac7e.png)

Related to #3407