### PR TITLE
Gs dash label border and app-dot realign

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
@@ -24,7 +24,7 @@ $dash_border_radius: $modal_radius + $dash_padding;
 
   // Running app indicator (also shown in app grid)
   .app-well-app-running-dot {
-    margin-bottom: 8px; // hardcoded - Yaru change: move dot a bit down
+    margin-bottom: 13px; // hardcoded - Yaru change: move dot a bit down
     background-color: $selected_bg_color; // Yaru: we want an orange dot
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
@@ -74,5 +74,5 @@ $dash_border_radius: $modal_radius + $dash_padding;
   padding: $base_padding $base_padding * 2;
   text-align: center;
   -y-offset: $base_margin * 2; // distance from the dash edge
-  border: 1px solid $borders_color_dark;
+  border: 1px solid $borders_color_dark; // Yaru change: add border
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
@@ -74,4 +74,5 @@ $dash_border_radius: $modal_radius + $dash_padding;
   padding: $base_padding $base_padding * 2;
   text-align: center;
   -y-offset: $base_margin * 2; // distance from the dash edge
+  border: 1px solid $borders_color_dark;
 }


### PR DESCRIPTION
Add border to dash-label and align app-running-dot like dock ones.

**Before:**

![Capture d’écran de 2022-03-14 09-40-19](https://user-images.githubusercontent.com/36476595/158135620-cd886908-6eac-4293-8a15-0c18402bdce5.png)

**After:**

![Capture d’écran de 2022-03-14 09-38-30](https://user-images.githubusercontent.com/36476595/158135641-0643acb4-a5c6-4f20-9413-5b31397fb388.png)
