### PR TITLE
Mate: Hide focus outline on menu-bar buttons

### DIFF
--- a/gtk/src/default/gtk-3.0/apps/_mate.scss
+++ b/gtk/src/default/gtk-3.0/apps/_mate.scss
@@ -99,11 +99,16 @@ MatePanelAppletFrameDBus > MatePanelAppletFrameDBus {
 /* outlines */
 window.background, /* selector where outlines are writen on GtkTrayIcon */
 .mate-panel-menu-bar menubar,
-.mate-panel-menu-bar button,
+// .mate-panel-menu-bar button,
 .mate-panel-menu-bar PanelApplet {
     outline-style: solid;
     outline-offset: -2px;
     outline-color: $focus_border_color;
+}
+
+// Hide focus outline on menu-bar buttons
+.mate-panel-menu-bar button {
+  outline-color: transparent;
 }
 
 PanelApplet.wnck-applet .wnck-pager {


### PR DESCRIPTION
**Before:**

![Capture d’écran du 2022-03-24 17-18-57](https://user-images.githubusercontent.com/36476595/159962299-fe21a3d8-a057-43d3-a768-a000e083f921.png)

**After:**

![Capture d’écran du 2022-03-24 17-16-30](https://user-images.githubusercontent.com/36476595/159962321-3c8b2a6a-bf42-41fd-8ab2-815f1160b873.png)

Closes #2760

CC @flexiondotorg 