### PR TITLE
Gtk3: Fix selected image

### DIFF
--- a/gtk/src/default/gtk-3.0/_tweaks.scss
+++ b/gtk/src/default/gtk-3.0/_tweaks.scss
@@ -463,3 +463,11 @@ scale:not(.marks-after) {
     }
   }
 }
+
+// Fix for selected image
+// By default this use white, but as we use lighter bg_color
+// we need a darker selected background on light theme
+// and a lighter one on dark theme
+image:selected {
+  background: if($variant == 'light', darken($bg_color, 10%), lighten($bg_color, 10%));
+}


### PR DESCRIPTION
Fix for selected image.
By default this use white, but as we use lighter `bg_color` we need a darker selected background on light theme and a lighter one on dark theme.

![Capture d’écran du 2022-03-25 15-29-11](https://user-images.githubusercontent.com/36476595/160141225-7dc8fb11-58bf-41e5-9394-61e92d2af8cb.png)
![Capture d’écran du 2022-03-25 15-29-31](https://user-images.githubusercontent.com/36476595/160141232-81810c00-0238-4945-bcb3-fd4c16772b80.png)

Closes #2813