### PR TITLE
Remove typo in _search-entry

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_search-entry.scss
@@ -23,8 +23,4 @@ $search_entry_height: 36px;
     margin-top: 2px; // center vertically
     padding: 0 4px;
   }
-
-  &:selected {
-    color: red!important;
-  }
 }


### PR DESCRIPTION
Remove a  typo in `_search-entry` I committed by mistake in #3446.