### PR TITLE
Add missing explore2 icon

### DIFF
--- a/icons/Yaru/scalable/emblems/explore2-symbolic.svg
+++ b/icons/Yaru/scalable/emblems/explore2-symbolic.svg
@@ -1,0 +1,1 @@
+explore-symbolic.svg

--- a/icons/src/symlinks/symbolic/emblems.list
+++ b/icons/src/symlinks/symbolic/emblems.list
@@ -1,1 +1,2 @@
 emblem-videos-symbolic.svg yelp-page-video-symbolic.svg
+explore-symbolic.svg explore2-symbolic.svg


### PR DESCRIPTION
This icon is used here (Adwaita on the screenshot):

![Capture d’écran du 2022-03-13 19-27-16](https://user-images.githubusercontent.com/36476595/158073810-afaebbf1-7c44-450f-b2f2-2c7fa58fcb8b.png)
