### PR TITLE
Increase contrast of popover menus

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -3,7 +3,7 @@
 @import 'palette';
 
 $base_color: if($variant=='light', #ffffff, lighten($jet, 4%));
-$bg_color_dark: lighten($jet, 6%);
+$bg_color_dark: lighten($jet, 2%);
 $bg_color: if($variant=='light', #FAFAFA, $bg_color_dark);
 $fg_color_dark: $porcelain;
 $fg_color: if($variant=='light', $inkstone, $fg_color_dark);
@@ -17,7 +17,7 @@ $selected_borders_color: if($variant=='light', darken($selected_bg_color, 15%), 
 $borders_color_dark: lighten(desaturate(lighten($jet, 4%), 100%), 14%); // Yaru: used for dash and other dark elements on light theme
 $borders_color: if($variant=='light', darken($bg_color, 20%), $borders_color_dark);
 $alt_borders_color: if($variant=='light', darken($bg_color, 24%), darken($bg_color, 10%));
-$borders_edge: if($variant=='light', transparentize(white, 0.2), transparentize($fg_color, 0.93));
+$borders_edge: if($variant=='light', transparentize(white, 0.2), transparentize($fg_color, 0.85));
 
 $link_color: if($variant=='light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
 $link_visited_color: if($variant=='light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));


### PR DESCRIPTION
Use a darker `$bg_color_dark` value and a lighten border.

**Before - `lighten($jet, 6%)`:**

![Capture d’écran du 2022-03-20 11-31-36](https://user-images.githubusercontent.com/36476595/159158268-88162655-6a5d-4b8c-9ddc-be8177a7300e.png)

**After - `lighten($jet, 2%)` + lighten border:**

![Capture d’écran du 2022-03-20 11-46-23](https://user-images.githubusercontent.com/36476595/159158748-f580b1e5-727f-4f6c-9e54-6954d5b5a1df.png)

This will affect all the popovers, but as we have the same issue with the overview which use the same bg as login screen, this is imo not a problem.

Closes #3490