### PR TITLE
Fix go-last-symbolic-rtl icon

### DIFF
--- a/icons/Yaru/scalable/actions/go-last-symbolic-rtl.svg
+++ b/icons/Yaru/scalable/actions/go-last-symbolic-rtl.svg
@@ -1,1 +1,1 @@
-go-last-symbolic.svg
+go-first-symbolic.svg

--- a/icons/src/symlinks/symbolic/actions.list
+++ b/icons/src/symlinks/symbolic/actions.list
@@ -16,13 +16,11 @@ format-ordered-list-symbolic.svg view-list-ordered-symbolic.svg
 format-text-direction-symbolic-rtl.svg format-text-direction-rtl-symbolic-rtl.svg
 format-unordered-list-symbolic.svg outline-symbolic.svg
 globe-symbolic.svg globe-centered-symbolic.svg
-go-first-symbolic.svg go-first-symbolic-rtl.svg
-go-first-symbolic.svg go-last-rtl-symbolic.svg
 go-first-symbolic.svg go-last-symbolic-rtl.svg
+go-first-symbolic.svg go-last-rtl-symbolic.svg
 go-jump-symbolic-rtl.svg go-jump-rtl-symbolic.svg
-go-last-symbolic.svg go-first-rtl-symbolic.svg
 go-last-symbolic.svg go-first-symbolic-rtl.svg
-go-last-symbolic.svg go-last-symbolic-rtl.svg
+go-last-symbolic.svg go-first-rtl-symbolic.svg
 go-next-symbolic.svg go-previous-rtl-symbolic.svg
 go-next-symbolic.svg go-previous-symbolic-rtl.svg
 go-next-symbolic.svg carousel-arrow-next-symbolic.svg


### PR DESCRIPTION
Fix `go-last-symbolic-rtl` icon which was symlinked to the wrong icon. Now it point to the left.
Also clean duplicated go-last-* and go-first-* symlinks.

Closes #3506 