### PR TITLE
Makes Unity7 panel follow bg color

### DIFF
--- a/gtk/src/default/gtk-3.0/apps/_unity7.scss
+++ b/gtk/src/default/gtk-3.0/apps/_unity7.scss
@@ -1,5 +1,5 @@
-$panel_bg_color: $jet;
-$panel_fg_color: $porcelain;
+$panel_bg_color: if($variant == 'light', darken($porcelain, 4%), $jet);
+$panel_fg_color: $fg_color;
 $wm_border_unfocused: none;
 $wm_border_focused: if($variant=='light', transparentize(black, 0.9), transparentize($borders_color, 0.1));
 $titlebar_bg_color: if($variant=='light', darken($porcelain, 9%), lighten($jet, 4%));


### PR DESCRIPTION
As we support now dark/light panel icons, this PR makes the Unity7 panel light in light theme and dark in dark theme.

**Before:**

![Capture d’écran du 2022-03-23 17-02-17](https://user-images.githubusercontent.com/36476595/159744020-30339d31-9421-4684-aac1-8442b80a397d.png)

**After:**

![Capture d’écran du 2022-03-23 17-03-57](https://user-images.githubusercontent.com/36476595/159744051-898f52a8-5176-4d40-8ccf-e6be6b317b77.png)
