### PR TITLE
gtk accent colours: subtler purple, magenta and red

### DIFF
--- a/common/accent-colors.scss.in
+++ b/common/accent-colors.scss.in
@@ -15,11 +15,11 @@
     } @else if $accent_color == 'blue' {
         $color: #0073E5;
     } @else if $accent_color == 'purple' {
-        $color: #8856EB;
+        $color: #7764D8;
     } @else if $accent_color == 'magenta' {
-        $color: #BC33DB;
+        $color: #A15AAF;
     } @else if $accent_color == 'red' {
-        $color: #E61D34;
+        $color: #BA4F97;
     } @else {
         @error('No known accent color defined!');
     }

--- a/common/accent-colors.scss.in
+++ b/common/accent-colors.scss.in
@@ -19,7 +19,7 @@
     } @else if $accent_color == 'magenta' {
         $color: #A15AAF;
     } @else if $accent_color == 'red' {
-        $color: #BA4F97;
+        $color: #DA3450;
     } @else {
         @error('No known accent color defined!');
     }


### PR DESCRIPTION
Adjust some of the accent colours to be less saturated and more in line with the rest of the palette.

Current set:

![image](https://user-images.githubusercontent.com/2741678/159070002-f6683aa1-2d34-4803-83a1-d89aca89e73a.png)

The colours have been tested against white and black text, and meet the minimum contrast ratio required by [WCAG 1.4.11](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) (This minimum is 4.5:1). The numbers inisde the colour swatches represent the actual contrast against white and black text respectively.

