### PR TITLE
gtk: Add MetacityThemeName to index.theme

### DIFF
--- a/gtk/src/index.theme.in
+++ b/gtk/src/index.theme.in
@@ -4,6 +4,7 @@ Type=X-GNOME-Metatheme
 Comment=Ubuntu @FlavourThemeName@ theme
 Encoding=UTF-8
 GtkTheme=@FlavourThemeName@
+MetacityTheme=@MetacityThemeName@
 IconTheme=@IconThemeName@
 CursorTheme=@ThemeName@
 CursorSize=24

--- a/gtk/src/meson.build
+++ b/gtk/src/meson.build
@@ -23,6 +23,7 @@ foreach flavour: flavours
   conf_data.set('ThemeName', meson.project_name())
   conf_data.set('FlavourThemeName', theme_name)
   conf_data.set('IconThemeName', is_accent ? '-'.join(meson.project_name(), base_theme_name) : meson.project_name())
+  conf_data.set('MetacityThemeName', is_dark ? '-'.join(meson.project_name(), 'dark') : meson.project_name())
   configure_file(input: 'index.theme.in',
     output: '@0@-index.theme'.format(theme_name),
     configuration: conf_data,


### PR DESCRIPTION
Adding `MetacityThemeName` to `index.theme` makes all the Yaru theme variants compatible with MATE Appearance Properties