### PR TITLE
metacity: Correct titlebar contrast for default and dark themes

### DIFF
--- a/metacity/src/dark/metacity-theme-1.xml.in
+++ b/metacity/src/dark/metacity-theme-1.xml.in
@@ -10,15 +10,15 @@
 
 	<!-- CONSTANTS -->
 	<constant name="C_titlebar" value="#222222" />
-	<constant name="C_titlebar_unfocused" value="#3e3e3e" />
-	<constant name="C_titlebar_border_focused" value="#232323" />
-	<constant name="C_titlebar_border_unfocused" value="#222222" />
-	<constant name="C_titlebar_highlight_focused" value="#3a3a3a" />
-	<constant name="C_titlebar_highlight_unfocused" value="#4b4b4b" />
-	<constant name="C_border_focused" value="#232323" />
-	<constant name="C_border_unfocused" value="#222222" />
+	<constant name="C_titlebar_unfocused" value="#2c2c2c" />
+	<constant name="C_titlebar_border_focused" value="#181818" />
+	<constant name="C_titlebar_border_unfocused" value="#181818" />
+	<constant name="C_titlebar_highlight_focused" value="#313131" />
+	<constant name="C_titlebar_highlight_unfocused" value="#3a3a3a" />
+	<constant name="C_border_focused" value="#161516" />
+	<constant name="C_border_unfocused" value="#161516" />
 	<constant name="C_title_focused" value="#f7f7f7" />
-	<constant name="C_title_unfocused" value="#d2d2d2" />
+	<constant name="C_title_unfocused" value="#b5b5b5" />
 
 	<!-- GEOMETRY -->
 	<!-- focused window -->

--- a/metacity/src/default/metacity-theme-1.xml.in
+++ b/metacity/src/default/metacity-theme-1.xml.in
@@ -10,11 +10,11 @@
 
 	<!-- CONSTANTS -->
 	<constant name="C_titlebar" value="#ebebeb" />
-	<constant name="C_titlebar_unfocused" value="#f7f7f7" />
-	<constant name="C_titlebar_border_focused" value="#919191" />
-	<constant name="C_titlebar_border_unfocused" value="#b8b8b8" />
-	<constant name="C_titlebar_highlight_focused" value="#f8f8f8" />
-	<constant name="C_titlebar_highlight_unfocused" value="#fdfdfd" />
+	<constant name="C_titlebar_unfocused" value="#fafafa" />
+	<constant name="C_titlebar_border_focused" value="#848484" />
+	<constant name="C_titlebar_border_unfocused" value="#bbbbbb" />
+	<constant name="C_titlebar_highlight_focused" value="#f9f9f9" />
+	<constant name="C_titlebar_highlight_unfocused" value="#fefefe" />
 	<constant name="C_border_focused" value="#919191" />
 	<constant name="C_border_unfocused" value="#b8b8b8" />
 	<constant name="C_title_focused" value="#3d3d3d" />


### PR DESCRIPTION
This pull request corrects `metacity-theme-1.xml.in` for the `default` and `dark` themes so Metacity matches GNOME/CSD windows. Essentially this is just copying the constants over from the `mate` and `mate-dark` themes.