### PR TITLE
Adjust hue of magenta so it corresponds better to the name magenta

### DIFF
--- a/common/accent-colors.scss.in
+++ b/common/accent-colors.scss.in
@@ -17,7 +17,7 @@
     } @else if $accent_color == 'purple' {
         $color: #7764D8;
     } @else if $accent_color == 'magenta' {
-        $color: #A15AAF;
+        $color: #B34CB3;
     } @else if $accent_color == 'red' {
         $color: #DA3450;
     } @else {


### PR DESCRIPTION
Adjusts the hue of the accent colour named magenta to better match the actual magenta colour. (https://en.wikipedia.org/wiki/Magenta)

N.B.: The saturation and brightness are still toned down to a) meet contrast ratio requirements and b) avoid looking garish, especially on dark backgrounds.

Addresses a comment by @Muqtxdir made on this pr https://github.com/ubuntu/yaru/pull/3496#issuecomment-1073048482


![image](https://user-images.githubusercontent.com/2741678/159240278-9e847cd9-fc71-4c7b-b863-c35297d13540.png)
