### PR TITLE
icons: Add more accented icons

### DIFF
--- a/icons/meson.build
+++ b/icons/meson.build
@@ -88,7 +88,7 @@ foreach flavour: icon_flavors
       category = fs.name(fs.parent(svg))
       render_bitmap_target = custom_target('render-icon-' + '-'.join([category, basename, flavour]),
         input: svg,
-        output: 'rendered-@BASENAME@-' + '-'.join([category, flavour]) + '.svg',
+        output: 'rendered-@0@-@BASENAME@-@1@.svg'.format(category, flavour),
         command: [
           render_bitmaps,
           rendering_args,

--- a/icons/src/fullcolor/accented/actions/edit-select-all.svg
+++ b/icons/src/fullcolor/accented/actions/edit-select-all.svg
@@ -1,0 +1,2021 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   inkscape:export-ydpi="96"
+   inkscape:export-xdpi="96"
+   width="400"
+   height="300"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="1.1.2 (76b9e6a115, 2022-02-25)"
+   sodipodi:docname="edit-select-all.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   style="display:inline;enable-background:new"
+   inkscape:export-filename="/home/stuart/fold.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title3004">Suru Icon Theme Template</title>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#f57900"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9999999"
+     inkscape:cx="315.125"
+     inkscape:cy="190.6875"
+     inkscape:current-layer="layer6"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="2488"
+     inkscape:window-height="1376"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     width="400px"
+     height="300px"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     gridtolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-grids="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="false"
+     showborder="false"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       spacingy="1"
+       spacingx="1"
+       id="grid5883"
+       type="xygrid"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid11592"
+       empspacing="2"
+       visible="true"
+       enabled="false"
+       spacingx="0.5"
+       spacingy="0.5"
+       color="#ff0000"
+       opacity="0.1254902"
+       empcolor="#ff0000"
+       empopacity="0.25098039"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5874">
+      <stop
+         style="stop-color:#4d4d4d;stop-opacity:0.05819242"
+         offset="0"
+         id="stop5870" />
+      <stop
+         style="stop-color:#e6e6e6;stop-opacity:0.21332305"
+         offset="1"
+         id="stop5872" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11951">
+      <stop
+         style="stop-color:#c43ac4;stop-opacity:1"
+         offset="0"
+         id="stop11947" />
+      <stop
+         style="stop-color:#d85eca;stop-opacity:1"
+         offset="1"
+         id="stop11949" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9430">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path9432"
+         d="m 166.0625,-196 h 179.875 C 491.2348,-196 512,-175.28677 512,-30.125 v 148.25 C 512,263.28618 491.2348,284 345.9375,284 H 166.0625 C 20.7652,284 0,263.28618 0,118.125 V -30.125 C 0,-175.28677 20.7652,-196 166.0625,-196 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath983">
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path985"
+         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient11878"
+       x1="331"
+       y1="192"
+       x2="333"
+       y2="199"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient11941"
+       gradientUnits="userSpaceOnUse"
+       x1="331"
+       y1="192"
+       x2="333"
+       y2="199"
+       gradientTransform="translate(0,9)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient11989"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9,9)"
+       x1="331"
+       y1="192"
+       x2="333"
+       y2="199" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5874"
+       id="linearGradient12188"
+       gradientUnits="userSpaceOnUse"
+       x1="330"
+       y1="188"
+       x2="334"
+       y2="199"
+       gradientTransform="translate(4,-52)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient12190"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4,-43)"
+       x1="324"
+       y1="192"
+       x2="326"
+       y2="203" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient12372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(17,-43)"
+       x1="324"
+       y1="192"
+       x2="326"
+       y2="203" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient4878"
+       x1="317.26004"
+       y1="255.44786"
+       x2="338.31595"
+       y2="230.85617"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(90,406.00001,170)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient993"
+       x1="328"
+       y1="238.00043"
+       x2="328"
+       y2="254"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4,-152)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient927">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop923" />
+      <stop
+         id="stop933"
+         offset="0.125"
+         style="stop-color:#ffffff;stop-opacity:0.09803922" />
+      <stop
+         id="stop931"
+         offset="0.92500001"
+         style="stop-color:#ffffff;stop-opacity:0.09803922" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         offset="1"
+         id="stop925" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath983-6">
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path985-8"
+         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient13909"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(90,416.50001,180.5)"
+       x1="317.26004"
+       y1="255.44786"
+       x2="338.31595"
+       y2="230.85617" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient13911"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(25,-152)"
+       x1="328"
+       y1="238.00043"
+       x2="328"
+       y2="254" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5874"
+       id="linearGradient13968"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(90,418.50001,161.5)"
+       x1="317.26004"
+       y1="255.44786"
+       x2="338.31595"
+       y2="230.85617" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient14240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4,-4,0,1080,-1124)"
+       x1="317.26004"
+       y1="255.44786"
+       x2="338.31595"
+       y2="230.85617" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient14244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4,-4,0,1164,-1124)"
+       x1="317.26004"
+       y1="255.44786"
+       x2="338.31595"
+       y2="230.85617" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5874"
+       id="linearGradient14248"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4,-4,0,1096,-1208)"
+       x1="317.26004"
+       y1="255.44786"
+       x2="338.31595"
+       y2="230.85617" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter14638"
+       x="-0.027008383"
+       width="1.0540168"
+       y="-0.026991623"
+       height="1.0539832">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.0727527"
+         id="feGaussianBlur14640" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5874"
+       id="linearGradient1386"
+       gradientUnits="userSpaceOnUse"
+       x1="331"
+       y1="192"
+       x2="333"
+       y2="199"
+       gradientTransform="translate(51,1)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient1388"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(51,10)"
+       x1="331"
+       y1="192"
+       x2="333"
+       y2="199" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11951"
+       id="linearGradient1390"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(60,10)"
+       x1="331"
+       y1="192"
+       x2="333"
+       y2="199" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient7864"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(8,-173)"
+       x1="328"
+       y1="238.00043"
+       x2="328"
+       y2="254" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Sam Hewitt</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title>Suru Icon Theme Template</dc:title>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:date />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="rect11858-1-6-7-5"
+     style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 338,150 c -0.554,0 -1,0.446 -1,1 v 9 c 0,0.554 0.446,1 1,1 h 9 c 0.554,0 1,-0.446 1,-1 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     id="rect11858-1-6-7"
+     style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 325,150 c -0.554,0 -1,0.446 -1,1 v 9 c 0,0.554 0.446,1 1,1 h 9 c 0.554,0 1,-0.446 1,-1 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     id="rect11858-1-6"
+     style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 327,137 c -0.554,0 -1,0.446 -1,1 v 9 c 0,0.554 0.446,1 1,1 h 18 c 0.554,0 1,-0.446 1,-1 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 364.00002,90.096258 c 0,-0.71904 -0.0147,-1.30185 -0.10928,-1.83593 -0.0947,-0.53409 -0.29163,-1.0683 -0.72157,-1.47657 -0.42993,-0.40826 -0.99564,-0.59657 -1.56066,-0.68554 -0.56503,-0.089 -1.18274,-0.10119 -1.94414,-0.0977 h -6.21984 -4.11505 c -0.75807,-0.003 -1.37472,0.009 -1.93796,0.0977 -0.56502,0.089 -1.13073,0.27727 -1.56066,0.68554 -0.42994,0.40827 -0.62694,0.94248 -0.72157,1.47657 -0.0947,0.53408 -0.10927,1.11689 -0.10927,1.83593 v 10.808312 c 0,0.71904 0.0145,1.30058 0.10927,1.83398 0.0948,0.53341 0.29336,1.06768 0.72363,1.47461 0.43027,0.40693 0.99509,0.59404 1.5586,0.68359 0.56353,0.0896 1.1775,0.10352 1.93796,0.10352 h 4.11505 6.22603 c 0.76046,0 1.37443,-0.014 1.93795,-0.10352 0.56351,-0.0895 1.12833,-0.27666 1.5586,-0.68359 0.43027,-0.40693 0.62889,-0.9412 0.72363,-1.47461 0.0948,-0.5334 0.10928,-1.11494 0.10928,-1.83398 z"
+     id="path997-3"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="scscccccccsscscscscscss" />
+  <g
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="Icon"
+     id="layer1">
+    <g
+       style="display:none"
+       inkscape:label="Baseplate"
+       id="layer7"
+       inkscape:groupmode="layer"
+       sodipodi:insensitive="true">
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="19.006836"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="context"
+         id="context"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
+           y="-8.2548828"
+           x="19.006836"
+           sodipodi:role="line"
+           id="tspan3933">actions</tspan></text>
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="146.48828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="icon-name"
+         id="icon-name"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+           y="-8.2548828"
+           x="146.48828"
+           sodipodi:role="line"
+           id="tspan3937">edit-select-all</tspan></text>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect16x16"
+         width="16"
+         height="16"
+         x="320"
+         y="236"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect24x24"
+         width="24"
+         height="24"
+         x="320"
+         y="188"
+         inkscape:label="24x24" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect32x32"
+         width="32"
+         height="32"
+         x="320"
+         y="132"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="48x48"
+         y="60"
+         x="320"
+         height="48"
+         width="48"
+         id="rect48x48"
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect3951"
+         width="256"
+         height="256"
+         x="24"
+         y="28"
+         inkscape:label="48x48" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.83333;marker:none;enable-background:accumulate"
+         id="rect24x24-1"
+         width="22"
+         height="22"
+         x="372"
+         y="190"
+         inkscape:label="24x24" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer4"
+       inkscape:label="Shadows"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="Background"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline">
+      <path
+         id="rect11858-3"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 325,193 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 14 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11858-4-5"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 325,202 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 5 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11858-4-6-6"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 334,202 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 5 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11870"
+         style="opacity:1;fill:url(#linearGradient11878);fill-opacity:1.0;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round"
+         d="m 325,192.5 h 14 c 0.277,0 0.5,0.223 0.5,0.5 v 5 c 0,0.277 -0.223,0.5 -0.5,0.5 h -14 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -5 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11870-2"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 325,192.5 h 14 c 0.277,0 0.5,0.223 0.5,0.5 v 5 c 0,0.277 -0.223,0.5 -0.5,0.5 h -14 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -5 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 333,210 v 1 h 2 v -1 z"
+         id="path1499" />
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 329,210 v 1 h 2 v -1 z"
+         id="path1497" />
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 342,201 v 2 h 1 v -2 z"
+         id="path1491" />
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 321,201 v 2 h 1 v -2 z"
+         id="path1489" />
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 342,197 v 2 h 1 v -2 z"
+         id="path1487" />
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 321,197 v 2 h 1 v -2 z"
+         id="path1485" />
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 333,189 v 1 h 2 v -1 z"
+         id="path1481" />
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 329,189 v 1 h 2 v -1 z"
+         id="path1479" />
+      <rect
+         style="opacity:1;fill:#1a7fd4;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;fill-opacity:1"
+         id="rect10382"
+         width="2"
+         height="1"
+         x="325"
+         y="189" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10382-0"
+         width="2"
+         height="1"
+         x="337"
+         y="189" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10382-6"
+         width="2"
+         height="1"
+         x="337"
+         y="210" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10382-1"
+         width="2"
+         height="1"
+         x="325"
+         y="210" />
+      <rect
+         style="opacity:1;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round"
+         id="rect10469"
+         width="1"
+         height="2"
+         x="321"
+         y="205" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10469-5"
+         width="1"
+         height="2"
+         x="321"
+         y="193" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10469-4"
+         width="1"
+         height="2"
+         x="342"
+         y="193" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10469-7"
+         width="1"
+         height="2"
+         x="342"
+         y="205" />
+      <path
+         id="rect11858"
+         style="opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round"
+         d="m 325,192 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 14 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 h 14 v 5 h -14 z"
+         sodipodi:nodetypes="sssssssssccccc" />
+      <path
+         id="rect11880"
+         style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round"
+         d="m 325,193 h 14 v 1 h -14 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11880-2"
+         style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 325,197 h 14 v 1 h -14 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11870-7"
+         style="display:inline;fill:url(#linearGradient11941);fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 325,201.5 h 5 c 0.277,0 0.5,0.223 0.5,0.5 v 5 c 0,0.277 -0.223,0.5 -0.5,0.5 h -5 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -5 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11858-4"
+         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 325,201 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 5 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 h 5 v 5 h -5 z"
+         sodipodi:nodetypes="sssssssssccccc" />
+      <path
+         id="rect11880-4"
+         style="display:inline;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 325,202 h 5 v 1 h -5 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11880-2-3"
+         style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 325,206 h 5 v 1 h -5 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11870-7-8"
+         style="display:inline;fill:url(#linearGradient11989);fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 334,201.5 h 5 c 0.277,0 0.5,0.223 0.5,0.5 v 5 c 0,0.277 -0.223,0.5 -0.5,0.5 h -5 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -5 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11858-4-6"
+         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 334,201 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 5 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 h 5 v 5 h -5 z"
+         sodipodi:nodetypes="sssssssssccccc" />
+      <path
+         id="rect11880-4-8"
+         style="display:inline;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 334,202 h 5 v 1 h -5 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11880-2-3-8"
+         style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 334,206 h 5 v 1 h -5 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+         d="m 384,211 v 1 h 2 v -1 z"
+         id="path1429" />
+      <path
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+         d="m 380,211 v 1 h 2 v -1 z"
+         id="path1427" />
+      <path
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+         d="m 393,202 v 2 h 1 v -2 z"
+         id="path1421" />
+      <path
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+         d="m 372,202 v 2 h 1 v -2 z"
+         id="path1419" />
+      <path
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+         d="m 393,198 v 2 h 1 v -2 z"
+         id="path1417" />
+      <path
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+         d="m 372,198 v 2 h 1 v -2 z"
+         id="path1415" />
+      <path
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+         d="m 384,190 v 1 h 2 v -1 z"
+         id="path1411" />
+      <path
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+         d="m 380,190 v 1 h 2 v -1 z"
+         id="path1409" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10382-06"
+         width="2"
+         height="1"
+         x="376"
+         y="190" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10382-0-8"
+         width="2"
+         height="1"
+         x="388"
+         y="190" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10382-6-9"
+         width="2"
+         height="1"
+         x="388"
+         y="211" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10382-1-2"
+         width="2"
+         height="1"
+         x="376"
+         y="211" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10469-6"
+         width="1"
+         height="2"
+         x="372"
+         y="206" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10469-5-6"
+         width="1"
+         height="2"
+         x="372"
+         y="194" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10469-4-4"
+         width="1"
+         height="2"
+         x="393"
+         y="194" />
+      <rect
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect10469-7-9"
+         width="1"
+         height="2"
+         x="393"
+         y="206" />
+      <path
+         id="rect11858-3-2"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,194 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 14 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11858-4-5-8"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,203 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 5 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11858-4-6-6-9"
+         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 385,203 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 5 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11870-73"
+         style="display:inline;fill:url(#linearGradient1386);fill-opacity:1.0;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,193.5 h 14 c 0.277,0 0.5,0.223 0.5,0.5 v 5 c 0,0.277 -0.223,0.5 -0.5,0.5 h -14 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -5 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11870-73-5"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,193.5 h 14 c 0.277,0 0.5,0.223 0.5,0.5 v 5 c 0,0.277 -0.223,0.5 -0.5,0.5 h -14 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -5 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11858-6"
+         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,193 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 14 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 h 14 v 5 h -14 z"
+         sodipodi:nodetypes="sssssssssccccc" />
+      <path
+         id="rect11880-1"
+         style="display:inline;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,194 h 14 v 1 h -14 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11880-2-2"
+         style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,198 h 14 v 1 h -14 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11870-7-9"
+         style="display:inline;fill:url(#linearGradient1388);fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,202.5 h 5 c 0.277,0 0.5,0.223 0.5,0.5 v 5 c 0,0.277 -0.223,0.5 -0.5,0.5 h -5 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -5 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11858-4-3"
+         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,202 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 5 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 h 5 v 5 h -5 z"
+         sodipodi:nodetypes="sssssssssccccc" />
+      <path
+         id="rect11880-4-1"
+         style="display:inline;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,203 h 5 v 1 h -5 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11880-2-3-9"
+         style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 376,207 h 5 v 1 h -5 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11870-7-8-4"
+         style="display:inline;fill:url(#linearGradient1390);fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 385,202.5 h 5 c 0.277,0 0.5,0.223 0.5,0.5 v 5 c 0,0.277 -0.223,0.5 -0.5,0.5 h -5 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -5 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         id="rect11858-4-6-7"
+         style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 385,202 c -0.554,0 -1,0.446 -1,1 v 5 c 0,0.554 0.446,1 1,1 h 5 c 0.554,0 1,-0.446 1,-1 v -5 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 h 5 v 5 h -5 z"
+         sodipodi:nodetypes="sssssssssccccc" />
+      <path
+         id="rect11880-4-8-8"
+         style="display:inline;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 385,203 h 5 v 1 h -5 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="rect11880-2-3-8-4"
+         style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 385,207 h 5 v 1 h -5 z"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path1431"
+         style="opacity:1;fill:#1a7fd4;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;fill-opacity:1"
+         d="M 373.95117 190 A 2 2 0 0 0 372 192 L 373 192 A 1 1 0 0 1 374 191 L 374 190 A 2 2 0 0 0 373.95117 190 z " />
+      <path
+         id="path1431-5"
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 373.95117,211.99985 a 2,-2 0 0 1 -1.95117,-2 h 1 a 1,-1 0 0 0 1,1 v 1 a 2,-2 0 0 1 -0.0488,0 z" />
+      <path
+         id="path1431-0"
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 392.04883,211.99985 a -2,2 0 0 0 1.95117,-2 h -1 a -1,1 0 0 1 -1,1 v 1 a -2,2 0 0 0 0.0488,0 z" />
+      <path
+         id="path1431-3"
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="M 392.04883,190 A 2,-2 0 0 1 394,192 h -1 a 1,-1 0 0 0 -1,-1 v -1 a 2,-2 0 0 1 0.0488,0 z" />
+      <path
+         id="path1431-6"
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="M 322.95117,189 A 2,2 0 0 0 321,191 h 1 a 1,1 0 0 1 1,-1 v -1 a 2,2 0 0 0 -0.0488,0 z" />
+      <path
+         id="path1431-5-1"
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 322.95117,210.99985 a 2,2 0 0 1 -1.95117,-2 h 1 a 1,1 0 0 0 1,1 v 1 a 2,2 0 0 1 -0.0488,0 z" />
+      <path
+         id="path1431-0-0"
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="m 341.04883,210.99985 a 2,2 0 0 0 1.95117,-2 h -1 a 1,1 0 0 1 -1,1 v 1 a 2,2 0 0 0 0.0488,0 z" />
+      <path
+         id="path1431-3-6"
+         style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         d="M 341.04883,189 A 2,2 0 0 1 343,191 h -1 a 1,1 0 0 0 -1,-1 v -1 a 2,2 0 0 1 0.0488,0 z" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer3"
+       inkscape:label="Folds"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer5"
+       inkscape:label="Highlights"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer9"
+       inkscape:label="Folded corner"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer8"
+       inkscape:label="Emblems" />
+    <rect
+       style="fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:1.02564;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect909"
+       width="10"
+       height="3.9999988"
+       x="323"
+       y="239" />
+    <rect
+       y="245"
+       x="323"
+       height="4.0000014"
+       width="4.0000005"
+       id="rect911"
+       style="fill:#9b33ae;fill-opacity:1;stroke:none;stroke-width:0.648671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <rect
+       style="fill:#9b33ae;fill-opacity:1;stroke:none;stroke-width:0.648671;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect913"
+       width="3.9999998"
+       height="3.9999988"
+       x="329"
+       y="245" />
+    <g
+       id="g907"
+       style="fill:#1a7fd4;fill-opacity:1"
+       transform="translate(320,236)">
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 1,3 V 1 H 3 V 0 H 0 v 3 z"
+         id="path842"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 1,13 v 2 h 2 v 1 H 0 v -3 z"
+         id="path846"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <rect
+         style="opacity:1;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:0.816497;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect848"
+         width="1"
+         height="2"
+         x="0"
+         y="5" />
+      <rect
+         y="9"
+         x="0"
+         height="2"
+         width="1"
+         id="rect850"
+         style="opacity:1;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:0.816497;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         transform="matrix(0,1,1,0,0,0)"
+         id="g874"
+         style="fill:#1a7fd4;fill-opacity:1">
+        <rect
+           style="opacity:1;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:0.816497;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect868"
+           width="1"
+           height="2"
+           x="0"
+           y="5" />
+        <rect
+           y="9"
+           x="0"
+           height="2"
+           width="1"
+           id="rect870"
+           style="opacity:1;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:0.816497;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         id="g880"
+         transform="matrix(0,1,1,0,0,15)"
+         style="fill:#1a7fd4;fill-opacity:1">
+        <rect
+           y="5"
+           x="0"
+           height="2"
+           width="1"
+           id="rect876"
+           style="opacity:1;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:0.816497;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="opacity:1;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:0.816497;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect878"
+           width="1"
+           height="2"
+           x="0"
+           y="9" />
+      </g>
+      <g
+         transform="matrix(-1,0,0,1,16,0)"
+         id="g866"
+         style="fill:#1a7fd4;fill-opacity:1">
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path858"
+           d="M 1,3 V 1 H 3 V 0 H 0 v 3 z"
+           style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccccc"
+           inkscape:connector-curvature="0"
+           id="path860"
+           d="m 1,13 v 2 h 2 v 1 H 0 v -3 z"
+           style="fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <rect
+           y="5"
+           x="0"
+           height="2"
+           width="1"
+           id="rect862"
+           style="opacity:1;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:0.816497;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="opacity:1;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:0.816497;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect864"
+           width="1"
+           height="2"
+           x="0"
+           y="9" />
+      </g>
+    </g>
+  </g>
+  <path
+     id="path918-21-8-9"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;filter:url(#filter14638)"
+     d="m 102.96094,65.90625 c -2.89192,-0.01489 -5.075735,0.121833 -6.601565,0.445312 -1.52581,0.323465 -2.315748,0.775514 -2.867187,1.390626 -1.10296,1.230224 -1.585938,4.187414 -1.585938,9.914062 v 60.68555 c 0,5.7252 0.476285,8.66606 1.578125,9.89062 0.55096,0.61228 1.354092,1.06383 2.882813,1.39063 1.528679,0.32676 3.707842,0.46875 6.601562,0.46875 H 120 201.03125 c 2.89376,0 5.07288,-0.14195 6.60156,-0.46875 1.52872,-0.32672 2.33185,-0.77835 2.88281,-1.39063 1.10186,-1.22456 1.57813,-4.16542 1.57813,-9.89062 V 77.65625 c 0,-5.726648 -0.48298,-8.683824 -1.58594,-9.914062 -0.55144,-0.615121 -1.34138,-1.067144 -2.86719,-1.390626 -1.52583,-0.323475 -4.02056,-0.408922 -6.60156,-0.445312 h -0.008 H 120 102.96875 Z m -32.000002,100 c -2.891921,-0.0149 -5.075723,0.12183 -6.601563,0.44531 -1.5258,0.32347 -2.315748,0.77552 -2.867187,1.39063 -1.102961,1.23022 -1.585938,4.18741 -1.585938,9.91406 v 60.68555 c 0,5.7252 0.476285,8.66606 1.578125,9.89062 0.55096,0.61228 1.354092,1.06383 2.882813,1.39063 1.528679,0.32676 3.72759,0.80624 6.601562,0.46875 H 88 133.03125 c 2.89376,-1.2e-4 5.07288,-0.14195 6.60156,-0.46875 1.52872,-0.32672 2.33185,-0.77835 2.88281,-1.39063 1.10186,-1.22456 1.57813,-4.16542 1.57813,-9.89062 v -60.68555 c 0,-5.72665 -0.48298,-8.68382 -1.58594,-9.91406 -0.55144,-0.61512 -1.34137,-1.06715 -2.86719,-1.39063 -1.52583,-0.32347 -3.7096,-0.44531 -6.60156,-0.44531 h -0.008 H 88 70.96875 Z m 100.000002,0 c -2.89192,-0.0149 -5.07573,0.12183 -6.60156,0.44531 -1.52582,0.32347 -2.31575,0.77552 -2.86719,1.39063 -1.10296,1.23022 -1.58594,4.18741 -1.58594,9.91406 v 60.68555 c 0,5.7252 0.47628,8.66606 1.57813,9.89062 0.55095,0.61228 1.35409,1.06383 2.88281,1.39063 1.52868,0.32676 3.72759,0.80624 6.60156,0.46875 H 188 233.03125 c 2.89376,-1.2e-4 5.07288,-0.14195 6.60156,-0.46875 1.52872,-0.32672 2.33185,-0.77835 2.88281,-1.39063 1.10186,-1.22456 1.57813,-4.16542 1.57813,-9.89062 v -60.68555 c 0,-5.72665 -0.48298,-8.68382 -1.58594,-9.91406 -0.55144,-0.61512 -1.34138,-1.06715 -2.86719,-1.39063 -1.52583,-0.32347 -3.7096,-0.44531 -6.60156,-0.44531 h -0.008 H 188 170.96875 Z" />
+  <path
+     id="rect11870-5"
+     style="display:inline;fill:url(#linearGradient12188);fill-opacity:1.0;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 327,136.5 h 18 c 0.277,0 0.5,0.223 0.5,0.5 v 9 c 0,0.277 -0.223,0.5 -0.5,0.5 h -18 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -9 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     id="rect11870-5-7"
+     style="display:inline;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 327,136.5 h 18 c 0.277,0 0.5,0.223 0.5,0.5 v 9 c 0,0.277 -0.223,0.5 -0.5,0.5 h -18 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -9 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 337,162 v 1 h 2 v -1 z"
+     id="path12237" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 333,162 v 1 h 2 v -1 z"
+     id="path12235" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 350,149 v 2 h 1 v -2 z"
+     id="path12229" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 321,149 v 2 h 1 v -2 z"
+     id="path12227" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 350,145 v 2 h 1 v -2 z"
+     id="path12225" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 321,145 v 2 h 1 v -2 z"
+     id="path12223" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 337,133 v 1 h 2 v -1 z"
+     id="path12219" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 333,133 v 1 h 2 v -1 z"
+     id="path12217" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-4"
+     width="2"
+     height="1"
+     x="329"
+     y="133" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9"
+     width="2"
+     height="1"
+     x="341"
+     y="133" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-6-0"
+     width="2"
+     height="1"
+     x="341"
+     y="162" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-1-9"
+     width="2"
+     height="1"
+     x="329"
+     y="162" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1"
+     width="1"
+     height="2"
+     x="321"
+     y="153" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-5-7"
+     width="1"
+     height="2"
+     x="321"
+     y="141" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-4-7"
+     width="1"
+     height="2"
+     x="350"
+     y="141" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-7-1"
+     width="1"
+     height="2"
+     x="350"
+     y="153" />
+  <path
+     id="rect11858-1"
+     style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 327,136 c -0.554,0 -1,0.446 -1,1 v 9 c 0,0.554 0.446,1 1,1 h 18 c 0.554,0 1,-0.446 1,-1 v -9 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 h 18 v 9 h -18 z"
+     sodipodi:nodetypes="sssssssssccccc" />
+  <path
+     id="rect11880-5"
+     style="display:inline;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 327,137 h 18 v 1 h -18 z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect11880-2-9"
+     style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 327,145 h 18 v 1 h -18 z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect11870-7-7"
+     style="display:inline;fill:url(#linearGradient12190);fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 325,149.5 h 9 c 0.277,0 0.5,0.223 0.5,0.5 v 9 c 0,0.277 -0.223,0.5 -0.5,0.5 h -9 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -9 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     id="rect11858-4-7"
+     style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 325,149 c -0.554,0 -1,0.446 -1,1 v 9 c 0,0.554 0.446,1 1,1 h 9 c 0.554,0 1,-0.446 1,-1 v -9 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 h 9 v 9 h -9 z"
+     sodipodi:nodetypes="sssssssssccccc" />
+  <path
+     id="rect11880-4-6"
+     style="display:inline;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 325,150 h 9 v 1 h -9 z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect11880-2-3-7"
+     style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 325,158 h 9 v 1 h -9 z"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-9"
+     width="2"
+     height="1"
+     x="345"
+     y="133" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4"
+     width="2"
+     height="1"
+     x="325"
+     y="133" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-8"
+     width="2"
+     height="1"
+     x="325"
+     y="162" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-1"
+     width="2"
+     height="1"
+     x="345"
+     y="162" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2"
+     width="1"
+     height="2"
+     x="321"
+     y="157" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-7-1-9"
+     width="1"
+     height="2"
+     x="350"
+     y="157" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-0"
+     width="1"
+     height="2"
+     x="321"
+     y="137" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-7-1-8"
+     width="1"
+     height="2"
+     x="350"
+     y="137" />
+  <path
+     id="rect11870-7-7-6"
+     style="display:inline;fill:url(#linearGradient12372);fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 338,149.5 h 9 c 0.277,0 0.5,0.223 0.5,0.5 v 9 c 0,0.277 -0.223,0.5 -0.5,0.5 h -9 c -0.277,0 -0.5,-0.223 -0.5,-0.5 v -9 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+     sodipodi:nodetypes="sssssssss" />
+  <path
+     id="rect11858-4-7-3"
+     style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 338,149 c -0.554,0 -1,0.446 -1,1 v 9 c 0,0.554 0.446,1 1,1 h 9 c 0.554,0 1,-0.446 1,-1 v -9 c 0,-0.554 -0.446,-1 -1,-1 z m 0,1 h 9 v 9 h -9 z"
+     sodipodi:nodetypes="sssssssssccccc" />
+  <path
+     id="rect11880-4-6-8"
+     style="display:inline;opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 338,150 h 9 v 1 h -9 z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="rect11880-2-3-7-5"
+     style="display:inline;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 338,158 h 9 v 1 h -9 z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 345,106 v 1 h 2 v -1 z"
+     id="path12237-4" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 341,106 v 1 h 2 v -1 z"
+     id="path12235-4" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 366,85 v 2 h 1 v -2 z"
+     id="path12229-7" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 321,85 v 2 h 1 v -2 z"
+     id="path12227-6" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 366,81 v 2 h 1 v -2 z"
+     id="path12225-3" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 321,81 v 2 h 1 v -2 z"
+     id="path12223-1" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 345,61 v 1 h 2 v -1 z"
+     id="path12219-5" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 341,61 v 1 h 2 v -1 z"
+     id="path12217-9" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-4-2"
+     width="2"
+     height="1"
+     x="337"
+     y="61" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-17"
+     width="2"
+     height="1"
+     x="349"
+     y="61" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-6-0-8"
+     width="2"
+     height="1"
+     x="349"
+     y="106" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-1-9-5"
+     width="2"
+     height="1"
+     x="337"
+     y="106"
+     ry="0" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-7"
+     width="1"
+     height="2"
+     x="321"
+     y="89" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-5-7-4"
+     width="1"
+     height="2"
+     x="321"
+     y="77" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-4-7-1"
+     width="1"
+     height="2"
+     x="366"
+     y="77" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-7-1-85"
+     width="1"
+     height="2"
+     x="366"
+     y="89" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-9-8"
+     width="2"
+     height="1"
+     x="353"
+     y="61" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9"
+     width="2"
+     height="1"
+     x="333"
+     y="61" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-8-6"
+     width="2"
+     height="1"
+     x="333"
+     y="106" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-1-4"
+     width="2"
+     height="1"
+     x="353"
+     y="106" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3"
+     width="1"
+     height="2"
+     x="321"
+     y="93" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-7-1-9-3"
+     width="1"
+     height="2"
+     x="366"
+     y="93" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-0-3"
+     width="1"
+     height="2"
+     x="321"
+     y="73" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-7-1-8-8"
+     width="1"
+     height="2"
+     x="366"
+     y="73" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-8"
+     width="2"
+     height="1"
+     x="329"
+     y="61" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-9"
+     width="2"
+     height="1"
+     x="325"
+     y="61" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-7"
+     width="2"
+     height="1"
+     x="357"
+     y="61" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-76"
+     width="2"
+     height="1"
+     x="361"
+     y="61" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-4"
+     width="2"
+     height="1"
+     x="361"
+     y="106" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-3"
+     width="2"
+     height="1"
+     x="357"
+     y="106" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-30"
+     width="2"
+     height="1"
+     x="329"
+     y="106" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-92"
+     width="2"
+     height="1"
+     x="325"
+     y="106" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-5"
+     width="1"
+     height="2"
+     x="321"
+     y="97" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-4"
+     width="1"
+     height="2"
+     x="321"
+     y="101" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-0"
+     width="1"
+     height="2"
+     x="321"
+     y="69" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-59"
+     width="1"
+     height="2"
+     x="321"
+     y="65" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-46"
+     width="1"
+     height="2"
+     x="366"
+     y="65" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-9"
+     width="1"
+     height="2"
+     x="366"
+     y="69" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-2"
+     width="1"
+     height="2"
+     x="366"
+     y="97" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-24"
+     width="1"
+     height="2"
+     x="366"
+     y="101" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 343.00002,90.096258 c 0,-0.71904 -0.0147,-1.30185 -0.10928,-1.83593 -0.0947,-0.53409 -0.29163,-1.0683 -0.72157,-1.47657 -0.42993,-0.40826 -0.99564,-0.59657 -1.56066,-0.68554 -0.56503,-0.089 -1.18274,-0.10119 -1.94414,-0.0977 h -6.21984 -4.11505 c -0.75807,-0.003 -1.37472,0.009 -1.93796,0.0977 -0.56502,0.089 -1.13073,0.27727 -1.56066,0.68554 -0.42994,0.40827 -0.62694,0.94248 -0.72157,1.47657 -0.0947,0.53408 -0.10927,1.11689 -0.10927,1.83593 v 10.808312 c 0,0.71904 0.0145,1.30058 0.10927,1.83398 0.0948,0.53341 0.29336,1.06768 0.72363,1.47461 0.43027,0.40693 0.99509,0.59404 1.5586,0.68359 0.56353,0.0896 1.1775,0.10352 1.93796,0.10352 h 4.11505 6.22603 c 0.76046,0 1.37443,-0.014 1.93795,-0.10352 0.56351,-0.0895 1.12833,-0.27666 1.5586,-0.68359 0.43027,-0.40693 0.62889,-0.9412 0.72363,-1.47461 0.0948,-0.5334 0.10928,-1.11494 0.10928,-1.83398 z"
+     id="path997"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="scscccccccsscscscscscss" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4878);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 342.49986,88.8545 c 0,-3.04166 -0.30899,-3.36894 -3.32331,-3.35403 h -7.17654 -4.17669 c -3.01432,-0.0149 -3.32331,0.31237 -3.32331,3.35403 v 11.29117 c 0,3.04167 0.30895,3.35404 3.32331,3.35404 h 4.17669 7.17654 c 3.01435,0 3.32331,-0.31238 3.32331,-3.35404 z"
+     id="path918"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="scccssscsss" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 324.57813,95 v 5.1756 c -0.017,3.01433 0.35794,3.32422 3.83398,3.32422 h 10.1893 c 3.47605,0 3.83203,-0.30985 3.83203,-3.32422 V 95 Z"
+     id="path918-7"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssscc" />
+  <path
+     id="path937"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.7;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient993);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 327.29102,85.011719 c -0.0647,0.0021 -0.13853,9e-4 -0.20118,0.0039 0.0651,-0.0022 0.13342,-0.0026 0.20118,-0.0039 z m 12.42172,0 c 0.0657,0.0013 0.13207,0.0018 0.19531,0.0039 -0.0608,-0.0029 -0.13256,-0.0019 -0.19531,-0.0039 z m -11.97251,0.964843 c -0.72298,-0.0037 -1.26893,0.03046 -1.65039,0.111329 -0.38145,0.08087 -0.57893,0.193878 -0.71679,0.347656 -0.27574,0.307556 -0.39649,1.046853 -0.39649,2.478515 v 11.171588 c 0,1.4313 0.11907,2.16652 0.39453,2.47266 0.13774,0.15307 0.33853,0.26597 0.72071,0.34765 0.38217,0.0817 0.92696,0.11719 1.65039,0.11719 H 332 h 7.25766 c 0.72344,0 1.26822,-0.0355 1.65039,-0.11719 0.38218,-0.0817 0.58297,-0.19458 0.72071,-0.34765 0.27546,-0.30614 0.39453,-1.04136 0.39453,-2.47266 V 88.914062 c 0,-1.431661 -0.12075,-2.170955 -0.39649,-2.478515 -0.13786,-0.15378 -0.33534,-0.266786 -0.71679,-0.347656 -0.38146,-0.08087 -0.9274,-0.111329 -1.65039,-0.111329 h -0.002 H 332 327.74219 Z M 328.09766,87 h 0.002 3.90039 6.90024 0.002 c 0.68538,0 1.19386,0.01878 1.50391,0.07031 0.31005,0.05154 0.37415,0.110444 0.39063,0.126954 0.0165,0.0165 0.0746,0.08274 0.12695,0.394531 0.0523,0.31179 0.0762,0.819106 0.0762,1.503906 v 10.808307 c 0,0.684802 -0.022,1.191632 -0.0742,1.501952 -0.0522,0.31032 -0.11277,0.37451 -0.1289,0.39063 -0.0161,0.0161 -0.0811,0.0767 -0.39258,0.1289 -0.31165,0.0523 -0.81974,0.0742 -1.50601,0.0742 H 332 328.10156 c -0.68627,0 -1.19438,-0.022 -1.50586,-0.0742 -0.31147,-0.0523 -0.37642,-0.11279 -0.39258,-0.1289 -0.0161,-0.0161 -0.0767,-0.0803 -0.1289,-0.39063 C 326.022,101.09564 326,100.58882 326,99.904009 V 89.095703 c 0,-0.6848 0.0238,-1.192116 0.0762,-1.503906 0.0523,-0.3118 0.11049,-0.378031 0.12695,-0.394531 0.0165,-0.01651 0.0806,-0.07541 0.39063,-0.126954 0.31005,-0.05153 0.81855,-0.07367 1.50391,-0.07031 z"
+     sodipodi:nodetypes="ccccccsssssssscsssssssscccsscccsssssssssscsssssscssss" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 327.74219,85 c -0.75078,-0.0037 -1.35101,0.02587 -1.85547,0.132812 -0.50552,0.107168 -0.93542,0.308214 -1.24219,0.650391 C 324.03099,86.467557 324,87.448405 324,88.914062 v 11.171588 c 0,1.4653 0.0327,2.4448 0.64648,3.12695 0.30691,0.34108 0.73544,0.54055 1.24024,0.64844 0.5048,0.10789 1.10291,0.13867 1.85547,0.13867 H 332 h 7.25766 c 0.75256,0 1.35067,-0.0308 1.85547,-0.13867 0.5048,-0.10789 0.93333,-0.30736 1.24024,-0.64844 0.6138,-0.68215 0.64648,-1.66165 0.64648,-3.12695 V 88.914062 c 0,-1.465657 -0.031,-2.446501 -0.64453,-3.130859 -0.30677,-0.342179 -0.73667,-0.543225 -1.24219,-0.650391 C 340.60867,85.025871 340.00844,84.996259 339.25766,85 H 332 327.74609 Z m -0.002,0.976562 h 0.002 4.25781 7.25766 0.002 c 0.72299,0 1.26893,0.03046 1.65039,0.111329 0.38145,0.08087 0.57893,0.193876 0.71679,0.347656 0.27574,0.30756 0.39649,1.046853 0.39649,2.478515 v 11.171588 c 0,1.4313 -0.11907,2.16652 -0.39453,2.47266 -0.13774,0.15307 -0.33853,0.26597 -0.72071,0.34765 -0.38217,0.0817 -0.92695,0.11716 -1.65039,0.11719 H 332 327.74219 c -0.72343,0 -1.26822,-0.0355 -1.65039,-0.11719 -0.38218,-0.0817 -0.58297,-0.19458 -0.72071,-0.34765 -0.27546,-0.30614 -0.39453,-1.04136 -0.39453,-2.47266 V 88.914062 c 0,-1.431662 0.12075,-2.170959 0.39649,-2.478515 0.13786,-0.153778 0.33534,-0.26679 0.71679,-0.347656 0.38146,-0.08087 0.92741,-0.115051 1.65039,-0.111329 z"
+     id="path958-6-0"
+     sodipodi:nodetypes="sssssssscssssssscccsccccsssssssscssssssssc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient13909);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 363.49986,88.8545 c 0,-3.04166 -0.30899,-3.36894 -3.32331,-3.35403 h -7.17654 -4.17669 c -3.01432,-0.0149 -3.32331,0.31237 -3.32331,3.35403 v 11.29117 c 0,3.04167 0.30895,3.35404 3.32331,3.35404 h 4.17669 7.17654 c 3.01435,0 3.32331,-0.31238 3.32331,-3.35404 z"
+     id="path918-0"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="scccssscsss" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 345.57813,95 v 5.1756 c -0.017,3.01433 0.35794,3.32422 3.83398,3.32422 h 10.1893 c 3.47605,0 3.83203,-0.30985 3.83203,-3.32422 V 95 Z"
+     id="path918-7-8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssscc" />
+  <path
+     id="path937-5"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.7;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient13911);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 348.29102,85.011719 c -0.0647,0.0021 -0.13853,9e-4 -0.20118,0.0039 0.0651,-0.0022 0.13342,-0.0026 0.20118,-0.0039 z m 12.42172,0 c 0.0657,0.0013 0.13207,0.0018 0.19531,0.0039 -0.0608,-0.0029 -0.13256,-0.0019 -0.19531,-0.0039 z m -11.97251,0.964843 c -0.72298,-0.0037 -1.26893,0.03046 -1.65039,0.111329 -0.38145,0.08087 -0.57893,0.193878 -0.71679,0.347656 -0.27574,0.307556 -0.39649,1.046853 -0.39649,2.478515 v 11.171588 c 0,1.4313 0.11907,2.16652 0.39453,2.47266 0.13774,0.15307 0.33853,0.26597 0.72071,0.34765 0.38217,0.0817 0.92696,0.11719 1.65039,0.11719 H 353 h 7.25766 c 0.72344,0 1.26822,-0.0355 1.65039,-0.11719 0.38218,-0.0817 0.58297,-0.19458 0.72071,-0.34765 0.27546,-0.30614 0.39453,-1.04136 0.39453,-2.47266 V 88.914062 c 0,-1.431661 -0.12075,-2.170955 -0.39649,-2.478515 -0.13786,-0.15378 -0.33534,-0.266786 -0.71679,-0.347656 -0.38146,-0.08087 -0.9274,-0.111329 -1.65039,-0.111329 h -0.002 H 353 348.74219 Z M 349.09766,87 h 0.002 3.90039 6.90024 0.002 c 0.68538,0 1.19386,0.01878 1.50391,0.07031 0.31005,0.05154 0.37415,0.110444 0.39063,0.126954 0.0165,0.0165 0.0746,0.08274 0.12695,0.394531 0.0523,0.31179 0.0762,0.819106 0.0762,1.503906 v 10.808307 c 0,0.684802 -0.022,1.191632 -0.0742,1.501952 -0.0522,0.31032 -0.11277,0.37451 -0.1289,0.39063 -0.0161,0.0161 -0.0811,0.0767 -0.39258,0.1289 -0.31165,0.0523 -0.81974,0.0742 -1.50601,0.0742 H 353 349.10156 c -0.68627,0 -1.19438,-0.022 -1.50586,-0.0742 -0.31147,-0.0523 -0.37642,-0.11279 -0.39258,-0.1289 -0.0161,-0.0161 -0.0767,-0.0803 -0.1289,-0.39063 C 347.022,101.09564 347,100.58882 347,99.904009 V 89.095703 c 0,-0.6848 0.0238,-1.192116 0.0762,-1.503906 0.0523,-0.3118 0.11049,-0.378031 0.12695,-0.394531 0.0165,-0.01651 0.0806,-0.07541 0.39063,-0.126954 0.31005,-0.05153 0.81855,-0.07367 1.50391,-0.07031 z"
+     sodipodi:nodetypes="ccccccsssssssscsssssssscccsscccsssssssssscsssssscssss" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 348.74219,85 c -0.75078,-0.0037 -1.35101,0.02587 -1.85547,0.132812 -0.50552,0.107168 -0.93542,0.308214 -1.24219,0.650391 C 345.03099,86.467557 345,87.448405 345,88.914062 v 11.171588 c 0,1.4653 0.0327,2.4448 0.64648,3.12695 0.30691,0.34108 0.73544,0.54055 1.24024,0.64844 0.5048,0.10789 1.10291,0.13867 1.85547,0.13867 H 353 h 7.25766 c 0.75256,0 1.35067,-0.0308 1.85547,-0.13867 0.5048,-0.10789 0.93333,-0.30736 1.24024,-0.64844 0.6138,-0.68215 0.64648,-1.66165 0.64648,-3.12695 V 88.914062 c 0,-1.465657 -0.031,-2.446501 -0.64453,-3.130859 -0.30677,-0.342179 -0.73667,-0.543225 -1.24219,-0.650391 C 361.60867,85.025871 361.00844,84.996259 360.25766,85 H 353 348.74609 Z m -0.002,0.976562 h 0.002 4.25781 7.25766 0.002 c 0.72299,0 1.26893,0.03046 1.65039,0.111329 0.38145,0.08087 0.57893,0.193876 0.71679,0.347656 0.27574,0.30756 0.39649,1.046853 0.39649,2.478515 v 11.171588 c 0,1.4313 -0.11907,2.16652 -0.39453,2.47266 -0.13774,0.15307 -0.33853,0.26597 -0.72071,0.34765 -0.38217,0.0817 -0.92695,0.11716 -1.65039,0.11719 H 353 348.74219 c -0.72343,0 -1.26822,-0.0355 -1.65039,-0.11719 -0.38218,-0.0817 -0.58297,-0.19458 -0.72071,-0.34765 -0.27546,-0.30614 -0.39453,-1.04136 -0.39453,-2.47266 V 88.914062 c 0,-1.431662 0.12075,-2.170959 0.39649,-2.478515 0.13786,-0.153778 0.33534,-0.26679 0.71679,-0.347656 0.38146,-0.08087 0.92741,-0.115051 1.65039,-0.111329 z"
+     id="path958-6-0-0"
+     sodipodi:nodetypes="sssssssscssssssscccsccccsssssssscssssssssc" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 360.00002,69.096258 c 0,-0.71904 -0.0143,-1.30185 -0.10686,-1.83593 -0.0926,-0.53409 -0.2852,-1.0683 -0.70565,-1.47657 -0.42044,-0.40826 -0.97366,-0.59657 -1.52621,-0.68554 -0.55256,-0.089 -1.15663,-0.10119 -1.90122,-0.0977 h -19.50196 -4.02422 c -0.74133,-0.003 -1.34437,0.009 -1.89517,0.0977 -0.55255,0.089 -1.10577,0.27727 -1.52621,0.68554 -0.42045,0.40827 -0.6131,0.94248 -0.70565,1.47657 -0.0926,0.53408 -0.10686,1.11689 -0.10686,1.83593 v 10.80831 c 0,0.71904 0.0142,1.30058 0.10686,1.83398 0.0927,0.53341 0.28689,1.06768 0.70766,1.47461 0.42077,0.40693 0.97313,0.59404 1.5242,0.68359 0.55108,0.0896 1.1515,0.10352 1.89517,0.10352 h 4.02422 19.50801 c 0.74367,0 1.34409,-0.014 1.89517,-0.10352 0.55107,-0.0895 1.10343,-0.27666 1.5242,-0.68359 0.42077,-0.40693 0.615,-0.9412 0.70766,-1.47461 0.0927,-0.5334 0.10686,-1.11494 0.10686,-1.83398 z"
+     id="path997-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="scscccccccsscscscscscss" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient13968);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 359.49986,67.8545 c 0,-3.04166 -0.30899,-3.36894 -3.32331,-3.35403 h -20.17654 -4.17669 c -3.01432,-0.0149 -3.32331,0.31237 -3.32331,3.35403 v 11.29117 c 0,3.04167 0.30895,3.35404 3.32331,3.35404 h 4.17669 20.17654 c 3.01435,0 3.32331,-0.31238 3.32331,-3.35404 z"
+     id="path918-2"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="scccssscsss" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 359.49985,67.854344 c 0,-3.04166 -0.30899,-3.36894 -3.32331,-3.35403 H 336 331.82331 c -3.01432,-0.0149 -3.32331,0.31237 -3.32331,3.35403 v 11.29117 c 0,3.04167 0.30895,3.35404 3.32331,3.35404 H 336 356.17654 c 3.01435,0 3.32331,-0.31238 3.32331,-3.35404 z"
+     id="path918-2-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="scccssscsss" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 328.57813,74 v 5.1756 c -0.017,3.01433 0.35794,3.32422 3.83398,3.32422 h 23.1893 c 3.47605,0 3.83203,-0.30985 3.83203,-3.32422 V 74 Z"
+     id="path918-7-84"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccssscc" />
+  <path
+     id="path937-7"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.7;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient7864);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 331.29102,64.011719 c -0.0647,0.0021 -0.13853,9e-4 -0.20118,0.0039 0.0651,-0.0022 0.13342,-0.0026 0.20118,-0.0039 z m 25.42172,0 c 0.0657,0.0013 0.13207,0.0018 0.19531,0.0039 -0.0608,-0.0029 -0.13256,-0.0019 -0.19531,-0.0039 z m -24.97251,0.964843 c -0.72298,-0.0037 -1.26893,0.03046 -1.65039,0.111329 -0.38145,0.08087 -0.57893,0.193878 -0.71679,0.347656 -0.27574,0.307556 -0.39649,1.046853 -0.39649,2.478515 V 79.08565 c 0,1.4313 0.11907,2.16652 0.39453,2.47266 0.13774,0.15307 0.33853,0.26597 0.72071,0.34765 0.38217,0.0817 0.92696,0.11719 1.65039,0.11719 H 336 356.25766 c 0.72344,0 1.26822,-0.0355 1.65039,-0.11719 0.38218,-0.0817 0.58297,-0.19458 0.72071,-0.34765 0.27546,-0.30614 0.39453,-1.04136 0.39453,-2.47266 V 67.914062 c 0,-1.431661 -0.12075,-2.170955 -0.39649,-2.478515 -0.13786,-0.15378 -0.33534,-0.266786 -0.71679,-0.347656 -0.38146,-0.08087 -0.9274,-0.111329 -1.65039,-0.111329 h -0.002 H 336 331.74219 Z M 332.09766,66 h 0.002 3.90039 19.90024 0.002 c 0.68538,0 1.19386,0.01878 1.50391,0.07031 0.31005,0.05154 0.37415,0.110444 0.39063,0.126954 0.0165,0.0165 0.0746,0.08274 0.12695,0.394531 0.0523,0.31179 0.0762,0.819106 0.0762,1.503906 v 10.808307 c 0,0.684802 -0.022,1.191632 -0.0742,1.501952 -0.0522,0.31032 -0.11277,0.37451 -0.1289,0.39063 -0.0161,0.0161 -0.0811,0.0767 -0.39258,0.1289 -0.31165,0.0523 -0.81974,0.0742 -1.50601,0.0742 H 336 332.10156 c -0.68627,0 -1.19438,-0.022 -1.50586,-0.0742 -0.31147,-0.0523 -0.37642,-0.11279 -0.39258,-0.1289 -0.0161,-0.0161 -0.0767,-0.0803 -0.1289,-0.39063 C 330.022,80.09564 330,79.58882 330,78.904009 V 68.095703 c 0,-0.6848 0.0238,-1.192116 0.0762,-1.503906 0.0523,-0.3118 0.11049,-0.378031 0.12695,-0.394531 0.0165,-0.01651 0.0806,-0.07541 0.39063,-0.126954 0.31005,-0.05153 0.81855,-0.07367 1.50391,-0.07031 z"
+     sodipodi:nodetypes="ccccccsssssssscsssssssscccsscccsssssssssscsssssscssss" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 331.74219,64 c -0.75078,-0.0037 -1.35101,0.02587 -1.85547,0.132812 -0.50552,0.107168 -0.93542,0.308214 -1.24219,0.650391 C 328.03099,65.467557 328,66.448405 328,67.914062 V 79.08565 c 0,1.4653 0.0327,2.4448 0.64648,3.12695 0.30691,0.34108 0.73544,0.54055 1.24024,0.64844 0.5048,0.10789 1.10291,0.13867 1.85547,0.13867 H 336 356.25766 c 0.75256,0 1.35067,-0.0308 1.85547,-0.13867 0.5048,-0.10789 0.93333,-0.30736 1.24024,-0.64844 0.6138,-0.68215 0.64648,-1.66165 0.64648,-3.12695 V 67.914062 c 0,-1.465657 -0.031,-2.446501 -0.64453,-3.130859 -0.30677,-0.342179 -0.73667,-0.543225 -1.24219,-0.650391 C 357.60867,64.025871 357.00844,63.996259 356.25766,64 H 336 331.74609 Z m -0.002,0.976562 h 0.002 4.25781 20.25766 0.002 c 0.72299,0 1.26893,0.03046 1.65039,0.111329 0.38145,0.08087 0.57893,0.193876 0.71679,0.347656 0.27574,0.30756 0.39649,1.046853 0.39649,2.478515 V 79.08565 c 0,1.4313 -0.11907,2.16652 -0.39453,2.47266 -0.13774,0.15307 -0.33853,0.26597 -0.72071,0.34765 -0.38217,0.0817 -0.92695,0.11719 -1.65039,0.11719 H 336 331.74219 c -0.72343,0 -1.26822,-0.0355 -1.65039,-0.11719 -0.38218,-0.0817 -0.58297,-0.19458 -0.72071,-0.34765 -0.27546,-0.30614 -0.39453,-1.04136 -0.39453,-2.47266 V 67.914062 c 0,-1.431662 0.12075,-2.170959 0.39649,-2.478515 0.13786,-0.153778 0.33534,-0.26679 0.71679,-0.347656 0.38146,-0.08087 0.92741,-0.115051 1.65039,-0.111329 z"
+     id="path958-6-0-2"
+     sodipodi:nodetypes="sssssssscssssssscccsccccsssssssscssssssssc" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 156,260 v 4 h 8 v -4 z"
+     id="path12237-4-1" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 140,260 v 4 h 8 v -4 z"
+     id="path12235-4-3" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 256,160 v 8 h 4 v -8 z"
+     id="path12229-7-0" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 44,160 v 8 h 4 v -8 z"
+     id="path12227-6-3" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 256,144 v 8 h 4 v -8 z"
+     id="path12225-3-4" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 44,144 v 8 h 4 v -8 z"
+     id="path12223-1-0" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 156,48 v 4 h 8 v -4 z"
+     id="path12219-5-9" />
+  <path
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+     d="m 140,48 v 4 h 8 v -4 z"
+     id="path12217-9-1" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-4-2-6"
+     width="8"
+     height="4"
+     x="124"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-17-9"
+     width="8"
+     height="4"
+     x="172"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-6-0-8-3"
+     width="8"
+     height="4"
+     x="172"
+     y="260" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-1-9-5-3"
+     width="8"
+     height="4"
+     x="124"
+     y="260"
+     ry="0" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-7-8"
+     width="4"
+     height="8"
+     x="44"
+     y="176" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-5-7-4-0"
+     width="4"
+     height="8"
+     x="44"
+     y="128" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-4-7-1-5"
+     width="4"
+     height="8"
+     x="256"
+     y="128" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-7-1-85-6"
+     width="4"
+     height="8"
+     x="256"
+     y="176" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-9-8-6"
+     width="8"
+     height="4"
+     x="188"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-40"
+     width="8"
+     height="4"
+     x="108"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-8-6-0"
+     width="8"
+     height="4"
+     x="108"
+     y="260" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-1-4-4"
+     width="8"
+     height="4"
+     x="188"
+     y="260" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-6"
+     width="4"
+     height="8"
+     x="44"
+     y="192" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-7-1-9-3-2"
+     width="4"
+     height="8"
+     x="256"
+     y="192" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-0-3-6"
+     width="4"
+     height="8"
+     x="44"
+     y="112" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-7-1-8-8-7"
+     width="4"
+     height="8"
+     x="256"
+     y="112" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-8-5"
+     width="8"
+     height="4"
+     x="92"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-9-6"
+     width="8"
+     height="4"
+     x="76"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-7-9"
+     width="8"
+     height="4"
+     x="204"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-76-8"
+     width="8"
+     height="4"
+     x="220"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-4-7"
+     width="8"
+     height="4"
+     x="220"
+     y="260" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-3-2"
+     width="8"
+     height="4"
+     x="204"
+     y="260" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-30-8"
+     width="8"
+     height="4"
+     x="92"
+     y="260" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-92-2"
+     width="8"
+     height="4"
+     x="76"
+     y="260" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-5-9"
+     width="4"
+     height="8"
+     x="44"
+     y="208" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-4-9"
+     width="4"
+     height="8"
+     x="44"
+     y="224" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-0-6"
+     width="4"
+     height="8"
+     x="44"
+     y="96" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-59-0"
+     width="4"
+     height="8"
+     x="44"
+     y="80" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-46-2"
+     width="4"
+     height="8"
+     x="256"
+     y="80" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-9-7"
+     width="4"
+     height="8"
+     x="256"
+     y="96" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-2-6"
+     width="4"
+     height="8"
+     x="256"
+     y="208" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-24-1"
+     width="4"
+     height="8"
+     x="256"
+     y="224" />
+  <path
+     id="path918-21"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient14240);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 70.960938,163.90625 c -2.891921,-0.0149 -5.075723,0.12183 -6.601563,0.44531 -1.5258,0.32347 -2.315748,0.77552 -2.867187,1.39063 -1.10296,1.23022 -1.585938,4.18741 -1.585938,9.91406 v 60.68555 c 0,5.7252 0.476285,8.66606 1.578125,9.89062 0.55096,0.61228 1.354092,1.06383 2.882813,1.39063 1.52868,0.32676 3.72759,0.80624 6.601562,0.46875 H 88 133.03125 c 2.89376,-1.2e-4 5.07288,-0.14195 6.60156,-0.46875 1.52872,-0.32672 2.33185,-0.77835 2.88281,-1.39063 1.10185,-1.22456 1.57813,-4.16542 1.57813,-9.89062 v -60.68555 c 0,-5.72665 -0.48298,-8.68382 -1.58594,-9.91406 -0.55144,-0.61512 -1.34138,-1.06715 -2.86719,-1.39063 -1.52583,-0.32347 -3.7096,-0.44531 -6.60156,-0.44531 h -0.008 H 88 70.96875 Z"
+     sodipodi:nodetypes="cscssssscccsssssscccc" />
+  <path
+     id="path918-0-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient14244);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 170.96094,163.90625 c -2.89192,-0.0149 -5.07573,0.12183 -6.60156,0.44531 -1.52581,0.32347 -2.31575,0.77552 -2.86719,1.39063 -1.10296,1.23022 -1.58594,4.18741 -1.58594,9.91406 v 60.68555 c 0,5.7252 0.47628,8.66606 1.57813,9.89062 0.55095,0.61228 1.35409,1.06383 2.88281,1.39063 1.52868,0.32676 3.72759,0.80624 6.60156,0.46875 H 188 233.03125 c 2.89376,-1.2e-4 5.07288,-0.14195 6.60156,-0.46875 1.52872,-0.32672 2.33185,-0.77835 2.88281,-1.39063 1.10185,-1.22456 1.57813,-4.16542 1.57813,-9.89062 v -60.68555 c 0,-5.72665 -0.48298,-8.68382 -1.58594,-9.91406 -0.55144,-0.61512 -1.34138,-1.06715 -2.86719,-1.39063 -1.52583,-0.32347 -3.7096,-0.44531 -6.60156,-0.44531 h -0.008 H 188 170.96875 Z"
+     sodipodi:nodetypes="sscssssscccsssssscccs" />
+  <path
+     id="path918-2-7-9"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 102.96094,63.90625 c -2.89192,-0.01489 -5.07573,0.121832 -6.60157,0.445312 -1.5258,0.323465 -2.31574,0.775514 -2.86718,1.390626 -1.10296,1.230224 -1.58594,4.187414 -1.58594,9.914062 v 60.68555 c 0,5.7252 0.47629,8.66606 1.57812,9.89062 0.55096,0.61228 1.3541,1.06383 2.88282,1.39063 1.52868,0.32676 3.70784,0.46875 6.60156,0.46875 H 120 201.03125 c 2.89376,0 5.07288,-0.14195 6.60156,-0.46875 1.52872,-0.32672 2.33185,-0.77835 2.88281,-1.39063 1.10185,-1.22456 1.57813,-4.16542 1.57813,-9.89062 V 75.65625 c 0,-5.726648 -0.48298,-8.683823 -1.58594,-9.914062 -0.55144,-0.61512 -1.34138,-1.067145 -2.86719,-1.390626 -1.52583,-0.323476 -4.02056,-0.408922 -6.60156,-0.445312 h -0.008 H 120 102.96875 Z"
+     sodipodi:nodetypes="cscssssscsccssssccccc" />
+  <path
+     id="path918-2-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient14248);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="m 102.96094,63.90625 c -2.89192,-0.01489 -5.07573,0.121832 -6.60157,0.445312 -1.5258,0.323465 -2.31574,0.775514 -2.86718,1.390626 -1.10296,1.230224 -1.58594,4.187414 -1.58594,9.914062 v 60.68555 c 0,5.7252 0.47629,8.66606 1.57812,9.89062 0.55096,0.61228 1.3541,1.06383 2.88282,1.39063 1.52868,0.32676 3.70784,0.46875 6.60156,0.46875 H 120 201.03125 c 2.89376,0 5.07288,-0.14195 6.60156,-0.46875 1.52872,-0.32672 2.33185,-0.77835 2.88281,-1.39063 1.10185,-1.22456 1.57813,-4.16542 1.57813,-9.89062 V 75.65625 c 0,-5.726648 -0.48298,-8.683823 -1.58594,-9.914062 -0.55144,-0.61512 -1.34138,-1.067145 -2.86719,-1.390626 -1.52583,-0.323476 -4.02056,-0.408922 -6.60156,-0.445312 h -0.008 H 120 102.96875 Z"
+     sodipodi:nodetypes="cscssssscsccssssccccc" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-9-6-0"
+     width="8"
+     height="4"
+     x="60"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-9-6-4"
+     width="8"
+     height="4"
+     x="236"
+     y="48" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-9-6-8"
+     width="8"
+     height="4"
+     x="236"
+     y="260" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10382-0-9-4-9-9-6-04"
+     width="8"
+     height="4"
+     x="60"
+     y="260" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-24-1-2"
+     width="4"
+     height="8"
+     x="256"
+     y="240" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-24-1-9"
+     width="4"
+     height="8"
+     x="256"
+     y="64" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-24-1-6"
+     width="4"
+     height="8"
+     x="44"
+     y="64" />
+  <rect
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     id="rect10469-1-2-3-24-1-1"
+     width="4"
+     height="8"
+     x="44"
+     y="240" />
+  <path
+     id="rect14407"
+     style="opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round"
+     d="M 91.90625 108 L 91.90625 136.3418 C 91.90625 142.067 92.382535 145.00786 93.484375 146.23242 C 94.035335 146.8447 94.838466 147.29625 96.367188 147.62305 C 97.220238 147.80539 98.299056 147.9253 99.568359 148 L 204.43164 148 C 205.70094 147.9253 206.77976 147.80541 207.63281 147.62305 C 209.16153 147.29633 209.96466 146.8447 210.51562 146.23242 C 211.61748 145.00786 212.09375 142.067 212.09375 136.3418 L 212.09375 108 L 91.90625 108 z " />
+  <path
+     id="rect14407-0"
+     style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="M 59.90625 208 L 59.90625 236.3418 C 59.90625 242.067 60.382535 245.00786 61.484375 246.23242 C 62.035335 246.8447 62.838467 247.29625 64.367188 247.62305 C 64.950471 247.74773 65.6627 247.88472 66.441406 248 L 136.43164 248 C 137.70094 247.92532 138.77976 247.80541 139.63281 247.62305 C 141.16153 247.29633 141.96466 246.8447 142.51562 246.23242 C 143.61748 245.00786 144.09375 242.067 144.09375 236.3418 L 144.09375 208 L 59.90625 208 z " />
+  <path
+     id="rect14407-0-5"
+     style="display:inline;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 160,208 v 28.3418 c 0,5.7252 0.47628,8.66606 1.57812,9.89062 0.55096,0.61228 1.3541,1.06383 2.88282,1.39063 0.58328,0.12468 1.29551,0.26167 2.07422,0.37695 h 69.99023 c 1.2693,-0.0747 2.34812,-0.19459 3.20117,-0.37695 1.52872,-0.32672 2.33185,-0.77835 2.88281,-1.39063 1.10186,-1.22456 1.57813,-4.16542 1.57813,-9.89062 V 208 Z" />
+  <path
+     id="path918-21-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;opacity:0.3"
+     d="M 102.96094 63.90625 C 100.06902 63.89136 97.885205 64.028083 96.359375 64.351562 C 94.833565 64.675027 94.043627 65.127076 93.492188 65.742188 C 92.389228 66.972412 91.90625 69.929602 91.90625 75.65625 L 91.90625 77.65625 C 91.90625 71.929602 92.389228 68.972412 93.492188 67.742188 C 94.043627 67.127076 94.833565 66.675027 96.359375 66.351562 C 97.885215 66.028083 100.06902 65.89136 102.96094 65.90625 L 102.96875 65.90625 L 120 65.90625 L 201.03125 65.90625 L 201.03906 65.90625 C 203.62006 65.94264 206.11479 66.028087 207.64062 66.351562 C 209.16643 66.675044 209.95637 67.127066 210.50781 67.742188 C 211.61077 68.972425 212.09375 71.929602 212.09375 77.65625 L 212.09375 75.65625 C 212.09375 69.929602 211.61077 66.972425 210.50781 65.742188 C 209.95637 65.127066 209.16643 64.675044 207.64062 64.351562 C 206.11479 64.028087 203.62006 63.94264 201.03906 63.90625 L 201.03125 63.90625 L 120 63.90625 L 102.96875 63.90625 L 102.96094 63.90625 z M 70.960938 163.90625 C 68.069017 163.89135 65.885215 164.02808 64.359375 164.35156 C 62.833575 164.67503 62.043627 165.12708 61.492188 165.74219 C 60.389226 166.97241 59.90625 169.9296 59.90625 175.65625 L 59.90625 177.65625 C 59.90625 171.9296 60.389226 168.97241 61.492188 167.74219 C 62.043627 167.12708 62.833575 166.67503 64.359375 166.35156 C 65.885215 166.02808 68.069017 165.89135 70.960938 165.90625 L 70.96875 165.90625 L 88 165.90625 L 133.03125 165.90625 L 133.03906 165.90625 C 135.93102 165.90625 138.11479 166.02809 139.64062 166.35156 C 141.16644 166.67504 141.95637 167.12707 142.50781 167.74219 C 143.61077 168.97243 144.09375 171.9296 144.09375 177.65625 L 144.09375 175.65625 C 144.09375 169.9296 143.61077 166.97243 142.50781 165.74219 C 141.95637 165.12707 141.16644 164.67504 139.64062 164.35156 C 138.11479 164.02809 135.93102 163.90625 133.03906 163.90625 L 133.03125 163.90625 L 88 163.90625 L 70.96875 163.90625 L 70.960938 163.90625 z M 170.96094 163.90625 C 168.06902 163.89135 165.88521 164.02808 164.35938 164.35156 C 162.83356 164.67503 162.04363 165.12708 161.49219 165.74219 C 160.38923 166.97241 159.90625 169.9296 159.90625 175.65625 L 159.90625 177.65625 C 159.90625 171.9296 160.38923 168.97241 161.49219 167.74219 C 162.04363 167.12708 162.83355 166.67503 164.35938 166.35156 C 165.88521 166.02808 168.06902 165.89135 170.96094 165.90625 L 170.96875 165.90625 L 188 165.90625 L 233.03125 165.90625 L 233.03906 165.90625 C 235.93102 165.90625 238.11479 166.02809 239.64062 166.35156 C 241.16643 166.67504 241.95637 167.12707 242.50781 167.74219 C 243.61077 168.97243 244.09375 171.9296 244.09375 177.65625 L 244.09375 175.65625 C 244.09375 169.9296 243.61077 166.97243 242.50781 165.74219 C 241.95637 165.12707 241.16643 164.67504 239.64062 164.35156 C 238.11479 164.02809 235.93102 163.90625 233.03906 163.90625 L 233.03125 163.90625 L 188 163.90625 L 170.96875 163.90625 L 170.96094 163.90625 z " />
+  <path
+     id="path918-21-8-4"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;opacity:0.15"
+     d="M 91.90625 134.3418 L 91.90625 136.3418 C 91.90625 142.067 92.382535 145.00786 93.484375 146.23242 C 94.035335 146.8447 94.838466 147.29625 96.367188 147.62305 C 97.895866 147.94981 100.07503 148.0918 102.96875 148.0918 L 120 148.0918 L 201.03125 148.0918 C 203.92501 148.0918 206.10413 147.94985 207.63281 147.62305 C 209.16153 147.29633 209.96466 146.8447 210.51562 146.23242 C 211.61748 145.00786 212.09375 142.067 212.09375 136.3418 L 212.09375 134.3418 C 212.09375 140.067 211.61748 143.00786 210.51562 144.23242 C 209.96466 144.8447 209.16153 145.29633 207.63281 145.62305 C 206.10413 145.94985 203.92501 146.0918 201.03125 146.0918 L 120 146.0918 L 102.96875 146.0918 C 100.07503 146.0918 97.895866 145.94981 96.367188 145.62305 C 94.838466 145.29625 94.035335 144.8447 93.484375 144.23242 C 92.382535 143.00786 91.90625 140.067 91.90625 134.3418 z M 59.90625 234.3418 L 59.90625 236.3418 C 59.90625 242.067 60.382535 245.00786 61.484375 246.23242 C 62.035335 246.8447 62.838467 247.29625 64.367188 247.62305 C 65.895866 247.94981 68.094778 248.42929 70.96875 248.0918 L 88 248.0918 L 133.03125 248.0918 C 135.92501 248.09168 138.10413 247.94985 139.63281 247.62305 C 141.16153 247.29633 141.96466 246.8447 142.51562 246.23242 C 143.61748 245.00786 144.09375 242.067 144.09375 236.3418 L 144.09375 234.3418 C 144.09375 240.067 143.61748 243.00786 142.51562 244.23242 C 141.96466 244.8447 141.16153 245.29633 139.63281 245.62305 C 138.10413 245.94985 135.92501 246.09168 133.03125 246.0918 L 88 246.0918 L 70.96875 246.0918 C 68.094778 246.42929 65.895866 245.94981 64.367188 245.62305 C 62.838467 245.29625 62.035335 244.8447 61.484375 244.23242 C 60.382535 243.00786 59.90625 240.067 59.90625 234.3418 z M 159.90625 234.3418 L 159.90625 236.3418 C 159.90625 242.067 160.38253 245.00786 161.48438 246.23242 C 162.03533 246.8447 162.83847 247.29625 164.36719 247.62305 C 165.89587 247.94981 168.09478 248.42929 170.96875 248.0918 L 188 248.0918 L 233.03125 248.0918 C 235.92501 248.09168 238.10413 247.94985 239.63281 247.62305 C 241.16153 247.29633 241.96466 246.8447 242.51562 246.23242 C 243.61748 245.00786 244.09375 242.067 244.09375 236.3418 L 244.09375 234.3418 C 244.09375 240.067 243.61748 243.00786 242.51562 244.23242 C 241.96466 244.8447 241.16153 245.29633 239.63281 245.62305 C 238.10413 245.94985 235.92501 246.09168 233.03125 246.0918 L 188 246.0918 L 170.96875 246.0918 C 168.09478 246.42929 165.89587 245.94981 164.36719 245.62305 C 162.83847 245.29625 162.03533 244.8447 161.48438 244.23242 C 160.38253 243.00786 159.90625 240.067 159.90625 234.3418 z " />
+  <path
+     id="path1431-32"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="M 322.95117,133 A 2,2 0 0 0 321,135 h 1 a 1,1 0 0 1 1,-1 v -1 a 2,2 0 0 0 -0.0488,0 z" />
+  <path
+     id="path1431-5-0"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 322.95117,162.99985 a 2,2 0 0 1 -1.95117,-2 h 1 a 1,1 0 0 0 1,1 v 1 a 2,2 0 0 1 -0.0488,0 z" />
+  <path
+     id="path1431-0-6"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 349.04883,162.99985 a 2,2 0 0 0 1.95117,-2 h -1 a 1,1 0 0 1 -1,1 v 1 a 2,2 0 0 0 0.0488,0 z" />
+  <path
+     id="path1431-3-1"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="M 349.04883,133 A 2,2 0 0 1 351,135 h -1 a 1,1 0 0 0 -1,-1 v -1 a 2,2 0 0 1 0.0488,0 z" />
+  <path
+     id="path1431-55"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="M 322.95117,61 A 2,2 0 0 0 321,63 h 1 a 1,1 0 0 1 1,-1 v -1 a 2,2 0 0 0 -0.0488,0 z" />
+  <path
+     id="path1431-5-4"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 322.95117,106.99985 a 2,2 0 0 1 -1.95117,-2 h 1 a 1,1 0 0 0 1,1 v 1 a 2,2 0 0 1 -0.0488,0 z" />
+  <path
+     id="path1431-0-7"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 365.04883,106.99985 a 2,2 0 0 0 1.95117,-2 h -1 a 1,1 0 0 1 -1,1 v 1 a 2,2 0 0 0 0.0488,0 z" />
+  <path
+     id="path1431-3-65"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="M 365.04883,61 A 2,2 0 0 1 367,63 h -1 a 1,1 0 0 0 -1,-1 v -1 a 2,2 0 0 1 0.0488,0 z" />
+  <path
+     id="path1431-3-65-6"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 252.19532,48.000298 a 7.9999996,7.9999996 0 0 1 7.80468,8 h -4 a 3.9999998,3.9999998 0 0 0 -4,-4 v -4 a 7.9999996,7.9999996 0 0 1 0.1952,0 z" />
+  <path
+     id="path1431-3-65-6-9"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 252.19532,263.9997 a 7.9999996,-7.9999996 0 0 0 7.80468,-8 h -4 a 3.9999998,-3.9999998 0 0 1 -4,4 v 4 a 7.9999996,-7.9999996 0 0 0 0.1952,0 z" />
+  <path
+     id="path1431-3-65-6-3"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 51.80468,263.9997 a 7.9999996,-7.9999996 0 0 1 -7.80468,-8 h 4 a 3.9999998,-3.9999998 0 0 0 4,4 v 4 a 7.9999996,-7.9999996 0 0 1 -0.1952,0 z" />
+  <path
+     id="path1431-3-65-6-7"
+     style="display:inline;fill:#1a7fd4;fill-opacity:1;stroke-width:3.52252;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+     d="m 51.80468,48.000298 a -7.9999996,7.9999996 0 0 0 -7.80468,8 h 4 a -3.9999998,3.9999998 0 0 1 4,-4 v -4 a -7.9999996,7.9999996 0 0 0 -0.1952,0 z" />
+</svg>

--- a/icons/src/fullcolor/accented/actions/folder-new.svg
+++ b/icons/src/fullcolor/accented/actions/folder-new.svg
@@ -1,0 +1,1219 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   inkscape:export-ydpi="96"
+   inkscape:export-xdpi="96"
+   width="400"
+   height="300"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="1.1.2 (76b9e6a115, 2022-02-25)"
+   sodipodi:docname="folder-new.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   style="display:inline;enable-background:new"
+   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title3004">Suru Icon Theme Template</title>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#f57900"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2"
+     inkscape:cx="111"
+     inkscape:cy="145.25"
+     inkscape:current-layer="layer5"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="2488"
+     inkscape:window-height="1376"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     width="400px"
+     height="300px"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     gridtolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-grids="true"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="false"
+     showborder="false"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       spacingy="1"
+       spacingx="1"
+       id="grid5883"
+       type="xygrid"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid11592"
+       empspacing="2"
+       visible="true"
+       enabled="false"
+       spacingx="0.5"
+       spacingy="0.5"
+       color="#ff0000"
+       opacity="0.1254902"
+       empcolor="#ff0000"
+       empopacity="0.25098039"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9430">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path9432"
+         d="m 166.0625,-196 h 179.875 C 491.2348,-196 512,-175.28677 512,-30.125 v 148.25 C 512,263.28618 491.2348,284 345.9375,284 H 166.0625 C 20.7652,284 0,263.28618 0,118.125 V -30.125 C 0,-175.28677 20.7652,-196 166.0625,-196 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath994">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
+         id="path996"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath959">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 330.1929,133.99999 c -5.61538,0 -6.21958,0.57678 -6.19206,6.20352 v 7.79648 7.79648 c -0.0276,5.62673 0.57668,6.20351 6.19206,6.20351 h 11.615 c 5.6154,0 6.19208,-0.5767 6.19208,-6.20351 v -7.79648 -7.79648 c 0,-5.6268 -0.5767,-6.20352 -6.19208,-6.20352 z"
+         id="path961"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath971">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
+         id="path973"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath983">
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path985"
+         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient4336-3">
+      <stop
+         style="stop-color:#5884f4;stop-opacity:1"
+         offset="0"
+         id="stop4338-8" />
+      <stop
+         id="stop4344-3"
+         offset="0.27800092"
+         style="stop-color:#5884f4;stop-opacity:1" />
+      <stop
+         style="stop-color:#2f5fdd;stop-opacity:1"
+         offset="0.27800092"
+         id="stop4346-3" />
+      <stop
+         id="stop4350-1"
+         offset="0.70735365"
+         style="stop-color:#2f5fdd;stop-opacity:1" />
+      <stop
+         id="stop4348-6"
+         offset="0.70936078"
+         style="stop-color:#234db8;stop-opacity:1" />
+      <stop
+         style="stop-color:#234db8;stop-opacity:1"
+         offset="1"
+         id="stop4340-0" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath994-1">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
+         id="path996-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1144">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1146"
+         d="m 563.72139,-143.78206 c 77.49205,0 88.56678,11.04708 88.56678,88.466604 V 6.684672 c 0,77.419349 -11.07473,88.466603 -88.56678,88.466603 h -78.86661 c -77.49171,0 -88.56661,-11.047254 -88.56661,-88.466603 v -62.000128 c 0,-77.419524 11.0749,-88.466604 88.56678,-88.466604 z"
+         style="display:inline;opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1151">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1153"
+         d="m 335.71582,189.50031 c 6.81081,10e-6 7.78418,0.97093 7.78418,7.77539 v 5.44891 c 0,6.80444 -0.97337,7.77539 -7.78418,7.77539 h -7.43164 c -6.81081,0 -7.78418,-0.97095 -7.78418,-7.77539 v -5.44892 c 0,-6.80446 0.97337,-7.7754 7.78418,-7.77539 z"
+         style="display:inline;opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1158">
+      <path
+         style="display:inline;opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 341.12109,133.5 c 9.08109,0 10.37891,1.29458 10.37891,10.36719 v 8.26562 c 0,9.07258 -1.29782,10.36719 -10.37891,10.36719 H 330.87891 C 321.79783,162.5 320.5,161.20539 320.5,152.13281 v -8.26562 c 0,-9.07261 1.29783,-10.36719 10.37891,-10.36719 z"
+         id="path1160"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1165">
+      <path
+         style="display:inline;opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="M 351.93164,62.5 C 365.55326,62.5 367.5,64.44187 367.5,78.05078 V 89.94922 C 367.5,103.55808 365.55326,105.5 351.93164,105.5 H 336.06836 C 322.44674,105.5 320.5,103.55808 320.5,89.94922 V 78.05078 C 320.5,64.44187 322.44674,62.5 336.06836,62.5 Z"
+         id="path1167"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1064">
+      <path
+         style="opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 115.03125,44 C 42.3826,44 32,54.356615 32,126.9375 v 58.125 c 0,10.16582 0.217657,19.07051 0.767578,26.9375 3.376331,48.30069 19.790377,56 82.263672,56 h 73.9375 c 62.4733,0 78.88734,-7.69931 82.26367,-56 C 271.78234,204.13301 272,195.22832 272,185.0625 v -58.125 C 272,54.356615 261.6174,44 188.96875,44 Z"
+         id="path1066"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1064-8">
+      <path
+         style="opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 115.03125,44 C 42.3826,44 32,54.356615 32,126.9375 v 58.125 c 0,10.16582 0.217657,19.07051 0.767578,26.9375 3.376331,48.30069 19.790377,56 82.263672,56 h 73.9375 c 62.4733,0 78.88734,-7.69931 82.26367,-56 C 271.78234,204.13301 272,195.22832 272,185.0625 v -58.125 C 272,54.356615 261.6174,44 188.96875,44 Z"
+         id="path1066-4"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1144-3">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1146-8"
+         d="m 563.72139,-143.78206 c 77.49205,0 88.56678,11.04708 88.56678,88.466604 V 6.684672 c 0,77.419349 -11.07473,88.466603 -88.56678,88.466603 h -78.86661 c -77.49171,0 -88.56661,-11.047254 -88.56661,-88.466603 v -62.000128 c 0,-77.419524 11.0749,-88.466604 88.56678,-88.466604 z"
+         style="display:inline;opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1151-3">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1153-6"
+         d="m 335.71582,189.50031 c 6.81081,10e-6 7.78418,0.97093 7.78418,7.77539 v 5.44891 c 0,6.80444 -0.97337,7.77539 -7.78418,7.77539 h -7.43164 c -6.81081,0 -7.78418,-0.97095 -7.78418,-7.77539 v -5.44892 c 0,-6.80446 0.97337,-7.7754 7.78418,-7.77539 z"
+         style="display:inline;opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1158-2">
+      <path
+         style="display:inline;opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 341.12109,133.5 c 9.08109,0 10.37891,1.29458 10.37891,10.36719 v 8.26562 c 0,9.07258 -1.29782,10.36719 -10.37891,10.36719 H 330.87891 C 321.79783,162.5 320.5,161.20539 320.5,152.13281 v -8.26562 c 0,-9.07261 1.29783,-10.36719 10.37891,-10.36719 z"
+         id="path1160-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1165-5">
+      <path
+         style="display:inline;opacity:1;fill:#a3dbf0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="M 351.93164,62.5 C 365.55326,62.5 367.5,64.44187 367.5,78.05078 V 89.94922 C 367.5,103.55808 365.55326,105.5 351.93164,105.5 H 336.06836 C 322.44674,105.5 320.5,103.55808 320.5,89.94922 V 78.05078 C 320.5,64.44187 322.44674,62.5 336.06836,62.5 Z"
+         id="path1167-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4851">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path4853"
+         d="m 335.71582,189.50031 c 6.81081,10e-6 7.78418,0.97093 7.78418,7.77539 v 5.44891 c 0,6.80444 -0.97337,7.77539 -7.78418,7.77539 h -7.43164 c -6.81081,0 -7.78418,-0.97095 -7.78418,-7.77539 v -5.44892 c 0,-6.80446 0.97337,-7.7754 7.78418,-7.77539 z"
+         style="display:inline;opacity:1;fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4824">
+      <path
+         style="display:inline;opacity:1;fill:#5bdbc1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 341.12109,133.5 c 9.08109,0 10.37891,1.29458 10.37891,10.36719 v 8.26562 c 0,9.07258 -1.29782,10.36719 -10.37891,10.36719 H 330.87891 C 321.79783,162.5 320.5,161.20539 320.5,152.13281 v -8.26562 c 0,-9.07261 1.29783,-10.36719 10.37891,-10.36719 z"
+         id="path4826"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4783">
+      <path
+         style="display:inline;opacity:1;fill:#d64310;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="M 351.93164,61.5 C 365.55326,61.5 367.5,63.44187 367.5,77.05078 V 88.94922 C 367.5,102.55808 365.55326,104.5 351.93164,104.5 H 336.06836 C 322.44674,104.5 320.5,102.55808 320.5,88.94922 V 77.05078 C 320.5,63.44187 322.44674,61.5 336.06836,61.5 Z"
+         id="path4785"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4653">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path4655"
+         d="m 412.21109,-140.08377 c 90.81111,0 103.78933,12.94582 103.78933,103.671926 v 72.656487 c 0,90.725907 -12.97822,103.671927 -103.78933,103.671927 h -92.42191 c -90.81071,0 -103.78912,-12.94602 -103.78912,-103.671927 v -72.656487 c 0,-90.726106 12.97841,-103.671926 103.78932,-103.671926 z"
+         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4657">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path4659"
+         d="m 415.5445,-130.07962 c 90.81091,1.3e-4 103.78919,12.94575 103.78919,103.671988 v 72.652221 c 0,90.725971 -12.97828,103.671991 -103.78919,103.671991 h -99.08865 c -90.81091,0 -103.78919,-12.94602 -103.78919,-103.671991 v -72.652354 c 0,-90.726245 12.97828,-103.672125 103.78919,-103.671995 z"
+         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4661">
+      <path
+         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 417.2112,-135.08366 c 90.81101,0 103.78923,12.94581 103.78923,103.672022 v 82.656299 c 0,90.725909 -12.97822,103.672029 -103.78923,103.672029 H 314.78928 c -90.81091,0 -103.78923,-12.94612 -103.78923,-103.672029 v -82.656299 c 0,-90.726212 12.97832,-103.672022 103.78923,-103.672022 z"
+         id="path4663"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4665">
+      <path
+         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 418.87763,-133.41668 c 90.8108,0 103.78907,12.9458 103.78907,103.671871 V 49.57813 c 0,90.72574 -12.97827,103.67187 -103.78907,103.67187 H 313.12242 c -90.81081,0 -103.78907,-12.94613 -103.78907,-103.67187 v -79.322939 c 0,-90.726071 12.97826,-103.671871 103.78907,-103.671871 z"
+         id="path4667"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath947">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path949"
+         d="m 191.43333,45.066672 c 77.49189,0 88.56666,11.047056 88.56666,88.466668 v 62 C 279.99999,272.95263 268.92522,284 191.43333,284 H 112.56666 C 35.074773,284 23.999999,272.95263 23.999999,195.53334 v -62 c 0,-77.419612 11.074774,-88.466668 88.566661,-88.466668 z"
+         style="opacity:1;fill:#a4c1f9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4657-5">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path4659-3"
+         d="m 415.5445,-130.07962 c 90.81091,1.3e-4 103.78919,12.94575 103.78919,103.671988 v 72.652221 c 0,90.725971 -12.97828,103.671991 -103.78919,103.671991 h -99.08865 c -90.81091,0 -103.78919,-12.94602 -103.78919,-103.671991 v -72.652354 c 0,-90.726245 12.97828,-103.672125 103.78919,-103.671995 z"
+         style="display:inline;opacity:1;fill:#f22c42;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4851-5">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path4853-6"
+         d="m 335.71582,189.50031 c 6.81081,10e-6 7.78418,0.97093 7.78418,7.77539 v 5.44891 c 0,6.80444 -0.97337,7.77539 -7.78418,7.77539 h -7.43164 c -6.81081,0 -7.78418,-0.97095 -7.78418,-7.77539 v -5.44892 c 0,-6.80446 0.97337,-7.7754 7.78418,-7.77539 z"
+         style="display:inline;opacity:1;fill:#46a926;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath971-7">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
+         id="path973-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath977-5">
+      <path
+         id="path979-7"
+         d="M 78.994141,52 C 43.625611,52 40,53.999146 40,89.296875 V 140 H 264 V 108.92188 C 264,73.624145 260.37439,68 225.00586,68 H 138 L 122,52 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f6531e;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3388">
+      <stop
+         style="stop-color:#666666;stop-opacity:1;"
+         offset="0"
+         id="stop3384" />
+      <stop
+         style="stop-color:#7a7a7a;stop-opacity:1"
+         offset="1"
+         id="stop3386" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1361">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop1357" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.20392157"
+         offset="1"
+         id="stop1359" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter11348"
+       x="-0.048000001"
+       width="1.096"
+       y="-0.048000001"
+       height="1.096">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.36"
+         id="feGaussianBlur11350" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1344-4-0"
+       x="-0.011357142"
+       width="1.0227143"
+       y="-0.012719999"
+       height="1.02544">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.06"
+         id="feGaussianBlur1346-22-9" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter959-45-6"
+       x="-0.011357142"
+       width="1.0227143"
+       y="-0.012230769"
+       height="1.0244615">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.06"
+         id="feGaussianBlur961-17-3" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36441-8"
+       id="linearGradient3050"
+       x1="40"
+       y1="259.9881"
+       x2="263.99503"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.5e-6,-1.98e-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36441-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.8"
+         offset="0"
+         id="stop36437-5" />
+      <stop
+         id="stop36445-6"
+         offset="0.10864977"
+         style="stop-color:#000000;stop-opacity:0.698" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.6"
+         offset="0.18689813"
+         id="stop36449-1" />
+      <stop
+         id="stop36451-1"
+         offset="0.2980746"
+         style="stop-color:#000000;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.4"
+         offset="0.37246177"
+         id="stop36453-5" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.302"
+         offset="0.44700962"
+         id="stop36447-9" />
+      <stop
+         id="stop36455-8"
+         offset="0.52428877"
+         style="stop-color:#000000;stop-opacity:0.2" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.102"
+         offset="0.59614229"
+         id="stop36457-4" />
+      <stop
+         id="stop36459-8"
+         offset="0.66876179"
+         style="stop-color:#ffffff;stop-opacity:0.102" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.204"
+         offset="0.79755175"
+         id="stop36461-1" />
+      <stop
+         id="stop36463-0"
+         offset="0.91251218"
+         style="stop-color:#ffffff;stop-opacity:0.302" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.404"
+         offset="1"
+         id="stop36439-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3388"
+       id="linearGradient13842-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.5e-6,4.2e-5)"
+       x1="40"
+       y1="84"
+       x2="264"
+       y2="260" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1361"
+       id="radialGradient3541-3-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.26304411,1.5e-6,60.033162)"
+       cx="152"
+       cy="-0.12591045"
+       fx="152"
+       fy="-0.12591045"
+       r="112" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1361"
+       id="radialGradient3543-79-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.25411554,1.5e-6,85.915832)"
+       cx="148"
+       cy="39.683556"
+       fx="148"
+       fy="39.683556"
+       r="112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36441-8"
+       id="linearGradient3077"
+       x1="321"
+       y1="106"
+       x2="367"
+       y2="63"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.6e-7,-1.9910124e-4)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3388"
+       id="linearGradient13848-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.6e-7,4.0898761e-5)"
+       x1="321"
+       y1="70"
+       x2="367"
+       y2="105" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36441-8"
+       id="linearGradient3104"
+       x1="321"
+       y1="164"
+       x2="351.5336"
+       y2="134.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93556829,0,0,0.96609197,21.634261,4.5603866)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3388"
+       id="linearGradient13846-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93556829,0,0,0.96609197,21.634261,4.5606183)"
+       x1="321"
+       y1="139"
+       x2="352"
+       y2="163" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36441-8"
+       id="linearGradient3245"
+       x1="320.51196"
+       y1="210.50024"
+       x2="343.50137"
+       y2="189.49901"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.91667002,0,0,0.91119849,27.708551,17.830571)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3388"
+       id="linearGradient13844"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.91667002,0,0,0.91119849,27.708551,17.83079)"
+       x1="320"
+       y1="194"
+       x2="344"
+       y2="211" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36441-8"
+       id="linearGradient3329"
+       x1="320.50748"
+       y1="250.50113"
+       x2="335.42361"
+       y2="236.50024"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2500041,0,0,1.1937668,-26.998306,-89.826073)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3388"
+       id="linearGradient1901-86"
+       x1="1120"
+       y1="-121"
+       x2="1136"
+       y2="-109"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2500041,0,0,1.1937668,-1027.0016,339.93026)" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Sam Hewitt</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title>Suru Icon Theme Template</dc:title>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:date />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="Icon"
+     id="layer1">
+    <g
+       style="display:none"
+       inkscape:label="Baseplate"
+       id="layer7"
+       inkscape:groupmode="layer"
+       sodipodi:insensitive="true">
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="19.006836"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="context"
+         id="context"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
+           y="-8.2548828"
+           x="19.006836"
+           sodipodi:role="line"
+           id="tspan3933">actions</tspan></text>
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="146.48828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16px;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="icon-name"
+         id="icon-name"><tspan
+           sodipodi:role="line"
+           id="tspan1027"
+           x="146.48828"
+           y="-8.2548828">folder-new</tspan></text>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect16x16"
+         width="16"
+         height="16"
+         x="320"
+         y="236"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect24x24"
+         width="24"
+         height="24"
+         x="320"
+         y="188"
+         inkscape:label="24x24" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect32x32"
+         width="32"
+         height="32"
+         x="320"
+         y="132"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="48x48"
+         y="60"
+         x="320"
+         height="48"
+         width="48"
+         id="rect48x48"
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect3951"
+         width="256"
+         height="256"
+         x="24"
+         y="28"
+         inkscape:label="48x48" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect24x24-9"
+         width="22"
+         height="22"
+         x="372"
+         y="190"
+         inkscape:label="24x24" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer5"
+       inkscape:label="Backgrounds"
+       style="display:inline;opacity:1">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter1344-4-0);enable-background:accumulate"
+         d="m 78.994138,54.000042 c -35.368527,0 -38.994137,1.99915 -38.994137,37.29688 v 41.624998 9.07812 73.07812 c 0,35.29774 3.62561,38.92188 38.994137,38.92188 H 225.0059 c 35.3685,0 38.9941,-3.62414 38.9941,-38.92188 v -73.07812 -25.07812 -6 C 264,75.624182 260.3744,70.000042 225.0059,70.000042 H 138 l -16,-16 z"
+         id="path3459-99-3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter959-45-6);enable-background:accumulate"
+         d="m 78.994138,53.000042 c -35.368527,0 -38.994137,1.99915 -38.994137,37.29688 v 41.624998 60.65624 29.5 c 0,35.29774 3.62561,38.92188 38.994137,38.92188 H 225.0059 c 35.3685,0 38.9941,-3.62414 38.9941,-38.92188 v -29.5 -76.65624 -6 C 264,74.624192 260.3744,69.000042 225.0059,69.000042 H 138 l -16,-16 z"
+         id="path3465-4-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssccssssccssccs" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 78.994138,52.000042 c -35.368527,0 -38.994137,1.99915 -38.994137,37.29688 V 140.00004 H 264 V 108.92192 C 264,73.624192 260.3744,68.000042 225.0059,68.000042 H 138 l -16,-16 z"
+         id="path3469-9-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssccssccs" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3050);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 78.994138,51.999802 c -35.368527,0 -38.994137,1.99915 -38.994137,37.29688 V 139.9998 H 264 V 108.92168 C 264,73.623952 260.3744,67.999802 225.0059,67.999802 H 138 l -16,-16 z"
+         id="path3469-9-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssccssccs" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3473-8-5"
+         d="m 78.993528,100.00004 c -35.368527,0 -38.993527,3.625 -38.993527,38.92273 v 82.15454 c 0,35.29773 3.625,38.92273 38.993527,38.92273 H 225.0065 c 35.3685,0 38.9935,-3.625 38.9935,-38.92273 V 122.92277 C 264,87.625042 260.375,84.000042 225.0065,84.000042 H 143.75 l -16.00782,15.999998 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient13842-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="ssssssssccs" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient3541-3-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 78.994138,52.000042 c -35.368527,0 -38.994137,1.99915 -38.994137,37.29688 v 2 c 0,-35.29773 3.62561,-37.29688 38.994137,-37.29688 H 122 l 16,16 h 87.0059 c 35.3685,0 38.9941,5.62414 38.9941,40.921878 v -2 C 264,73.624182 260.3744,68.000042 225.0059,68.000042 H 138 l -16,-16 z"
+         id="path3475-9-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sscsccscssccs" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient3543-79-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="M 143.75,84.000042 127.74219,100.00004 H 78.994138 c -35.368527,0 -38.994137,3.62415 -38.994137,38.92188 v 2 c 0,-35.29773 3.62561,-38.92188 38.994137,-38.92188 H 127.74219 L 143.75,86.000042 h 81.2559 c 35.3685,0 38.9941,3.62415 38.9941,38.921878 v -2 c 0,-35.297728 -3.6256,-38.921878 -38.9941,-38.921878 z"
+         id="path3477-3-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsscsccscssc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 264,194.00004 -64,64 h 25.0059 c 35.3685,0 38.9941,-3.62414 38.9941,-38.92188 z"
+         id="path3479-14-2"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#491706;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 40.000002,219.07816 v 2 c 0,35.29774 3.62561,38.92188 38.994137,38.92188 H 225.0059 c 35.3685,0 38.9941,-3.62414 38.9941,-38.92188 v -2 c 0,35.29774 -3.6256,38.92188 -38.9941,38.92188 H 78.994138 c -35.368527,0 -38.994137,-3.62414 -38.994136,-38.92188 z"
+         id="path3487-7-1"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 329.8125,64.000041 c -2.9004,0 -5.051,-0.095 -6.6562,1.11914 -0.8135,0.61532 -1.3536,1.54216 -1.6641,2.716801 -0.3093,1.16994 -0.4278,2.61376 -0.4278,4.48828 v 9.40625 3.26953 12.26953 c 0,1.952219 0.053,3.441368 0.2676,4.644528 0.2154,1.20586 0.6222,2.18455 1.3868,2.86524 0.7626,0.67895 1.7527,0.95992 2.8945,1.09179 1.1408,0.13175 2.4963,0.12891 4.1992,0.12891 h 28.5039 c 1.6708,0 3.0101,0.002 4.1445,-0.12891 v 0 c 1.1353,-0.13187 2.1255,-0.41132 2.8946,-1.08593 0.7708,-0.67622 1.1929,-1.653 1.4199,-2.86133 0.2265,-1.20563 0.2871,-2.699209 0.2871,-4.654298 V 78.730511 c 0,-0.25826 -0.012,-0.42611 -0.014,-0.60547 v -0.0117 l 0.014,-1.875 c 0.013,-1.81021 0.019,-3.25112 -0.1152,-4.45508 -0.134,-1.20424 -0.4167,-2.23038 -1.0957,-3.027339 -0.682,-0.80032 -1.6746,-1.24023 -2.8907,-1.4707 -1.2123,-0.22969 -2.7045,-0.28516 -4.6465,-0.28516 h -15.9023 l -3,-3 z"
+         id="path3461-6-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccsccscccssccccssccccccsccs" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 329.8125,63.000041 c -2.9004,0 -5.051,-0.095 -6.6562,1.11914 -0.8135,0.61532 -1.3536,1.54216 -1.6641,2.716801 -0.3093,1.16994 -0.4278,2.61376 -0.4278,4.48828 v 8.67578 h 46 v -2.26953 c 0,-0.258261 -0.012,-0.42611 -0.014,-0.60547 v -0.0117 l 0.014,-1.875 c 0.013,-1.81021 0.019,-3.25112 -0.1152,-4.45508 -0.134,-1.20424 -0.4166,-2.23038 -1.0957,-3.02734 -0.6819,-0.80032 -1.6746,-1.24023 -2.8906,-1.4707 -1.2124,-0.22968 -2.7045,-0.28516 -4.6465,-0.28516 h -15.9023 l -3,-3 z"
+         id="path3463-06-9"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient3077);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 329.8121,62.991541 c -2.9004,0 -5.051,-0.095 -6.6562,1.11914 -0.8135,0.615319 -1.3536,1.542159 -1.6641,2.7168 -0.3093,1.16994 -0.4278,2.61376 -0.4278,4.48828 v 8.67578 h 46 v -2.26953 c 0,-0.25826 -0.012,-0.42611 -0.014,-0.60547 v -0.0117 l 0.014,-1.875 c 0.013,-1.81021 0.019,-3.25112 -0.1152,-4.45508 -0.134,-1.20424 -0.4166,-2.23038 -1.0957,-3.02734 -0.6819,-0.80032 -1.6746,-1.24023 -2.8906,-1.4707 -1.2124,-0.22968 -2.7045,-0.28516 -4.6465,-0.28516 h -15.9023 l -3,-3 z"
+         id="path3463-06-1"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 343.002,70.00004 -3.002,3 h -10.1875 c -6.8128,0 -7.748,-2.08e-4 -7.748,7.73047 v 1 c 0,-7.73068 0.9352,-7.73047 7.748,-7.73047 H 340 l 3.002,-3 h 15.3144 c 6.6839,0 7.7481,-2.08e-4 7.7481,7.73047 v -1 c 0,-7.73068 -1.0642,-7.73047 -7.7481,-7.73047 z"
+         id="path3485-6-6"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path3523-6-4"
+         d="m 358.3229,70.00004 c 2.9004,0 5.051,-0.095 6.6562,1.119141 0.8135,0.615319 1.3536,1.542159 1.6641,2.716801 0.3092,1.16994 0.4277,2.61376 0.4277,4.48828 v 9.40625 4.26953 4.26953 c 0,1.952219 -0.053,3.441379 -0.2676,4.644528 -0.2153,1.20586 -0.6221,2.18455 -1.3867,2.86524 -0.7627,0.67895 -1.7527,0.95992 -2.8945,1.09179 -1.1408,0.13175 -2.4963,0.12891 -4.1992,0.12891 h -28.504 c -1.6707,0 -3.0101,0.002 -4.1445,-0.12891 v 0 c -1.1352,-0.13187 -2.1255,-0.41132 -2.8945,-1.08593 -0.7709,-0.67622 -1.193,-1.653 -1.4199,-2.86133 -0.2265,-1.205629 -0.2871,-2.699209 -0.2871,-4.654298 V 84.730511 c 0,-0.25826 0.012,-0.42611 0.014,-0.60547 v -0.0117 l -0.014,-1.875 c -0.013,-1.81021 -0.019,-3.25112 0.1152,-4.45508 0.134,-1.20424 0.4166,-2.23038 1.0957,-3.027339 0.6819,-0.80032 1.6746,-1.24023 2.8906,-1.4707 1.2125,-0.22968 2.7144,-0.48029 4.6466,-0.28516 h 9.9023 l 3,-3 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient13848-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccsccscccssccccssccccccsccs" />
+      <path
+         id="path3525-5-3"
+         d="m 367,92.00004 -12,12 h 4.6886 c 6.6316,0 7.3114,-0.67952 7.3114,-7.29786 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 321.0645,95.269571 v 1 c 0,1.95222 0.053,3.44137 0.2675,4.644529 0.2154,1.20586 0.6222,2.18455 1.3868,2.86524 0.7626,0.67895 1.7527,0.95992 2.8945,1.09179 1.1408,0.13175 2.4963,0.12891 4.1992,0.12891 h 28.5039 c 1.6708,0 3.0101,0.002 4.1445,-0.12891 v 0 c 1.1353,-0.13187 2.1255,-0.41132 2.8946,-1.08593 0.7708,-0.67622 1.1929,-1.653 1.4199,-2.86133 0.2265,-1.205629 0.2871,-2.699209 0.2871,-4.6543 v -1 c 0,1.95509 -0.061,3.448671 -0.2871,4.654301 -0.227,1.208329 -0.6491,2.185109 -1.4199,2.861329 -0.7691,0.67461 -1.7593,0.95406 -2.8946,1.08593 v 0 c -1.1344,0.13091 -2.4737,0.12891 -4.1445,0.12891 h -28.5039 c -1.7029,0 -3.0584,0.003 -4.1992,-0.12891 -1.1418,-0.13187 -2.1319,-0.41284 -2.8945,-1.09179 -0.7646,-0.68069 -1.1714,-1.65938 -1.3868,-2.865239 -0.2147,-1.20316 -0.2676,-2.692311 -0.2675,-4.64453 z"
+         id="path3527-422-3"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 342.7207,70.00004 -3,3 h -9.9023 c -1.9322,-0.19513 -3.4341,0.0555 -4.6465,0.285162 -1.216,0.230469 -2.2087,0.670389 -2.8906,1.470698 -0.6791,0.79696 -0.9618,1.8231 -1.0957,3.02734 -0.073,0.65514 -0.1018,1.40002 -0.1133,2.2168 h 0.039 c 0.017,-0.42337 0.034,-0.850578 0.074,-1.2168 0.134,-1.20424 0.4166,-2.23038 1.0957,-3.02734 0.6819,-0.800309 1.6746,-1.240229 2.8906,-1.470698 1.2124,-0.229681 2.7143,-0.48029 4.6465,-0.285162 h 9.9023 l 3,-3 h 15.6016 c 2.9004,0 5.051,-0.095 6.6562,1.119141 0.8135,0.615319 1.3536,1.542159 1.6641,2.716801 0.3092,1.16994 0.4277,2.61376 0.4277,4.48828 v -1 c 0,-1.87452 -0.1185,-3.31834 -0.4277,-4.48828 -0.3105,-1.17464 -0.8506,-2.10148 -1.6641,-2.716801 -1.6052,-1.21418 -3.7558,-1.119141 -6.6562,-1.119141 z"
+         id="path3529-1-3"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path3531-7-8"
+         d="m 342.7207,69.00004 -3,3 h -9.9023 c -1.9322,-0.19513 -3.4341,0.0555 -4.6465,0.285162 -1.216,0.230469 -2.2087,0.670389 -2.8906,1.470698 -0.6791,0.79696 -0.9618,1.8231 -1.0957,3.02734 -0.073,0.65514 -0.1018,1.40002 -0.1133,2.2168 h 0.039 c 0.017,-0.42337 0.034,-0.850578 0.074,-1.2168 0.134,-1.20424 0.4166,-2.23038 1.0957,-3.02734 0.6819,-0.800309 1.6746,-1.240229 2.8906,-1.470698 1.2124,-0.229681 2.7143,-0.48029 4.6465,-0.285162 h 9.9023 l 3,-3 h 15.6016 c 2.9004,0 5.051,-0.095 6.6562,1.119141 0.8135,0.615319 1.3536,1.542159 1.6641,2.716801 0.3092,1.16994 0.4277,2.61376 0.4277,4.48828 v -1 c 0,-1.87452 -0.1185,-3.31834 -0.4277,-4.48828 -0.3105,-1.17464 -0.8506,-2.10148 -1.6641,-2.716801 -1.6052,-1.21418 -3.7558,-1.119141 -6.6562,-1.119141 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 329.8125,63.000041 c -2.9004,0 -5.051,-0.095 -6.6562,1.11914 -0.8135,0.61532 -1.3536,1.54216 -1.6641,2.716801 -0.3093,1.16994 -0.4278,2.61376 -0.4278,4.48828 v 1 c 0,-1.87452 0.1185,-3.31834 0.4278,-4.48828 0.3105,-1.17464 0.8505,-2.101481 1.6641,-2.716801 1.6052,-1.21418 3.7558,-1.119139 6.6562,-1.119139 h 9.6016 l 3,3 h 15.9023 c 1.942,0 3.4341,0.0555 4.6465,0.28516 1.216,0.23047 2.2087,0.67039 2.8906,1.4707 0.6791,0.79696 0.9617,1.8231 1.0957,3.02734 0.067,0.60198 0.1,1.263 0.1133,2 0,-1.127931 -0.019,-2.152821 -0.1133,-3 -0.134,-1.20424 -0.4166,-2.23038 -1.0957,-3.02734 -0.6819,-0.80031 -1.6746,-1.24023 -2.8906,-1.4707 -1.2124,-0.229681 -2.7045,-0.28516 -4.6465,-0.28516 h -15.9023 l -3,-3 z m 37.2441,14.367191 -0.01,0.746089 v 0.0117 c 0,0.17936 0.014,0.34721 0.014,0.60547 v -1 c 0,-0.15495 0,-0.251412 -0.01,-0.363281 z"
+         id="path3533-2-6"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 327.59616,134.98305 c -1.4286,0 -2.52753,0.0553 -3.43165,0.2453 -0.90798,0.19086 -1.66644,0.54693 -2.19269,1.17742 -0.52393,0.62772 -0.7393,1.41735 -0.8424,2.27937 -0.103,0.86094 -0.10553,1.84607 -0.11329,3.053 v 0.002 0.004 14.49515 0.004 0.002 c 0.0159,2.40661 -0.0776,4.02179 0.78756,5.26444 0.44561,0.63997 1.12933,1.03595 1.92962,1.2378 0.79138,0.19963 1.72789,0.25284 2.92729,0.25284 h 17.77579 c 1.42862,0 2.52783,-0.0553 3.43167,-0.24528 0.90741,-0.19087 1.66438,-0.54539 2.18905,-1.17743 0.52232,-0.62921 0.73498,-1.4204 0.83321,-2.28315 0.0981,-0.86141 0.095,-1.8496 0.095,-3.05678 v -12.5592 c 0,-1.20709 0,-2.19511 -0.095,-3.05677 -0.0982,-0.86276 -0.31089,-1.65396 -0.83321,-2.28314 -0.52467,-0.63205 -1.28164,-0.98656 -2.18905,-1.17743 -0.90384,-0.19038 -2.00305,-0.24557 -3.43167,-0.24557 h -9.92217 l -2.00444,-1.93218 h -0.36918 c -1.93092,-9e-5 -3.65995,-2e-5 -4.07664,0 z"
+         id="path3453-68-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccccccccccsscccsscccsccccs" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 327.59616,134.5 c -1.41635,0 -2.49066,0.0577 -3.33848,0.23586 -0.84771,0.17822 -1.49288,0.49353 -1.93138,1.01893 -0.4385,0.52539 -0.63516,1.20656 -0.73274,2.02276 -0.0977,0.81618 -0.10189,1.79076 -0.10965,2.99827 v 0.002 14.49514 0.002 c 0.016,2.41501 -0.0356,3.93093 0.69991,4.98708 0.36767,0.52806 0.93499,0.866 1.6609,1.0491 0.72601,0.18312 1.6308,0.23964 2.81588,0.23964 h 17.77579 c 1.41636,0 2.49114,-0.0577 3.33849,-0.23586 0.84734,-0.17823 1.49092,-0.49271 1.92773,-1.01892 0.43683,-0.52622 0.63057,-1.20822 0.72367,-2.02464 0.0926,-0.81643 0.0916,-1.79256 0.0916,-3.00018 v -12.55931 c 0,-1.20761 0,-2.18375 -0.0916,-3.00017 -0.0936,-0.81642 -0.28684,-1.49841 -0.72367,-2.02464 -0.43681,-0.52622 -1.08039,-0.8407 -1.92773,-1.01893 -0.84735,-0.17823 -1.92213,-0.23586 -3.33849,-0.23586 h -10.10666 l -2.00455,-1.93218 h -0.18458 c -2.15247,-1e-4 -4.54444,0 -4.54444,0 z"
+         id="path3455-5-2"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscccccccsscscsscsssccccc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient3104);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 327.59616,134.49976 c -1.41635,0 -2.49066,0.0577 -3.33848,0.23586 -0.84771,0.17821 -1.49288,0.49353 -1.93138,1.01893 -0.4385,0.5254 -0.63516,1.20657 -0.73274,2.02275 -0.0977,0.81619 -0.10189,1.79077 -0.10965,2.99828 v 0.002 14.49515 0.002 c 0.016,2.415 -0.0356,3.93094 0.69991,4.98708 0.36767,0.52807 0.93499,0.866 1.6609,1.04911 0.72601,0.1831 1.6308,0.23963 2.81588,0.23963 h 17.77579 c 1.41636,0 2.49114,-0.0577 3.33849,-0.23585 0.84734,-0.17824 1.49092,-0.4927 1.92773,-1.01893 0.43683,-0.52622 0.63057,-1.20821 0.72367,-2.02464 0.0926,-0.81642 0.0916,-1.79255 0.0916,-3.00017 v -12.55919 c 0,-1.20762 0,-2.18375 -0.0916,-3.00018 -0.0936,-0.81641 -0.28684,-1.49841 -0.72367,-2.02463 -0.43681,-0.52622 -1.08039,-0.8407 -1.92773,-1.01893 -0.84735,-0.17823 -1.92213,-0.23586 -3.33849,-0.23586 h -10.10666 l -2.00455,-1.93218 h -0.18458 c -2.15247,-1e-4 -4.54444,0 -4.54444,0 z"
+         id="path3455-5-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscccccccsscscsscsssccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3495-15-4"
+         d="m 336.11864,138.84741 -2.00456,1.93219 h -7.01675 c -5.58264,0 -5.61323,0.96287 -5.61342,5.72485 0,0.0263 0,0.0452 0,0.0716 0,2.37437 0.0178,4.74689 0.01,7.10984 -1.8e-4,0.01 -1.8e-4,0.0188 0,0.0283 0.0505,1.70433 -0.0942,3.51379 0.20096,5.38143 0,0.01 0.01,0.0189 0.01,0.0283 0.24989,1.2914 1.33692,2.11916 2.48871,2.26993 1.69535,0.26054 3.32763,0.10154 4.84783,0.15662 0.01,1.6e-4 0.0178,1.6e-4 0.0272,0 6.07578,-0.007 12.17034,0.0238 18.25819,-0.12265 0.0337,-3.4e-4 0.0674,-0.003 0.10047,-0.008 0.53628,-0.0859 1.12858,-0.25276 1.66832,-0.59815 0.53972,-0.34536 1.03707,-0.91956 1.19321,-1.69066 0,-0.0193 0.01,-0.0389 0.01,-0.0584 0.28226,-2.20369 0.14211,-4.36538 0.18814,-6.4381 9e-5,-0.007 9e-5,-0.0139 0,-0.0207 -0.0103,-3.38165 0.0188,-6.77713 -0.0253,-10.17793 -0.16588,-2.90029 -0.98113,-3.58888 -5.58599,-3.58888 0,0 -6.60203,-9e-5 -8.7545,0 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient13846-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="ccsscsccccccc"
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 336.11864,138.84741 -2.00456,1.93219 h -7.01675 c -5.61342,0 -5.61342,0.96609 -5.61342,5.79655 v 0.96609 c 0,-4.83046 0,-5.79655 5.61342,-5.79655 h 7.01675 l 2.00456,-1.93218 c 2.15245,-1e-4 8.75485,0 8.75485,0 5.61341,0 5.61332,0.96609 5.64447,5.79655 v -0.96609 c -0.0309,-4.83046 -0.0309,-5.79656 -5.64447,-5.79656 0,0 -6.6024,-1e-4 -8.75485,0 z"
+         id="path3497-0-0" />
+      <path
+         sodipodi:nodetypes="ccscccccccsscscsscsssccccc"
+         inkscape:connector-curvature="0"
+         id="path3499-90-6"
+         d="m 327.59616,134.5 c -1.41635,0 -2.49066,0.0577 -3.33848,0.23586 -0.84771,0.17822 -1.49288,0.49353 -1.93138,1.01893 -0.4385,0.52539 -0.63516,1.20656 -0.73274,2.02276 -0.0977,0.81618 -0.10189,1.79076 -0.10965,2.99827 v 0.002 14.49514 0.002 c 0.016,2.41501 -0.0356,3.93093 0.69991,4.98708 0.36767,0.52806 0.93499,0.866 1.6609,1.0491 0.72601,0.18312 1.6308,0.23964 2.81588,0.23964 h 17.77579 c 1.41636,0 2.49114,-0.0577 3.33849,-0.23586 0.84734,-0.17823 1.49092,-0.49271 1.92773,-1.01892 0.43683,-0.52622 0.63057,-1.20822 0.72367,-2.02464 0.0926,-0.81643 0.0916,-1.79256 0.0916,-3.00018 v -12.55931 c 0,-1.20761 0,-2.18375 -0.0916,-3.00017 -0.0936,-0.81642 -0.28684,-1.49841 -0.72367,-2.02464 -0.43681,-0.52622 -1.08039,-0.8407 -1.92773,-1.01893 -0.84735,-0.17823 -1.92213,-0.23586 -3.33849,-0.23586 h -10.10666 l -2.00455,-1.93218 h -0.18458 c -2.15247,-1e-4 -4.54444,0 -4.54444,0 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="ccsscsccccccc"
+         id="path3501-40-2"
+         d="m 336.11864,137.88132 -2.00456,1.93219 h -7.01675 c -5.61342,0 -5.61342,0.96609 -5.61342,5.79655 v 0.96609 c 0,-4.83046 0,-5.79655 5.61342,-5.79655 h 7.01675 l 2.00456,-1.93219 c 2.15245,-1e-4 8.75485,0 8.75485,0 5.61341,0 5.61332,0.9661 5.64447,5.79656 v -0.9661 c -0.0309,-4.83046 -0.0309,-5.79655 -5.64447,-5.79655 0,0 -6.6024,-10e-5 -8.75485,0 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 327.59616,134.98305 c -5.61341,0 -5.61331,0.96609 -5.64446,5.79655 v 0.96609 c 0.0309,-4.83046 0.0309,-5.79655 5.64446,-5.79655 0,0 2.39197,-1e-4 4.54444,0 l 2.00454,1.93218 h 10.29125 c 5.61342,0 5.61342,0.96609 5.61342,5.79655 v -0.96609 c 0,-4.83046 0,-5.79655 -5.61342,-5.79655 h -10.29125 l -2.00454,-1.93218 c -2.15247,-1e-4 -4.54444,0 -4.54444,0 z"
+         id="path3513-30-9" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.05;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 350.01874,152.3727 -8.42011,8.69483 h 3.74227 c 4.67784,0 4.67775,-0.96609 4.70891,-5.79656 z"
+         id="path3517-21-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#491706;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 325.62631,190.9585 c -1.36391,0 -2.51791,-0.0822 -3.44824,0.65136 -0.48061,0.37891 -0.78045,0.93692 -0.93995,1.58037 -0.15785,0.63669 -0.20543,1.38524 -0.19516,2.33494 v 10.9237 c 0,0.94839 0.0559,1.69447 0.21487,2.32783 0.16078,0.63943 0.45375,1.19375 0.93097,1.57324 0.92437,0.73511 2.07332,0.65493 3.43751,0.65493 h 12.83338 c 0.95407,0 1.70464,-0.0552 2.34182,-0.21357 0.64322,-0.15984 1.20093,-0.45105 1.58272,-0.92543 0.73948,-0.91887 0.65881,-2.06096 0.65881,-3.417 v -9.11198 c 0,-0.94838 -0.0559,-1.69447 -0.21487,-2.32783 -0.16078,-0.63942 -0.45375,-1.19374 -0.93097,-1.57324 -0.92437,-0.73511 -2.07332,-0.65492 -3.43751,-0.65492 h -6.92874 l -1.86194,-1.8224 z"
+         id="path3451-81"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccsccssccssccsccs" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 325.62631,190.5029 c -1.375,0 -2.39883,-0.0495 -3.16361,0.55348 -0.38234,0.30148 -0.63608,0.75555 -0.7788,1.33121 -0.14273,0.57566 -0.19269,1.29004 -0.1826,2.22104 v 10.92905 c 0,0.93017 0.0559,1.64331 0.20056,2.21748 0.14438,0.57418 0.3938,1.0258 0.7734,1.32764 0.75918,0.6037 1.77605,0.55527 3.15105,0.55527 h 12.83338 c 0.93574,0 1.65322,-0.0558 2.23081,-0.19933 0.57759,-0.14354 1.03199,-0.39151 1.33559,-0.76882 0.60738,-0.75461 0.55862,-1.76545 0.55862,-3.13224 v -9.11199 c 0,-0.93018 -0.0559,-1.64331 -0.20048,-2.21748 -0.14447,-0.57419 -0.39389,-1.0258 -0.77349,-1.32765 -0.75909,-0.60369 -1.77604,-0.55526 -3.15105,-0.55526 h -7.11675 l -1.86194,-1.8224 z"
+         id="path3457-21"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssscsccssccssccsccs" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient3245);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 325.62665,190.50276 c -1.37501,0 -2.39883,-0.0495 -3.16361,0.55348 -0.38235,0.30147 -0.63608,0.75554 -0.7788,1.3312 -0.14273,0.57566 -0.19269,1.29005 -0.18261,2.22105 v 10.92904 c 0,0.93018 0.0559,1.64331 0.20057,2.21748 0.14438,0.57419 0.3938,1.0258 0.7734,1.32765 0.75918,0.60369 1.77604,0.55526 3.15105,0.55526 h 12.83338 c 0.93574,0 1.65321,-0.0558 2.23081,-0.19932 0.57759,-0.14354 1.03199,-0.39152 1.33559,-0.76883 0.60738,-0.7546 0.55861,-1.76544 0.55861,-3.13224 v -9.11198 c 0,-0.93018 -0.0559,-1.64331 -0.20047,-2.21749 -0.14447,-0.57418 -0.39389,-1.0258 -0.77349,-1.32764 -0.75909,-0.6037 -1.77605,-0.55527 -3.15105,-0.55527 h -7.11675 l -1.86194,-1.82239 z"
+         id="path3457-21-6-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssscsccssccssccsccs" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3481-8"
+         d="m 342.1855,203.65655 -5.55915,5.52592 h 1.09038 c 4.0526,0 4.46877,-0.41279 4.46877,-4.43319 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="ccssc" />
+      <path
+         id="path3483-9"
+         d="m 332.07343,193.6921 -1.86377,1.82239 -4.18029,0.0605 c -4.05205,0.0668 -4.46877,0.41455 -4.46877,4.43496 v 0.9112 c 0,-4.02041 0.41672,-4.36817 4.46877,-4.43497 l 4.18029,-0.0605 1.86377,-1.8224 h 6.10163 c 4.05269,0 4.46877,0.41279 4.46877,4.43319 v -0.91119 c 0,-4.02041 -0.41608,-4.43319 -4.46877,-4.43319 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsccccscssc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3489-73"
+         d="m 332.04117,194.60267 -1.86231,1.82239 h -5.01391 c -2.71738,0 -3.64184,0.0141 -3.66365,3.52912 -2.8e-4,2.30543 0.009,4.61131 0.0623,6.91585 -0.0202,0.99335 0.39353,2.10417 1.3717,2.52359 0.76185,0.36758 1.63562,0.17068 2.44962,0.23136 4.91876,0.0213 9.83926,0.0145 14.75701,-0.005 0.79228,-0.18104 1.7095,-0.43484 2.08974,-1.22977 0.49161,-0.93148 0.26427,-2.02009 0.33669,-3.02546 0,-1.53601 0.0147,-3.07128 0.0156,-4.6076 v -0.66383 c -7.3e-4,-1.02561 -0.0211,-2.05171 -0.0358,-3.07707 -0.20084,-2.40903 -1.23558,-2.41325 -3.63157,-2.41325 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient13844);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00009;marker:none;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="ccsscsccsccsc"
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none;enable-background:accumulate"
+         d="m 332.04126,194.60329 -1.86203,1.8224 h -5.01281 c -2.75001,0 -3.66668,0 -3.66668,3.64479 v 0.9112 c 0,-3.64479 0.91667,-3.64479 3.66668,-3.64479 h 5.01281 l 1.86203,-1.8224 h 6.87502 c 2.75001,0 3.7061,0 3.66668,3.6448 v -0.9112 c 0.0394,-3.6448 -0.91667,-3.6448 -3.66668,-3.6448 z"
+         id="path3491-71" />
+      <path
+         sodipodi:nodetypes="ssscsccssccssccsccs"
+         inkscape:connector-curvature="0"
+         id="path3493-22"
+         d="m 325.62631,190.5029 c -1.375,0 -2.39883,-0.0495 -3.16361,0.55348 -0.38234,0.30148 -0.63608,0.75555 -0.7788,1.33121 -0.14273,0.57566 -0.19269,1.29004 -0.1826,2.22104 v 10.92905 c 0,0.93017 0.0559,1.64331 0.20056,2.21748 0.14438,0.57418 0.3938,1.0258 0.7734,1.32764 0.75918,0.6037 1.77605,0.55527 3.15105,0.55527 h 12.83338 c 0.93574,0 1.65322,-0.0558 2.23081,-0.19933 0.57759,-0.14354 1.03199,-0.39151 1.33559,-0.76882 0.60738,-0.75461 0.55862,-1.76545 0.55862,-3.13224 v -9.11199 c 0,-0.93018 -0.0559,-1.64331 -0.20048,-2.21748 -0.14447,-0.57419 -0.39389,-1.0258 -0.77349,-1.32765 -0.75909,-0.60369 -1.77604,-0.55526 -3.15105,-0.55526 h -7.11675 l -1.86194,-1.8224 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         id="path3511-1"
+         d="m 329.29235,190.9585 1.86203,1.8224 h 7.30467 c 2.75001,0 3.66668,0 3.66668,3.64479 v 0.9112 c 0,-3.64479 -0.91667,-3.64479 -3.66668,-3.64479 h -7.30467 l -1.86203,-1.8224 h -3.66668 c -2.75001,0 -3.70601,0 -3.66668,3.64479 v -0.9112 c -0.0394,-3.64479 0.91667,-3.64479 3.66668,-3.64479 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsscsccsccsc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none;enable-background:accumulate"
+         d="m 342.12463,202.80586 -6.41495,6.37661 h 2.74827 c 2.75001,0 3.66668,0 3.66668,-3.64479 z"
+         id="path3519-7" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 378.00302,193.09694 c -1.00575,0 -1.81976,0.0757 -2.52438,0.27512 -0.71526,0.20239 -1.33701,0.5599 -1.75789,1.09584 -0.80787,1.02878 -0.71775,2.228 -0.71775,3.4041 v 8.46596 c 0,0.93461 0.0763,1.69265 0.28563,2.35255 0.21212,0.67044 0.58875,1.24954 1.14013,1.64143 1.0595,0.75284 2.28525,0.6715 3.45951,0.6715 h 10.22703 c 0.97876,0 1.77263,-0.0735 2.46351,-0.2728 0.70175,-0.20242 1.30988,-0.56129 1.72113,-1.08884 0.78938,-1.01255 0.7015,-2.18473 0.70075,-3.30618 l 0.002,-7.26985 c 0,-0.92195 -0.0613,-1.672 -0.24412,-2.33157 -0.186,-0.66945 -0.52825,-1.26786 -1.07176,-1.68807 -1.04712,-0.80951 -2.3195,-0.75543 -3.68413,-0.75543 h -4.48239 l -1.25001,-1.19376 z"
+         id="path3447-48"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccssccssccccccsccs" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 378.00302,192.50005 c -0.97225,0 -1.72813,0.0746 -2.34613,0.24948 -0.61813,0.17488 -1.11126,0.47063 -1.43563,0.88367 -0.64876,0.82609 -0.59326,1.85127 -0.59326,3.04504 v 8.46595 c 0,0.90235 0.0763,1.60441 0.25876,2.18002 0.18212,0.57561 0.491,1.03431 0.9155,1.33599 0.84913,0.60338 1.89313,0.55259 3.08601,0.55259 h 10.22703 c 0.94488,0 1.68001,-0.0733 2.28276,-0.24715 0.60288,-0.17387 1.08538,-0.46892 1.40138,-0.87434 0.63213,-0.81084 0.577,-1.80984 0.57625,-2.94945 V 197.872 c 0,-0.89612 -0.0613,-1.59735 -0.22212,-2.17769 -0.16126,-0.58034 -0.44376,-1.05474 -0.86188,-1.37797 -0.83613,-0.64643 -1.91876,-0.62252 -3.29101,-0.62252 h -4.74127 l -1.25,-1.19377 z"
+         id="path3449-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsssccssccccccsccs" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient3329);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 378.00296,192.49977 c -0.97226,0 -1.72813,0.0746 -2.34614,0.24947 -0.61812,0.17489 -1.11125,0.47063 -1.43563,0.88367 -0.64875,0.82609 -0.59325,1.85127 -0.59325,3.04504 v 8.46595 c 0,0.90235 0.0762,1.60442 0.25875,2.18003 0.18213,0.57561 0.491,1.0343 0.91551,1.33599 0.84912,0.60338 1.89313,0.55258 3.08601,0.55258 h 10.22703 c 0.94488,0 1.68,-0.0733 2.28276,-0.24714 0.60287,-0.17388 1.08538,-0.46893 1.40138,-0.87434 0.63212,-0.81085 0.577,-1.80985 0.57625,-2.94946 v -7.26984 c 0,-0.89613 -0.0612,-1.59736 -0.22213,-2.1777 -0.16125,-0.58033 -0.44375,-1.05474 -0.86188,-1.37796 -0.83612,-0.64644 -1.91875,-0.62253 -3.29101,-0.62253 h -4.74126 l -1.25001,-1.19376 z"
+         id="path3449-4-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsssccssccccccsccs" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3503-1"
+         d="m 383.00304,195.48447 -1.25001,1.19377 h -4.37501 c -2.71264,0 -3.73677,0.11364 -3.74752,3.53233 0.0125,1.22696 0.0188,2.45524 0.0125,3.68156 0.06,1.21261 -0.1025,2.4749 0.30026,3.64659 0.37125,1.01091 1.4485,1.69848 2.57563,1.64143 4.22576,0.0612 8.45265,0.0308 12.67829,-0.0303 1.0085,0.047 2.11313,-0.31887 2.70026,-1.12849 0.3705,-0.51632 0.54763,-1.11243 0.46138,-1.73702 -0.0137,-2.82234 0.0125,-5.64663 -0.015,-8.46829 -0.115,-1.54519 -0.69663,-2.33157 -3.71339,-2.33157 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient1901-86);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="scsssccssccccccsccs"
+         inkscape:connector-curvature="0"
+         id="path3505-3"
+         d="m 378.00302,192.50005 c -0.97225,0 -1.72813,0.0746 -2.34613,0.24948 -0.61813,0.17488 -1.11126,0.47063 -1.43563,0.88367 -0.64876,0.82609 -0.59326,1.85127 -0.59326,3.04504 v 8.46595 c 0,0.90235 0.0763,1.60441 0.25876,2.18002 0.18212,0.57561 0.491,1.03431 0.9155,1.33599 0.84913,0.60338 1.89313,0.55259 3.08601,0.55259 h 10.22703 c 0.94488,0 1.68001,-0.0733 2.28276,-0.24715 0.60288,-0.17387 1.08538,-0.46892 1.40138,-0.87434 0.63213,-0.81084 0.577,-1.80984 0.57625,-2.94945 V 197.872 c 0,-0.89612 -0.0613,-1.59735 -0.22212,-2.17769 -0.16126,-0.58034 -0.44376,-1.05474 -0.86188,-1.37797 -0.83613,-0.64643 -1.91876,-0.62252 -3.29101,-0.62252 h -4.74127 l -1.25,-1.19377 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 383.00304,195.48447 -1.25001,1.19377 h -4.37476 c -2.72714,0 -3.75002,0.10875 -3.75002,3.5813 v 1.19376 c 0,-3.47257 1.02288,-3.5813 3.75002,-3.5813 h 4.37476 l 1.25001,-1.19376 h 5.62526 c 3.75002,0 3.75002,1.19376 3.75002,3.5813 v -1.19377 c 0,-2.38753 0,-3.5813 -3.75002,-3.5813 z"
+         id="path3507-74"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsscsccscssc" />
+      <path
+         sodipodi:nodetypes="ccsscsccscssc"
+         inkscape:connector-curvature="0"
+         id="path3509-1"
+         d="m 383.00304,194.2907 -1.25001,1.19377 h -4.37476 c -2.72714,0 -3.75002,0.10875 -3.75002,3.5813 v 1.19377 c 0,-3.47258 1.02288,-3.5813 3.75002,-3.5813 h 4.37476 l 1.25001,-1.19377 h 5.62526 c 3.75002,0 3.75002,1.19377 3.75002,3.5813 V 197.872 c 0,-2.38753 0,-3.5813 -3.75002,-3.5813 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 378.00302,193.09694 c -3.75001,0 -3.75001,1.19376 -3.75001,3.5813 v 1.19376 c 0,-2.38753 0,-3.5813 3.75001,-3.5813 h 3.75001 l 0.625,0.59689 0.62501,-0.59689 -1.25001,-1.19376 z"
+         id="path3515-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sscsccccs" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 391.75306,203.84084 -5.00001,4.77506 h 1.36475 c 2.38576,0 3.63526,8.6e-4 3.63526,-3.47171 z"
+         id="path3521-5" />
+      <path
+         style="display:inline;opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new"
+         d="m 320,249 v -10 c 0,-1 1,-2 2,-2 h 4 c 1,0 1,0 2,1 1,1 1,1 2,1 h 4 c 1,0 2,1 2,2 v 8 c 0,1 -1,2 -2,2 h -12 c -1,0 -2,-1 -2,-2 z"
+         id="path819"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccc" />
+      <path
+         sodipodi:nodetypes="cccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path823"
+         d="m 321,248 v -8 c 0,-1.49718 0.49718,-2 2,-2 h 2.75 c 0.875,0 0.875,0.28571 1.75,1.14286 C 328.375,240 328.375,240 329.25,240 H 333 c 1.50391,0 2,0.49833 2,2 v 6 c 0,1.49777 -0.5,2 -2,2 h -10 c -1.5,0 -2,-0.50223 -2,-2 z"
+         style="display:inline;fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:0.866025px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;enable-background:new" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictograms"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="Highlights"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer3"
+       inkscape:label="Emblems"
+       style="display:inline">
+      <circle
+         style="display:inline;vector-effect:none;fill:#0f8420;fill-opacity:1;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="path2644-5-3"
+         cy="207.49998"
+         cx="389.5"
+         r="4.5" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1063-0-6"
+         overflow="visible"
+         font-weight="400"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;marker:none;enable-background:new"
+         d="m 389,204.99999 v 2 h -2 v 1 h 2 v 2 h 1 v -2 h 2 v -1 h -2 v -2 z" />
+      <circle
+         style="display:inline;vector-effect:none;fill:#0f8420;fill-opacity:1;stroke:none;stroke-width:3.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="path2644"
+         cy="248.49998"
+         cx="332.5"
+         r="3.5" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1063"
+         overflow="visible"
+         font-weight="400"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;marker:none;enable-background:new"
+         d="m 332,245.99999 v 2 h -2 v 1 h 2 v 2 h 1 v -2 h 2 v -1 h -2 v -2 z" />
+      <circle
+         style="display:inline;opacity:0.2;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:34;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter11348);enable-background:new"
+         id="path2644-5-5-7-5-9"
+         cy="244.00002"
+         cx="238"
+         r="34" />
+      <circle
+         style="display:inline;vector-effect:none;fill:#0f8420;fill-opacity:1;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="path2644-5-3-6"
+         cy="207.50002"
+         cx="389.5"
+         r="4.5" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1063-0-6-2"
+         overflow="visible"
+         font-weight="400"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;marker:none;enable-background:new"
+         d="m 389.00001,204.99999 v 2 h -2 v 1 h 2 v 2 h 1 v -2 h 2 v -1 h -2 v -2 z" />
+      <circle
+         style="display:inline;vector-effect:none;fill:#0f8420;fill-opacity:1;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="path2644-5"
+         cy="207.50002"
+         cx="339.5"
+         r="4.5" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1063-0"
+         overflow="visible"
+         font-weight="400"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;marker:none;enable-background:new"
+         d="m 339.00001,204.99999 v 2 h -2 v 1 h 2 v 2 h 1 v -2 h 2 v -1 h -2 v -2 z" />
+      <circle
+         style="display:inline;vector-effect:none;fill:#0f8420;fill-opacity:1;stroke:none;stroke-width:3.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="path2644-9"
+         cy="248.50002"
+         cx="332.50003"
+         r="3.5" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1063-1"
+         overflow="visible"
+         font-weight="400"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;marker:none;enable-background:new"
+         d="m 332.00001,245.99999 v 2 h -2 v 1 h 2 v 2 h 1 v -2 h 2 v -1 h -2 v -2 z" />
+      <circle
+         style="display:inline;vector-effect:none;fill:#0f8420;fill-opacity:1;stroke:none;stroke-width:4.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="path2644-5-5"
+         cy="159.49998"
+         cx="347.5"
+         r="4.5" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1063-0-4"
+         overflow="visible"
+         font-weight="400"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;marker:none;enable-background:new"
+         d="m 347.00001,156.99999 v 2 h -2 v 1 h 2 v 2 h 1 v -2 h 2 v -1 h -2 v -2 z"
+         sodipodi:nodetypes="ccccccccccccc" />
+      <circle
+         style="display:inline;vector-effect:none;fill:#0f8420;fill-opacity:1;stroke:none;stroke-width:6.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="path2644-5-5-7"
+         cy="101.5"
+         cx="361.5"
+         r="6.5" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1063-0-4-6"
+         overflow="visible"
+         font-weight="400"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;marker:none;enable-background:new"
+         d="m 360.99998,98.000004 v 2.999986 h -3 v 1 h 3 v 3 h 1 v -3 h 3 v -1 h -3 v -2.999986 z"
+         sodipodi:nodetypes="ccccccccccccc" />
+      <circle
+         style="display:inline;vector-effect:none;fill:#0f8420;fill-opacity:1;stroke:none;stroke-width:34;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         id="path2644-5-5-7-5"
+         cy="242.00002"
+         cx="238"
+         r="34" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1063-0-4-6-6"
+         overflow="visible"
+         font-weight="400"
+         style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;white-space:normal;display:inline;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#ffffff;fill-opacity:1;stroke-width:6;marker:none;enable-background:new"
+         d="m 236.00001,219.99999 v 20 h -20 v 4 h 20 v 20 h 4 v -20 h 20 v -4 h -20 v -20 z"
+         sodipodi:nodetypes="ccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/actions/go-first.svg
+++ b/icons/src/fullcolor/accented/actions/go-first.svg
@@ -1,0 +1,511 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
+   width="400"
+   height="300"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="go-first.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   style="display:inline;enable-background:new"
+   inkscape:export-filename="/home/sam/suru-template.png">
+  <title
+     id="title3004">Suru Icon Theme Template</title>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#f57900"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="341.27781"
+     inkscape:cy="236.1373"
+     inkscape:current-layer="layer7"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1366"
+     inkscape:window-height="768"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     width="400px"
+     height="300px"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     gridtolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-grids="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="false"
+     showborder="false"
+     inkscape:bbox-nodes="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       spacingy="1"
+       spacingx="1"
+       id="grid5883"
+       type="xygrid"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid11592"
+       empspacing="2"
+       visible="true"
+       enabled="false"
+       spacingx="0.5"
+       spacingy="0.5"
+       color="#ff0000"
+       opacity="0.1254902"
+       empcolor="#ff0000"
+       empopacity="0.25098039"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9430">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path9432"
+         d="m 166.0625,-196 h 179.875 C 491.2348,-196 512,-175.28677 512,-30.125 v 148.25 C 512,263.28618 491.2348,284 345.9375,284 H 166.0625 C 20.7652,284 0,263.28618 0,118.125 V -30.125 C 0,-175.28677 20.7652,-196 166.0625,-196 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4338">
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1"
+         offset="0"
+         id="stop4340" />
+      <stop
+         style="stop-color:#f9f9f9;stop-opacity:1"
+         offset="1"
+         id="stop4342" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath994">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
+         id="path996"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath959">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 330.1929,133.99999 c -5.61538,0 -6.21958,0.57678 -6.19206,6.20352 v 7.79648 7.79648 c -0.0276,5.62673 0.57668,6.20351 6.19206,6.20351 h 11.615 c 5.6154,0 6.19208,-0.5767 6.19208,-6.20351 v -7.79648 -7.79648 c 0,-5.6268 -0.5767,-6.20352 -6.19208,-6.20352 z"
+         id="path961"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath971">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
+         id="path973"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath983">
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path985"
+         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3284">
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path3286"
+         d="M 102.92162,44 C 67.624897,44 63.82701,47.625418 64,82.99353 V 156 229.00647 C 63.82701,264.37459 67.624897,268 102.92162,268 h 98.15676 C 236.3751,268 240,264.375 240,229.00647 V 156 82.99353 C 240,47.624997 236.3751,44 201.07838,44 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3288);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4338"
+       id="linearGradient3288"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.453125,0.45311204,0,26.0376,268)"
+       x1="529.65515"
+       y1="401.58368"
+       x2="-35.310345"
+       y2="119.09284" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Sam Hewitt</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title>Suru Icon Theme Template</dc:title>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:date />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="Icon"
+     id="layer1">
+    <g
+       style="display:none;opacity:1"
+       inkscape:label="Baseplate"
+       id="layer7"
+       inkscape:groupmode="layer">
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="19.006836"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="context"
+         id="context"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
+           y="-8.2548828"
+           x="19.006836"
+           sodipodi:role="line"
+           id="tspan3933">actions</tspan></text>
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="146.48828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="icon-name"
+         id="icon-name"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+           y="-8.2548828"
+           x="146.48828"
+           sodipodi:role="line"
+           id="tspan3937">go-first</tspan></text>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect16x16"
+         width="16"
+         height="16"
+         x="320"
+         y="236"
+         inkscape:label="16x16"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/16x16/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect24x24"
+         width="24"
+         height="24"
+         x="320"
+         y="188"
+         inkscape:label="24x24"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/24x24/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect32x32"
+         width="32"
+         height="32"
+         x="320"
+         y="132"
+         inkscape:label="32x32"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/32x32/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         inkscape:label="48x48"
+         y="60"
+         x="320"
+         height="48"
+         width="48"
+         id="rect48x48"
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/48x48/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect3951"
+         width="256"
+         height="256"
+         x="24"
+         y="28"
+         inkscape:label="48x48"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/256x256/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.83333;marker:none;enable-background:accumulate"
+         id="rect24x24-5"
+         width="22"
+         height="22"
+         x="364"
+         y="190"
+         inkscape:label="24x24"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/22x22/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer4"
+       inkscape:label="Shadows"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="Background"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline;opacity:1">
+      <path
+         id="path5264-6-7-4-6"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1;enable-background:new"
+         d="m 120,132 v 48 c 0,0 -24,-8 -48,-24 24,-16 48,-24 48,-24 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="opacity:1;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+         id="rect20380"
+         width="160"
+         height="8"
+         x="-240"
+         y="152"
+         transform="scale(-1,1)" />
+      <rect
+         style="opacity:1;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+         id="rect20382"
+         width="8"
+         height="176"
+         x="-72"
+         y="68"
+         transform="scale(-1,1)" />
+      <path
+         id="path5264-6-7-4-6-0"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1;enable-background:new"
+         d="m 336,78 v 12 c 0,0 -6,-2 -12,-6 6,-4 12,-6 12,-6 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6"
+         width="40"
+         height="2"
+         x="-366"
+         y="83"
+         transform="scale(-1,1)" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2"
+         width="2"
+         height="36"
+         x="-324"
+         y="66"
+         transform="scale(-1,1)" />
+      <path
+         id="path5264-6-7-4-6-0-6"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1;enable-background:new"
+         d="m 332,144 v 8 c 0,0 -4,-1.33333 -8,-4 4,-2.66667 8,-4 8,-4 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6-1"
+         width="21"
+         height="2"
+         x="-350"
+         y="147"
+         transform="scale(-1,1)" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2-8"
+         width="2"
+         height="24"
+         x="-324"
+         y="136"
+         transform="scale(-1,1)" />
+      <path
+         id="path5264-6-7-4-6-0-7"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 331,195.99999 v 8 c 0,0 -4,-1.33333 -8,-4 4,-2.66666 8,-4 8,-4 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6-9"
+         width="18"
+         height="2"
+         x="-343"
+         y="199"
+         transform="scale(-1,1)" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2-2"
+         width="2"
+         height="18"
+         x="-323"
+         y="191"
+         transform="scale(-1,1)" />
+      <path
+         id="path5264-6-7-4-6-0-7-0"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 374,196.99999 v 8 c 0,0 -4,-1.33333 -8,-4 4,-2.66666 8,-4 8,-4 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6-9-2"
+         width="18"
+         height="2"
+         x="-386"
+         y="200"
+         transform="scale(-1,1)" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2-2-3"
+         width="2"
+         height="18"
+         x="-366"
+         y="192"
+         transform="scale(-1,1)" />
+      <path
+         id="path5264-6-7-4-6-0-7-7"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 328,240.99999 v 6 c 0,0 -3,-1 -6,-3 3,-1.99999 6,-3 6,-3 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6-9-5"
+         width="10"
+         height="2"
+         x="-336"
+         y="243"
+         transform="scale(-1,1)" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2-2-9"
+         width="2"
+         height="12"
+         x="-322"
+         y="238"
+         transform="scale(-1,1)" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer3"
+       inkscape:label="Folds"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer5"
+       inkscape:label="Highlights"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer8"
+       inkscape:label="Emblems" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/actions/go-last.svg
+++ b/icons/src/fullcolor/accented/actions/go-last.svg
@@ -1,0 +1,499 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
+   width="400"
+   height="300"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="go-last.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   style="display:inline;enable-background:new"
+   inkscape:export-filename="/home/sam/suru-template.png">
+  <title
+     id="title3004">Suru Icon Theme Template</title>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#f57900"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="341.27781"
+     inkscape:cy="236.1373"
+     inkscape:current-layer="svg11300"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1366"
+     inkscape:window-height="768"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     width="400px"
+     height="300px"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     gridtolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-grids="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="false"
+     showborder="false"
+     inkscape:bbox-nodes="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       spacingy="1"
+       spacingx="1"
+       id="grid5883"
+       type="xygrid"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid11592"
+       empspacing="2"
+       visible="true"
+       enabled="false"
+       spacingx="0.5"
+       spacingy="0.5"
+       color="#ff0000"
+       opacity="0.1254902"
+       empcolor="#ff0000"
+       empopacity="0.25098039"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9430">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path9432"
+         d="m 166.0625,-196 h 179.875 C 491.2348,-196 512,-175.28677 512,-30.125 v 148.25 C 512,263.28618 491.2348,284 345.9375,284 H 166.0625 C 20.7652,284 0,263.28618 0,118.125 V -30.125 C 0,-175.28677 20.7652,-196 166.0625,-196 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4338">
+      <stop
+         style="stop-color:#f2f2f2;stop-opacity:1"
+         offset="0"
+         id="stop4340" />
+      <stop
+         style="stop-color:#f9f9f9;stop-opacity:1"
+         offset="1"
+         id="stop4342" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath994">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
+         id="path996"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath959">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 330.1929,133.99999 c -5.61538,0 -6.21958,0.57678 -6.19206,6.20352 v 7.79648 7.79648 c -0.0276,5.62673 0.57668,6.20351 6.19206,6.20351 h 11.615 c 5.6154,0 6.19208,-0.5767 6.19208,-6.20351 v -7.79648 -7.79648 c 0,-5.6268 -0.5767,-6.20352 -6.19208,-6.20352 z"
+         id="path961"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath971">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
+         id="path973"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath983">
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path985"
+         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3284">
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path3286"
+         d="M 102.92162,44 C 67.624897,44 63.82701,47.625418 64,82.99353 V 156 229.00647 C 63.82701,264.37459 67.624897,268 102.92162,268 h 98.15676 C 236.3751,268 240,264.375 240,229.00647 V 156 82.99353 C 240,47.624997 236.3751,44 201.07838,44 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3288);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4338"
+       id="linearGradient3288"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.453125,0.45311204,0,26.0376,268)"
+       x1="529.65515"
+       y1="401.58368"
+       x2="-35.310345"
+       y2="119.09284" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Sam Hewitt</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title>Suru Icon Theme Template</dc:title>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:date />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="Icon"
+     id="layer1">
+    <g
+       style="display:none;opacity:1"
+       inkscape:label="Baseplate"
+       id="layer7"
+       inkscape:groupmode="layer">
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="19.006836"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="context"
+         id="context"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
+           y="-8.2548828"
+           x="19.006836"
+           sodipodi:role="line"
+           id="tspan3933">actions</tspan></text>
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="146.48828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="icon-name"
+         id="icon-name"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+           y="-8.2548828"
+           x="146.48828"
+           sodipodi:role="line"
+           id="tspan3937">go-last</tspan></text>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect16x16"
+         width="16"
+         height="16"
+         x="320"
+         y="236"
+         inkscape:label="16x16"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/16x16/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect24x24"
+         width="24"
+         height="24"
+         x="320"
+         y="188"
+         inkscape:label="24x24"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/24x24/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect32x32"
+         width="32"
+         height="32"
+         x="320"
+         y="132"
+         inkscape:label="32x32"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/32x32/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         inkscape:label="48x48"
+         y="60"
+         x="320"
+         height="48"
+         width="48"
+         id="rect48x48"
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/48x48/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect3951"
+         width="256"
+         height="256"
+         x="24"
+         y="28"
+         inkscape:label="48x48"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/256x256/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.83333;marker:none;enable-background:accumulate"
+         id="rect24x24-5"
+         width="22"
+         height="22"
+         x="364"
+         y="190"
+         inkscape:label="24x24"
+         inkscape:export-filename="/home/stuart/yaru/icons/Suru/22x22/legacy/document-revert.png"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer4"
+       inkscape:label="Shadows"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="Background"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline;opacity:1">
+      <path
+         id="path5264-6-7-4-6"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1;enable-background:new"
+         d="m 184,132 v 48 c 0,0 24,-8 48,-24 -24,-16 -48,-24 -48,-24 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="opacity:1;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+         id="rect20380"
+         width="160"
+         height="8"
+         x="64"
+         y="152" />
+      <rect
+         style="opacity:1;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+         id="rect20382"
+         width="8"
+         height="176"
+         x="232"
+         y="68" />
+      <path
+         id="path5264-6-7-4-6-0"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1;enable-background:new"
+         d="m 352,78 v 12 c 0,0 6,-2 12,-6 -6,-4 -12,-6 -12,-6 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6"
+         width="40"
+         height="2"
+         x="322"
+         y="83" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2"
+         width="2"
+         height="36"
+         x="364"
+         y="66" />
+      <path
+         id="path5264-6-7-4-6-0-6"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1;enable-background:new"
+         d="m 340,144 v 8 c 0,0 4,-1.33333 8,-4 -4,-2.66667 -8,-4 -8,-4 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6-1"
+         width="21"
+         height="2"
+         x="322"
+         y="147" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2-8"
+         width="2"
+         height="24"
+         x="348"
+         y="136" />
+      <path
+         id="path5264-6-7-4-6-0-7"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 333,195.99999 v 8 c 0,0 4,-1.33333 8,-4 -4,-2.66666 -8,-4 -8,-4 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6-9"
+         width="18"
+         height="2"
+         x="321"
+         y="199" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2-2"
+         width="2"
+         height="18"
+         x="341"
+         y="191" />
+      <path
+         id="path5264-6-7-4-6-0-7-0"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 376,196.99999 v 8 c 0,0 4,-1.33333 8,-4 -4,-2.66666 -8,-4 -8,-4 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6-9-2"
+         width="18"
+         height="2"
+         x="364"
+         y="200" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2-2-3"
+         width="2"
+         height="18"
+         x="384"
+         y="192" />
+      <path
+         id="path5264-6-7-4-6-0-7-7"
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 328,240.99999 v 6 c 0,0 3,-1 6,-3 -3,-1.99999 -6,-3 -6,-3 z"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20380-6-9-5"
+         width="10"
+         height="2"
+         x="320"
+         y="243" />
+      <rect
+         style="display:inline;fill:#00ff01;fill-opacity:1;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+         id="rect20382-2-2-9"
+         width="2"
+         height="12"
+         x="334"
+         y="238" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer3"
+       inkscape:label="Folds"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer5"
+       inkscape:label="Highlights"
+       style="display:inline" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer8"
+       inkscape:label="Emblems" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/actions/mail-reply-all.svg
+++ b/icons/src/fullcolor/accented/actions/mail-reply-all.svg
@@ -1,0 +1,646 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
+   width="400"
+   height="300"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="mail-reply-all.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   style="display:inline;enable-background:new"
+   inkscape:export-filename="/home/sam/suru-template.png">
+  <title
+     id="title3004">Suru Icon Theme Template</title>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#f57900"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="295.31146"
+     inkscape:cy="267.50571"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1294"
+     inkscape:window-height="704"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     width="400px"
+     height="300px"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     gridtolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-grids="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="false"
+     showborder="false"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       spacingy="1"
+       spacingx="1"
+       id="grid5883"
+       type="xygrid"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       dotted="false" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid11592"
+       empspacing="4"
+       visible="true"
+       enabled="false"
+       spacingx="0.5"
+       spacingy="0.5"
+       color="#000000"
+       opacity="0.1254902"
+       empcolor="#000000"
+       empopacity="0.25098039"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       dotted="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9430">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path9432"
+         d="m 166.0625,-196 h 179.875 C 491.2348,-196 512,-175.28677 512,-30.125 v 148.25 C 512,263.28618 491.2348,284 345.9375,284 H 166.0625 C 20.7652,284 0,263.28618 0,118.125 V -30.125 C 0,-175.28677 20.7652,-196 166.0625,-196 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath994">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
+         id="path996"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath994-5">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
+         id="path996-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath971">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
+         id="path973"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath983">
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path985"
+         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath959">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 330.1929,133.99999 c -5.61538,0 -6.21958,0.57678 -6.19206,6.20352 v 7.79648 7.79648 c -0.0276,5.62673 0.57668,6.20351 6.19206,6.20351 h 11.615 c 5.6154,0 6.19208,-0.5767 6.19208,-6.20351 v -7.79648 -7.79648 c 0,-5.6268 -0.5767,-6.20352 -6.19208,-6.20352 z"
+         id="path961"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3045">
+      <stop
+         id="stop3047"
+         offset="0"
+         style="stop-color:#847784;stop-opacity:0.99607843" />
+      <stop
+         id="stop3049"
+         offset="1"
+         style="stop-color:#695f69;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4213">
+      <stop
+         style="stop-color:#b1d7f3;stop-opacity:1"
+         offset="0"
+         id="stop4215" />
+      <stop
+         style="stop-color:#8fafda;stop-opacity:1"
+         offset="1"
+         id="stop4217" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient5460">
+      <stop
+         id="stop5462"
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1" />
+      <stop
+         id="stop5464"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5476">
+      <stop
+         id="stop5478"
+         offset="0"
+         style="stop-color:#772953;stop-opacity:1;" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter4154">
+      <feComposite
+         operator="arithmetic"
+         k4="0"
+         result="composite1"
+         k1="0"
+         k2="1"
+         k3="0"
+         in2="SourceGraphic"
+         id="feComposite4156" />
+      <feColorMatrix
+         in="composite1"
+         result="colormatrix1"
+         values="0"
+         type="saturate"
+         id="feColorMatrix4158" />
+      <feFlood
+         flood-color="rgb(72,59,72)"
+         result="flood1"
+         id="feFlood4160" />
+      <feBlend
+         in="flood1"
+         in2="colormatrix1"
+         mode="multiply"
+         result="blend1"
+         id="feBlend4162" />
+      <feBlend
+         result="blend2"
+         in2="blend1"
+         mode="screen"
+         id="feBlend4164" />
+      <feColorMatrix
+         in="blend2"
+         result="colormatrix2"
+         values="1"
+         type="saturate"
+         id="feColorMatrix4166" />
+      <feComposite
+         in="colormatrix2"
+         in2="SourceGraphic"
+         result="composite2"
+         operator="in"
+         id="feComposite4168" />
+    </filter>
+    <clipPath
+       id="clipPath3062"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         y="-194.96773"
+         x="34.167744"
+         height="445.93549"
+         width="475.66452"
+         id="rect3064"
+         style="color:#000000;fill:url(#linearGradient3066);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:40;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       y2="288"
+       x2="256"
+       y1="50"
+       x1="256"
+       gradientTransform="matrix(1.8580645,0,0,1.8736786,4.4387126,-288.65166)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3066"
+       xlink:href="#linearGradient3045"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient876"
+       id="linearGradient11065"
+       x1="104"
+       y1="44"
+       x2="200"
+       y2="268"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(18.766288,58.793643)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient876">
+      <stop
+         style="stop-color:#1a7fd4;stop-opacity:1;"
+         offset="0"
+         id="stop872" />
+      <stop
+         style="stop-color:#37a6e6;stop-opacity:1"
+         offset="1"
+         id="stop874" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter3014"
+       x="-0.00025217466"
+       width="1.0005043"
+       y="-0.00039294101"
+       height="1.0007859">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.0016374856"
+         id="feGaussianBlur3016" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter3014-6-7"
+       x="-1.1359458e-05"
+       width="1.0000226"
+       y="-1.7793132e-05"
+       height="1.0000356">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.0016755201"
+         id="feGaussianBlur3016-2-0" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter3014-6-7-0"
+       x="-1.1359458e-05"
+       width="1.0000226"
+       y="-1.7793132e-05"
+       height="1.0000356">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.0016755201"
+         id="feGaussianBlur3016-2-0-6" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter3014-7"
+       x="-1.1359458e-05"
+       width="1.0000226"
+       y="-1.7793132e-05"
+       height="1.0000356">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.0016755201"
+         id="feGaussianBlur3016-5" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter3014-3"
+       x="-1.1359458e-05"
+       width="1.0000226"
+       y="-1.7793132e-05"
+       height="1.0000356">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.0016755201"
+         id="feGaussianBlur3016-6" />
+    </filter>
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Sam Hewitt</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title>Suru Icon Theme Template</dc:title>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:date />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="Icon"
+     id="layer1">
+    <g
+       style="display:none"
+       inkscape:label="Baseplate"
+       id="layer7"
+       inkscape:groupmode="layer">
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="19.006836"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="context"
+         id="context"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
+           y="-8.2548828"
+           x="19.006836"
+           sodipodi:role="line"
+           id="tspan3933">actions</tspan></text>
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="146.48828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="icon-name"
+         id="icon-name"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+           y="-8.2548828"
+           x="146.48828"
+           sodipodi:role="line"
+           id="tspan924">mail-reply-all</tspan></text>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect16x16"
+         width="16"
+         height="16"
+         x="320"
+         y="236"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect24x24"
+         width="24"
+         height="24"
+         x="320"
+         y="188"
+         inkscape:label="24x24" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect32x32"
+         width="32"
+         height="32"
+         x="320"
+         y="132"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="48x48"
+         y="60"
+         x="320"
+         height="48"
+         width="48"
+         id="rect48x48"
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect3951"
+         width="256"
+         height="256"
+         x="24"
+         y="28"
+         inkscape:label="48x48" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect24x24-5"
+         width="22"
+         height="22"
+         x="372"
+         y="190"
+         inkscape:label="24x24" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="Background"
+       style="display:inline;">
+      <path
+         d="m 16.294516,10.5 c 0,1.5 -0.64,2.493 -1.558,2.974 -0.917,0.482 -2.019,0.526 -3.071,0.526 H -2.8744842 V 13 H 11.665516 c 1.012,0 1.976,-0.08 2.606,-0.411 0.631,-0.331 1.023,-0.839 1.023,-2.089 V 3.994974 h 1 z"
+         font-family="sans-serif"
+         font-weight="400"
+         overflow="visible"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke-width:25126;filter:url(#filter3014-6-7)"
+         white-space="normal"
+         id="path1754-3-1-3"
+         sodipodi:nodetypes="scsccscsccs"
+         transform="matrix(1.9949736,0,0,1.9949866,333.49252,66.065174)" />
+      <path
+         d="m 1.70782,9.80018 -0.003,7.5 c -1.1816388,-0.541983 -2.34385665,-1.125344 -3.4845,-1.749 -1.17,-0.6465 -2.301,-1.314 -3.3885,-2.001 1.0875,-0.6735 2.217,-1.3335 3.39,-1.98 1.182,-0.645 2.343,-1.2345 3.4845,-1.77 z"
+         overflow="visible"
+         id="path1756-5-2-6"
+         style="fill:#00ff01;fill-opacity:1;stroke-width:0.250629;filter:url(#filter3014-6-7)"
+         sodipodi:nodetypes="ccccccc"
+         transform="matrix(1.9949736,0,0,1.9949866,333.49252,66.065174)" />
+      <path
+         d="M 16,8.5 C 16,10 15.36,10.993 14.442,11.474 13.525,11.956 12.423,12 11.371,12 h -8.54 v -1 h 8.54 c 1.012,0 1.976,-0.08 2.606,-0.411 C 14.608,10.258 15,9.75 15,8.5 V 4 h 1 z"
+         font-family="sans-serif"
+         font-weight="400"
+         overflow="visible"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke-width:24999.3;filter:url(#filter3014)"
+         white-space="normal"
+         id="path1754-6"
+         transform="matrix(2.0000226,0,0,2.0000356,319.99934,132.00021)" />
+      <path
+         d="M 5,9 4.998,14 A 36.975,36.975 0 0 1 2.675,12.834 C 1.895,12.403 1.141,11.958 0.416,11.5 1.141,11.051 1.894,10.611 2.676,10.18 3.464,9.75 4.238,9.357 4.999,9 Z"
+         overflow="visible"
+         id="path1756-7"
+         style="fill:#00ff01;fill-opacity:1;stroke-width:24999.3;filter:url(#filter3014)"
+         transform="matrix(2.0000226,0,0,2.0000356,319.99934,132.00021)" />
+      <path
+         d="m 16.294516,10.5 c 0,1.5 -0.64,2.493 -1.558,2.974 -0.917,0.482 -2.019,0.526 -3.071,0.526 H -2.8744842 V 13 H 11.665516 c 1.012,0 1.976,-0.08 2.606,-0.411 0.631,-0.331 1.023,-0.839 1.023,-2.089 V 3.994974 h 1 z"
+         font-family="sans-serif"
+         font-weight="400"
+         overflow="visible"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke-width:6281.43;filter:url(#filter3014-6-7-0)"
+         white-space="normal"
+         id="path1754-3-1-3-6"
+         sodipodi:nodetypes="scsccscsccs"
+         transform="matrix(7.9799402,0,0,7.9800699,109.97071,72.121717)" />
+      <path
+         d="m 1.70782,9.80018 -0.003,7.5 c -1.1816388,-0.541983 -2.34385665,-1.125344 -3.4845,-1.749 -1.17,-0.6465 -2.301,-1.314 -3.3885,-2.001 1.0875,-0.6735 2.217,-1.3335 3.39,-1.98 1.182,-0.645 2.343,-1.2345 3.4845,-1.77 z"
+         overflow="visible"
+         id="path1756-5-2-6-1"
+         style="fill:#00ff01;fill-opacity:1;stroke-width:0.0626566;filter:url(#filter3014-6-7-0)"
+         sodipodi:nodetypes="ccccccc"
+         transform="matrix(7.9799402,0,0,7.9800699,109.97071,72.121717)" />
+      <path
+         d="m 13.000034,8.5 c 0,1.5 -0.64,2.493 -1.558,2.974 C 10.525034,11.956 9.4230339,12 8.3710339,12 H 2.831 v -1 h 5.5400339 c 1.012,0 1.9760001,-0.08 2.6060001,-0.411 0.631,-0.331 1.023,-0.839 1.023,-2.089 V 4 h 1 z"
+         font-family="sans-serif"
+         font-weight="400"
+         overflow="visible"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke-width:24999.3;filter:url(#filter3014-7)"
+         white-space="normal"
+         id="path1754-6-2"
+         sodipodi:nodetypes="scsccscsccs"
+         transform="matrix(2.0000226,0,0,2.0000356,319.99934,132.00021)" />
+      <path
+         d="m 357.99965,87.01254 c 0,2.99248 -1.27679,4.9735 -3.10817,5.93309 -1.82939,0.96158 -4.02785,1.04936 -6.12656,1.04936 H 327.758 V 92 h 21.00692 c 2.01891,0 3.94206,-0.1596 5.1989,-0.81994 1.25882,-0.66034 2.04085,-1.67379 2.04085,-4.16752 V 74.035096 h 1.99498 z"
+         font-family="sans-serif"
+         font-weight="400"
+         overflow="visible"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;display:inline;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke-width:50125.9;filter:url(#filter3014-6-7);enable-background:new"
+         white-space="normal"
+         id="path1754-3-1-3-8"
+         sodipodi:nodetypes="scsccscsccs" />
+      <path
+         d="m 207.99998,155.91246 c 0,11.9701 -5.10717,19.89431 -12.43275,23.73273 -7.31761,3.84639 -16.1115,4.19751 -24.5064,4.19751 H 87.0325 v -7.98007 h 84.02833 c 8.0757,0 15.76836,-0.6384 20.79573,-3.2798 5.03534,-2.64141 7.77945,-6.70268 8.16348,-16.67037 V 104.0019 h 7.97994 z"
+         font-family="sans-serif"
+         font-weight="400"
+         overflow="visible"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;display:inline;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke-width:50125.8;filter:url(#filter3014-6-7-0);enable-background:new"
+         white-space="normal"
+         id="path1754-3-1-3-6-9"
+         sodipodi:nodetypes="scsccscsccs" />
+      <path
+         id="path966"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+         d="m 321.50018,239.99984 c -0.27613,3e-5 -0.49997,0.22387 -0.5,0.5 v 3.5 c 0,1.64235 0.74213,2.84997 1.82617,3.41797 1.052,0.55296 2.23699,0.58203 3.30274,0.58203 h 4.87304 v 1.5 c -5.7e-4,0.36498 0.3774,0.60758 0.70899,0.45508 0.79816,-0.36623 1.58304,-0.76026 2.35351,-1.18164 6.7e-4,-6.6e-4 10e-4,-0.001 0.002,-0.002 0.788,-0.43542 1.55131,-0.88603 2.28515,-1.3496 0.312,-0.19739 0.30985,-0.65322 -0.004,-0.84766 -0.73232,-0.45353 -1.49197,-0.89702 -2.28125,-1.33203 -6.6e-4,-6.7e-4 -10e-4,-10e-4 -0.002,-0.002 -0.79637,-0.43457 -1.57888,-0.83179 -2.34961,-1.19335 -0.0666,-0.031 -0.13928,-0.047 -0.21279,-0.0468 h -0.002 c -0.27613,3e-5 -0.49997,0.22387 -0.5,0.5 v 1.5 h -4.87109 c -0.98593,0 -1.8998,-0.10487 -2.37305,-0.35352 -0.25993,-0.13634 -0.41759,-0.26955 -0.54102,-0.49609 -0.12343,-0.22654 -0.21484,-0.57772 -0.21484,-1.15039 v -3.5 c -3e-5,-0.27613 -0.22387,-0.49997 -0.5,-0.5 z"
+         transform="matrix(-1,0,0,1,657.00013,-0.99984)"
+         sodipodi:nodetypes="ccscsccccccccccssccscssccc" />
+      <path
+         id="path966-7"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter3014-3);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+         d="m 325.50018,239.99984 c -0.27613,3e-5 -0.49997,0.22387 -0.5,0.5 v 3.5 c 0,1.64235 0.74213,2.84997 1.82617,3.41797 1.052,0.55296 2.23699,0.58203 3.30274,0.58203 h 0.87304 v 1.5 c -5.7e-4,0.36498 0.3774,0.60758 0.70899,0.45508 0.79816,-0.36623 1.58304,-0.76026 2.35351,-1.18164 6.7e-4,-6.6e-4 10e-4,-0.001 0.002,-0.002 0.788,-0.43542 1.55131,-0.88603 2.28515,-1.3496 0.312,-0.19739 0.30985,-0.65322 -0.004,-0.84766 -0.73232,-0.45353 -1.49197,-0.89702 -2.28125,-1.33203 -6.6e-4,-6.7e-4 -10e-4,-10e-4 -0.002,-0.002 -0.79637,-0.43457 -1.57888,-0.83179 -2.34961,-1.19335 -0.0666,-0.031 -0.13928,-0.047 -0.21279,-0.0468 h -0.002 c -0.27613,3e-5 -0.49997,0.22387 -0.5,0.5 v 1.5 h -0.87109 c -0.98593,0 -1.8998,-0.10487 -2.37305,-0.35352 -0.25993,-0.13634 -0.41759,-0.26955 -0.54102,-0.49609 -0.12343,-0.22654 -0.21484,-0.57772 -0.21484,-1.15039 v -3.5 c -3e-5,-0.27613 -0.22387,-0.49997 -0.5,-0.5 z"
+         transform="matrix(-1,0,0,1,657.12904,-0.99984)"
+         sodipodi:nodetypes="ccscsccccccccccssccscssccc" />
+      <path
+         id="path1754-3-1-7"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;display:inline;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;enable-background:new"
+         d="M 321.00021,197 321,203.5 c -5e-5,1.5 0.64059,2.49361 1.55859,2.97461 0.917,0.482 2.01832,0.52539 3.07032,0.52539 h 10.08007 l 0.002,3.30078 c 2.4428,-1.12768 5.7488,-2.91143 7.87302,-4.24978 -2.29588,-1.41372 -5.58782,-3.17376 -7.87498,-4.25011 -0.003,0.72906 -6.7e-4,2.46687 0,3.19911 H 326.629 c -2.629,0 -3.629,0 -3.62896,-2.5 l 2.1e-4,-5.5 z"
+         sodipodi:nodetypes="cscsccccccccc"
+         transform="matrix(-1,0,0,1,664.00025,-2)" />
+      <path
+         id="path1754-3-1-7-5"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;display:inline;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;enable-background:new"
+         d="m 325.99996,197 -2.1e-4,6.5 c -5e-5,1.5 0.64059,2.49361 1.55859,2.97461 0.917,0.482 2.01832,0.52539 3.07032,0.52539 h 5.08032 l 0.002,3.30078 c 2.4428,-1.12768 5.7488,-2.91143 7.87302,-4.24978 -2.29588,-1.41372 -5.58782,-3.17376 -7.87498,-4.25011 -0.003,0.72906 -6.7e-4,2.46687 0,3.19911 h -4.08027 c -2.629,0 -3.629,0 -3.62896,-2.5 L 328,197 Z"
+         sodipodi:nodetypes="cscsccccccccc"
+         transform="matrix(-1,0,0,1,664.00025,-2)" />
+      <path
+         id="path1754-3-1-7-6"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;display:inline;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;enable-background:new"
+         d="m 394.00016,195 2.1e-4,6.5 c 5e-5,1.5 -0.64059,2.49361 -1.55859,2.97461 -0.917,0.482 -2.01832,0.52539 -3.07032,0.52539 h -9.08019 l -0.002,3.30078 c -2.4428,-1.12768 -5.7488,-2.91143 -7.87302,-4.24978 2.29588,-1.41372 5.58782,-3.17376 7.87498,-4.25011 0.003,0.72906 6.7e-4,2.46687 0,3.19911 h 8.08014 c 2.62901,0 3.62901,0 3.62896,-2.5 l -2.1e-4,-5.5 z"
+         sodipodi:nodetypes="cscsccccccccc" />
+      <path
+         id="path1754-3-1-7-5-2"
+         style="font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;shape-padding:0;display:inline;isolation:auto;mix-blend-mode:normal;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;enable-background:new"
+         d="m 389.00041,195 2.1e-4,6.5 c 5e-5,1.5 -0.64059,2.49361 -1.55859,2.97461 -0.917,0.482 -2.01832,0.52539 -3.07032,0.52539 h -4.08044 l -0.002,3.30078 c -2.4428,-1.12768 -5.7488,-2.91143 -7.87302,-4.24978 2.29588,-1.41372 5.58782,-3.17376 7.87498,-4.25011 0.003,0.72906 6.7e-4,2.46687 0,3.19911 h 3.08039 c 2.62901,0 3.62901,0 3.62896,-2.5 l -2e-4,-5.5 z"
+         sodipodi:nodetypes="cscsccccccccc" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline">
+      <g
+         transform="matrix(1.0084216,0,0,1.0084215,7.89435,-1.5580552)"
+         style="display:inline;stroke:none;enable-background:new"
+         id="g1453-4" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer3"
+       inkscape:label="Emblems" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/categories/preferences-desktop-wallpaper.svg
+++ b/icons/src/fullcolor/accented/categories/preferences-desktop-wallpaper.svg
@@ -435,7 +435,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan924">user-desktop</tspan></text>
+           id="tspan924">preferences-desktop-wallpaper</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"

--- a/icons/src/fullcolor/accented/categories/preferences-desktop-wallpaper.svg
+++ b/icons/src/fullcolor/accented/categories/preferences-desktop-wallpaper.svg
@@ -1,0 +1,822 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
+   width="400"
+   height="300"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="1.1.2 (76b9e6a115, 2022-02-25)"
+   sodipodi:docname="preferences-desktop-wallpaper.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   style="display:inline;enable-background:new"
+   inkscape:export-filename="/home/sam/suru-template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title3004">Suru Icon Theme Template</title>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#f57900"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="267.99347"
+     inkscape:cy="213.36947"
+     inkscape:current-layer="layer5"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="2488"
+     inkscape:window-height="1376"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     width="400px"
+     height="300px"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     gridtolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-grids="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="false"
+     showborder="false"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       spacingy="1"
+       spacingx="1"
+       id="grid5883"
+       type="xygrid"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid11592"
+       empspacing="2"
+       visible="true"
+       enabled="false"
+       spacingx="0.5"
+       spacingy="0.5"
+       color="#ff0000"
+       opacity="0.1254902"
+       empcolor="#ff0000"
+       empopacity="0.25098039"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1923">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.502"
+         offset="0"
+         id="stop1921" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.255"
+         offset="1"
+         id="stop1919" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2652">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.1"
+         offset="0"
+         id="stop2648" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.6"
+         offset="1"
+         id="stop2650" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4346"
+       x="-0.013249797"
+       width="1.0264996"
+       y="-0.011357288"
+       height="1.0227146">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.120027"
+         id="feGaussianBlur4348" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient927">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop923" />
+      <stop
+         id="stop933"
+         offset="0.125"
+         style="stop-color:#ffffff;stop-opacity:0.09803922" />
+      <stop
+         id="stop931"
+         offset="0.92500001"
+         style="stop-color:#ffffff;stop-opacity:0.09803922" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         offset="1"
+         id="stop925" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient981"
+       x1="333"
+       y1="192"
+       x2="333"
+       y2="208"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(90,331.99966,200)" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath971">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
+         id="path973"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient993"
+       x1="329"
+       y1="239"
+       x2="329"
+       y2="250"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(90,328,244)" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath983">
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path985"
+         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient969"
+       x1="336"
+       y1="136"
+       x2="336"
+       y2="160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(90,335.99998,147.99998)" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath959">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#46a926;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 330.1929,133.99999 c -5.61538,0 -6.21958,0.57678 -6.19206,6.20352 v 7.79648 7.79648 c -0.0276,5.62673 0.57668,6.20351 6.19206,6.20351 h 11.615 c 5.6154,0 6.19208,-0.5767 6.19208,-6.20351 v -7.79648 -7.79648 c 0,-5.6268 -0.5767,-6.20352 -6.19208,-6.20352 z"
+         id="path961"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient927-3-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop923-3" />
+      <stop
+         id="stop933-6"
+         offset="0.125"
+         style="stop-color:#ffffff;stop-opacity:0.09803922" />
+      <stop
+         id="stop931-7"
+         offset="0.92500001"
+         style="stop-color:#ffffff;stop-opacity:0.09803922" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49803922"
+         offset="1"
+         id="stop925-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927-3-6"
+       id="linearGradient945"
+       x1="348"
+       y1="65"
+       x2="348"
+       y2="105"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter965"
+       x="-0.025999608"
+       width="1.0519992"
+       y="-0.022286005"
+       height="1.044572">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="4.160054"
+         id="feGaussianBlur967" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1923"
+       id="linearGradient1459"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.453125,0,0,0.45311204,39.99725,46.040197)"
+       x1="0.0017588965"
+       y1="472.20496"
+       x2="494.34659"
+       y2="48.456802" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1923"
+       id="linearGradient1712"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11328125,0,0,0.11327801,315.99932,50.510765)"
+       x1="44.143932"
+       y1="479.8147"
+       x2="450.21289"
+       y2="128.00072" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1923"
+       id="linearGradient1900"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07208805,0,0,0.07208601,318.18144,126.0953)"
+       x1="46.034813"
+       y1="494.25803"
+       x2="448.3212"
+       y2="148.35301" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1923"
+       id="linearGradient2252"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.05664062,0,0,0.05663901,317.99961,183.43159)"
+       x1="44.144821"
+       y1="481.02765"
+       x2="450.21384"
+       y2="145.72163" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2652"
+       id="linearGradient2478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03604403,0,0,0.03604301,319.09069,232.43595)"
+       x1="459.03448"
+       y1="419.23337"
+       x2="35.310345"
+       y2="207.36522" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15024"
+       id="radialGradient15026"
+       cx="200"
+       cy="131.99759"
+       fx="200"
+       fy="131.99759"
+       r="31.99707"
+       gradientTransform="matrix(1,0,0,1.0000752,-4.6e-5,-0.007623)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient15024">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop15020" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop15022" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter15084"
+       x="-0.14400541"
+       width="1.2880108"
+       y="-0.14399458"
+       height="1.2879892">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="3.8397928"
+         id="feGaussianBlur15086" />
+    </filter>
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Sam Hewitt</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title>Suru Icon Theme Template</dc:title>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:date />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="Icon"
+     id="layer1">
+    <g
+       style="display:none"
+       inkscape:label="Baseplate"
+       id="layer7"
+       inkscape:groupmode="layer">
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="19.006836"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="context"
+         id="context"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
+           y="-8.2548828"
+           x="19.006836"
+           sodipodi:role="line"
+           id="tspan3933">places</tspan></text>
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="146.48828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="icon-name"
+         id="icon-name"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+           y="-8.2548828"
+           x="146.48828"
+           sodipodi:role="line"
+           id="tspan924">user-desktop</tspan></text>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect16x16"
+         width="16"
+         height="16"
+         x="320"
+         y="236"
+         inkscape:label="16x16"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect24x24"
+         width="24"
+         height="24"
+         x="320"
+         y="188"
+         inkscape:label="24x24"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect32x32"
+         width="32"
+         height="32"
+         x="320"
+         y="132"
+         inkscape:label="32x32"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <rect
+         inkscape:label="48x48"
+         y="60"
+         x="320"
+         height="48"
+         width="48"
+         id="rect48x48"
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect3951"
+         width="256"
+         height="256"
+         x="24"
+         y="28"
+         inkscape:label="48x48"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer4"
+       inkscape:label="Shadows"
+       style="display:inline"
+       sodipodi:insensitive="true">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 324.10156,238 c -0.71915,0 -1.30483,0.0125 -1.83594,0.10156 -0.53547,0.0898 -1.06731,0.277 -1.47656,0.68555 -0.40957,0.4089 -0.59739,0.93918 -0.6875,1.47461 -0.0893,0.5307 -0.10156,1.11632 -0.10156,1.83398 v 5.8086 c 0,0.7177 0.0124,1.30264 0.10156,1.83398 0.09,0.53651 0.27895,1.06902 0.6875,1.47852 0.40843,0.40938 0.93899,0.59618 1.47656,0.68554 0.53194,0.0884 1.11889,0.10116 1.8379,0.0977 H 328 h 3.89648 c 0.71856,0.003 1.30564,-0.009 1.8379,-0.0977 0.53758,-0.0893 1.06814,-0.27615 1.47656,-0.68554 0.40854,-0.40951 0.59548,-0.94204 0.68554,-1.47852 C 335.98565,249.20693 336,248.622 336,247.9043 v -5.8086 c 0,-0.71766 -0.0142,-1.30328 -0.10352,-1.83398 -0.0901,-0.53541 -0.27596,-1.0657 -0.68554,-1.47461 -0.40926,-0.40854 -0.94112,-0.59573 -1.47656,-0.68555 C 333.20327,238.0125 332.61759,238 331.89844,238 H 328 Z"
+         id="path1036"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccsscscccccscsscccscs" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 320.99928,95.268807 c 0,2.22316 0.0512,3.97368 0.29297,5.414063 0.24178,1.44039 0.69529,2.61905 1.55664,3.48243 0.86134,0.86337 2.03947,1.31906 3.48046,1.55859 1.441,0.23953 3.19535,0.28629 5.42383,0.27539 h 12.2461 12.25195 c 2.22506,0.0108 3.97852,-0.0361 5.41797,-0.27539 1.441,-0.23953 2.61913,-0.69522 3.48047,-1.55859 0.86134,-0.86338 1.31486,-2.04204 1.55664,-3.48243 0.24179,-1.440393 0.29297,-3.190903 0.29297,-5.414063 v -16.53906 c 0,-2.22316 -0.0511,-3.97276 -0.29297,-5.41016 -0.24189,-1.4374 -0.69694,-2.61246 -1.55859,-3.47265 -0.86165,-0.8602 -2.03894,-1.3132 -3.47852,-1.55469 -1.43957,-0.24149 -3.19036,-0.29297 -5.41797,-0.29297 h -12.25195 -12.25196 c -2.22761,0 -3.97839,0.0515 -5.41797,0.29297 -1.43957,0.24149 -2.61686,0.69449 -3.47851,1.55469 -0.86165,0.86019 -1.31671,2.03525 -1.55859,3.47265 -0.24189,1.4374 -0.29297,3.187 -0.29297,5.41016 z"
+         id="path1020"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
+         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 418.15677 C 488.75021,522 494.0629,514.72348 496,444.01294 V 298 151.98706 C 496,81.249993 488.75021,74 418.15677,74 Z"
+         id="rect4158-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss"
+         transform="matrix(0,-0.5,0.5,0,2.9973021,316.9973)" />
+      <path
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path4350"
+         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 418.15677 C 488.75021,522 496,514.75001 496,444.01294 V 298 151.98706 C 496,81.249993 488.75021,74 418.15677,74 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate;filter:url(#filter965)"
+         transform="matrix(0,0.5,0.5,0,2.9973021,13.00269)" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 320.99951,155.80615 c 0,1.42096 0.0308,2.54883 0.19141,3.50586 0.16064,0.95703 0.4726,1.79146 1.09179,2.41211 0.61919,0.62065 1.45612,0.93647 2.41407,1.0957 0.95795,0.15924 2.08705,0.18666 3.51171,0.17969 h 7.79102 7.79688 c 1.42131,0.007 2.5495,-0.0207 3.50585,-0.17969 0.95796,-0.15923 1.79488,-0.47505 2.41407,-1.0957 0.61919,-0.62065 0.93115,-1.45508 1.09179,-2.41211 0.16065,-0.95703 0.19141,-2.0849 0.19141,-3.50586 v -11.61523 c 0,-1.42097 -0.0307,-2.54669 -0.19141,-3.50196 -0.16075,-0.95527 -0.47425,-1.78779 -1.09375,-2.40625 -0.6195,-0.61845 -1.45363,-0.93134 -2.41015,-1.09179 -0.95653,-0.16046 -2.08403,-0.19141 -3.50781,-0.19141 h -7.79688 -7.79688 c -1.42378,0 -2.55128,0.031 -3.50781,0.19141 -0.95653,0.16045 -1.79065,0.47334 -2.41015,1.09179 -0.61951,0.61846 -0.933,1.45098 -1.09375,2.40625 -0.16076,0.95527 -0.19141,2.08099 -0.19141,3.50196 z"
+         id="path999"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scscccccscsscccscscscss" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 325.875,192 c -1.1215,0 -2.02115,0.0225 -2.79492,0.15234 -0.77661,0.13029 -1.47821,0.38927 -2.00781,0.91797 -0.52965,0.52877 -0.78935,1.22994 -0.91993,2.00586 C 320.0223,195.84899 320,196.746 320,197.86523 v 8.26954 c 0,1.11925 0.0224,2.01501 0.15234,2.78906 0.13049,0.77729 0.39053,1.48303 0.91993,2.01367 0.52954,0.5308 1.23351,0.78862 2.01171,0.91797 0.77469,0.12878 1.67184,0.14998 2.79297,0.14453 H 332 h 6.12305 c 1.12086,0.005 2.01803,-0.0157 2.79297,-0.14453 0.77821,-0.12935 1.48217,-0.38716 2.01171,-0.91797 0.52939,-0.53064 0.78749,-1.23638 0.91797,-2.01367 0.12993,-0.77406 0.1543,-1.66981 0.1543,-2.78906 v -8.26954 c 0,-1.11922 -0.0242,-2.01621 -0.1543,-2.78906 -0.13058,-0.77592 -0.38832,-1.47709 -0.91797,-2.00586 -0.5296,-0.5287 -1.23315,-0.78768 -2.00976,-0.91797 C 340.14424,192.02256 339.24651,192 338.125,192 H 332 Z"
+         id="path1065"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccsscccccccccsscccscs" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="Background"
+       style="display:inline">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 324.10156,237.5 c -0.71121,-0.003 -1.27546,0.0103 -1.7539,0.0898 -0.47898,0.0796 -0.89549,0.23655 -1.20508,0.54688 -0.3096,0.31033 -0.46655,0.72851 -0.54688,1.20703 -0.0763,0.45474 -0.0922,0.99487 -0.0937,1.65625 -8e-5,0.0346 -0.002,0.0604 -0.002,0.0957 v 5.8086 c 0,0.71048 0.0153,1.27236 0.0957,1.75 0.0804,0.47763 0.23713,0.89583 0.54688,1.20508 0.30975,0.30921 0.72681,0.46469 1.20508,0.54492 0.47826,0.0802 1.04201,0.0957 1.7539,0.0957 H 328 h 3.89844 c 0.71189,0 1.27564,-0.0155 1.7539,-0.0957 0.47827,-0.0802 0.89533,-0.23572 1.20508,-0.54492 0.30975,-0.30924 0.4665,-0.72745 0.54688,-1.20508 0.0804,-0.47764 0.0957,-1.03952 0.0957,-1.75 v -5.8086 c 0,-0.0353 -0.002,-0.0611 -0.002,-0.0957 -0.002,-0.66138 -0.0174,-1.20152 -0.0937,-1.65625 -0.0803,-0.47851 -0.23728,-0.89671 -0.54688,-1.20703 -0.30959,-0.31032 -0.7261,-0.46726 -1.20508,-0.54688 -0.47897,-0.0796 -1.04352,-0.0933 -1.75586,-0.0898 H 328 Z"
+         id="path918"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 331.74805,65 c -2.22703,0 -3.98101,0.04964 -5.41993,0.291016 -1.44026,0.241603 -2.61438,0.693961 -3.47656,1.554687 -0.86248,0.861023 -1.3166,2.036651 -1.55859,3.474609 C 321.20683,70.832186 321.15149,71.401094 321.10742,72 321.02784,73.081663 321,74.299797 321,75.730469 v 18.539062 c 0,2.222843 0.0514,3.974746 0.29297,5.414063 0.24191,1.441106 0.69492,2.616716 1.55664,3.480466 0.86187,0.86391 2.03884,1.31896 3.48047,1.5586 1.43916,0.23922 3.19276,0.2882 5.41992,0.27734 H 344 356.24805 c 2.22714,0.0108 3.98268,-0.0381 5.42187,-0.27734 1.44163,-0.23964 2.61664,-0.69468 3.47852,-1.5586 0.86171,-0.86375 1.31473,-2.03935 1.55664,-3.480466 C 366.94669,98.244252 367,96.492367 367,94.269531 V 75.730469 C 367,74.299833 366.9727,73.081645 366.89258,72 c -0.0444,-0.598936 -0.10136,-1.16779 -0.1875,-1.679688 -0.24198,-1.43796 -0.69415,-2.613586 -1.55664,-3.474609 -0.86218,-0.860726 -2.03824,-1.313084 -3.47852,-1.554687 C 360.23999,65.051137 358.7096,65 356.25195,65 H 344 Z"
+         id="path958"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1712);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 331.74805,65 c -2.22703,0 -3.98101,0.0496 -5.41993,0.29101 -1.44026,0.24161 -2.61438,0.69396 -3.47656,1.55469 -0.86248,0.86102 -1.3166,2.03665 -1.55859,3.47461 -0.0861,0.51187 -0.14148,1.08078 -0.18555,1.67969 C 321.02782,73.08166 321,74.29979 321,75.73047 v 18.53906 c 0,2.22284 0.0514,3.97474 0.29297,5.41406 0.24191,1.44111 0.69492,2.61672 1.55664,3.48047 0.86187,0.86391 2.03884,1.31896 3.48047,1.5586 1.43916,0.23922 3.19276,0.2882 5.41992,0.27734 H 344 356.24805 c 2.22714,0.0108 3.98268,-0.0381 5.42187,-0.27734 1.44163,-0.23964 2.61664,-0.69468 3.47852,-1.5586 0.86171,-0.86375 1.31473,-2.03935 1.55664,-3.48047 C 366.94669,98.24425 367,96.49236 367,94.26953 V 75.73047 c 0,-1.43064 -0.0273,-2.64883 -0.10742,-3.73047 -0.0444,-0.59894 -0.10136,-1.16779 -0.1875,-1.67969 -0.24198,-1.43796 -0.69415,-2.61359 -1.55664,-3.47461 -0.86218,-0.86073 -2.03824,-1.31308 -3.47852,-1.55469 C 360.23999,65.05113 358.7096,65 356.25195,65 H 344 Z"
+         id="path958-9"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 78.990234,68.003906 c -35.36812,-0.172978 -38.992187,4.1647 -38.992187,39.458984 V 108 v 1 112.08203 c 0,35.29672 3.623657,38.91992 38.992187,38.91992 h 73.007816 73.00586 c 35.36853,0 38.99414,-3.6232 38.99414,-38.91992 V 109 v -1 -0.53711 c 0,-35.294284 -3.62603,-39.631962 -38.99414,-39.458984 h -73.00586 z"
+         id="rect4158"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 325.875,191.5 c -1.1131,-0.005 -1.989,0.017 -2.70898,0.13672 -0.72051,0.11976 -1.30957,0.3476 -1.74024,0.7793 -0.43067,0.43169 -0.6584,1.02199 -0.7793,1.74218 -0.086,0.51249 -0.11622,1.143 -0.13086,1.8418 -0.006,0.28323 -0.0156,0.54464 -0.0156,0.86523 v 8.26954 c 0,1.11158 0.0255,1.98637 0.14648,2.70507 0.12095,0.7187 0.34848,1.30623 0.7793,1.73633 0.43083,0.4301 1.01849,0.6566 1.73828,0.77735 0.71979,0.12074 1.59713,0.14648 2.71094,0.14648 h 6.125 6.125 c 1.11381,0 1.99115,-0.0257 2.71094,-0.14648 0.71979,-0.12075 1.30745,-0.34725 1.73828,-0.77735 0.43082,-0.4301 0.65835,-1.01763 0.7793,-1.73633 0.12094,-0.7187 0.14648,-1.59349 0.14648,-2.70507 v -8.26954 c 0,-0.32059 -0.01,-0.582 -0.0156,-0.86523 -0.0146,-0.6988 -0.0448,-1.32931 -0.13086,-1.8418 -0.1209,-0.72019 -0.34863,-1.3105 -0.7793,-1.74218 -0.43067,-0.43169 -1.01974,-0.65954 -1.74024,-0.7793 -0.72049,-0.11977 -1.59669,-0.14217 -2.71093,-0.13672 H 332 Z"
+         id="path914"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#00ff01;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 328.20312,136.5 c -1.41451,-0.007 -2.52269,0.024 -3.42382,0.17383 -0.90165,0.14987 -1.61915,0.43041 -2.14063,0.95312 -0.52148,0.52272 -0.8018,1.24112 -0.95312,2.14258 -0.0612,0.3645 -0.0927,0.79158 -0.1211,1.23047 -0.0418,0.64654 -0.0645,1.35205 -0.0645,2.19336 v 11.61523 c 0,1.41241 0.0342,2.51847 0.18555,3.41797 0.15137,0.8995 0.43149,1.61597 0.95312,2.13672 0.52163,0.52075 1.23774,0.80004 2.13867,0.95117 0.90094,0.15113 2.01057,0.18555 3.42578,0.18555 H 336 h 7.79688 c 1.41523,0 2.52484,-0.0344 3.42578,-0.18555 0.90093,-0.15113 1.61703,-0.43042 2.13867,-0.95117 0.52163,-0.52075 0.80175,-1.23722 0.95312,-2.13672 0.15137,-0.8995 0.18555,-2.00556 0.18555,-3.41797 v -11.61523 c 0,-0.84132 -0.0246,-1.54681 -0.0664,-2.19336 -0.0284,-0.43888 -0.0579,-0.86598 -0.11914,-1.23047 -0.15132,-0.90145 -0.43164,-1.61987 -0.95312,-2.14258 -0.52148,-0.5227 -1.23898,-0.80325 -2.14063,-0.95312 -0.90164,-0.14988 -2.0101,-0.18075 -3.42578,-0.17383 H 336 Z"
+         id="path922"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 39.998047,219.08203 v 2 c 0,35.29672 3.623654,38.91992 38.992187,38.91992 h 73.007816 73.00586 c 35.36853,0 38.99414,-3.6232 38.99414,-38.91992 v -2 c 0,35.29672 -3.62561,38.91992 -38.99414,38.91992 H 151.99805 78.990234 c -35.368533,0 -38.992187,-3.6232 -38.992187,-38.91992 z"
+         id="path1056"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csscsscscsc"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1459);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="M 78.99019,68.003803 C 43.62206,67.830825 39.998,72.168503 39.998,107.46279 v 0.53711 1 112.08203 c 0,35.29672 3.62365,38.91992 38.99219,38.91992 h 73.00781 73.00586 c 35.36853,0 38.99414,-3.6232 38.99414,-38.91992 v -112.08203 -1 -0.53711 c 0,-35.294287 -3.62603,-39.631965 -38.99414,-39.458987 H 151.998 Z"
+         id="rect4158-5"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="opacity:0.3;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 74.814453,68.003906 C 43.235773,67.830928 40,72.16861 40,107.46289 V 108 v 1 112.08203 c 0,35.29672 3.235408,38.91992 34.814453,38.91992 H 90 V 68.003906 Z"
+         id="rect1767"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccssccc"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="display:inline;opacity:0.3;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 330.67329,65.001953 c -1.97334,0.0018 -3.54481,0.052 -4.82954,0.289063 -1.30933,0.241603 -2.37671,0.693961 -3.16051,1.554687 -0.78408,0.861023 -1.19691,2.036652 -1.4169,3.474609 C 321.18806,70.832188 321.13772,71.401094 321.09765,72 321.02531,73.081664 321,74.299797 321,75.730469 v 18.539062 c 0,2.222843 0.0467,3.974742 0.26634,5.414063 0.21991,1.441096 0.63174,2.616716 1.41512,3.480466 0.78352,0.86391 1.85349,1.31896 3.16407,1.5586 1.30832,0.23922 2.90251,0.2882 4.9272,0.27734 H 331 V 65.001953 Z"
+         id="rect1767-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccssccccccc"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1900);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 328.20317,136.72439 c -1.41452,-0.007 -2.5227,0.024 -3.42382,0.17383 -0.90165,0.14987 -1.61915,0.43041 -2.14063,0.95312 -0.52148,0.52272 -0.8018,1.24112 -0.95312,2.14258 -0.0612,0.3645 -0.0927,0.79158 -0.1211,1.23047 -0.0418,0.64654 -0.0645,1.35205 -0.0645,2.19336 v 11.61523 c 0,1.41241 0.0342,2.51847 0.18554,3.41797 0.15137,0.8995 0.43149,1.61597 0.95312,2.13672 0.52164,0.52075 1.23774,0.80004 2.13867,0.95117 0.90094,0.15113 2.01057,0.18555 3.42578,0.18555 h 7.79693 7.79688 c 1.41523,0 2.52484,-0.0344 3.42578,-0.18555 0.90093,-0.15113 1.61703,-0.43042 2.13867,-0.95117 0.52163,-0.52075 0.80175,-1.23722 0.95312,-2.13672 0.15137,-0.8995 0.18555,-2.00556 0.18555,-3.41797 v -11.61523 c 0,-0.84132 -0.0246,-1.54681 -0.0664,-2.19336 -0.0284,-0.43888 -0.0579,-0.86598 -0.11914,-1.23047 -0.15132,-0.90145 -0.43164,-1.61987 -0.95312,-2.14258 -0.52148,-0.5227 -1.23898,-0.80325 -2.14063,-0.95312 -0.90164,-0.14988 -2.0101,-0.18075 -3.42578,-0.17383 h -7.79493 z"
+         id="path922-7"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="display:inline;opacity:0.3;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 327.36841,136.5 c -1.19716,0.001 -2.1505,0.0325 -2.92991,0.18067 -0.79432,0.151 -1.44186,0.43373 -1.91737,0.97169 -0.47566,0.53815 -0.72611,1.27292 -0.85958,2.17166 -0.0475,0.31993 -0.078,0.6755 -0.10232,1.04982 -0.0438,0.67605 -0.0593,1.43739 -0.0593,2.33158 v 11.58707 c 0,1.3893 0.0283,2.48425 0.16156,3.38384 0.13344,0.9007 0.38327,1.63547 0.85851,2.17532 0.47535,0.53995 1.12445,0.82436 1.91953,0.97414 0.79371,0.14951 1.76084,0.18013 2.98915,0.17334 l 0.57125,6.2e-4 V 136.5 Z"
+         id="rect1767-6-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccssccccccc"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2252);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 325.87498,191.67652 c -1.1131,-0.005 -1.989,0.017 -2.70898,0.13672 -0.72051,0.11976 -1.30957,0.3476 -1.74024,0.7793 -0.43067,0.43169 -0.6584,1.02199 -0.7793,1.74218 -0.086,0.51249 -0.11622,1.143 -0.13086,1.8418 -0.006,0.28323 -0.0156,0.54464 -0.0156,0.86523 v 8.26954 c 0,1.11158 0.0255,1.98637 0.14648,2.70507 0.12095,0.7187 0.34848,1.30623 0.7793,1.73633 0.43083,0.4301 1.01849,0.6566 1.73828,0.77735 0.71979,0.12074 1.59713,0.14648 2.71094,0.14648 h 6.125 6.125 c 1.11381,0 1.99115,-0.0257 2.71094,-0.14648 0.71979,-0.12075 1.30745,-0.34725 1.73828,-0.77735 0.43082,-0.4301 0.65835,-1.01763 0.7793,-1.73633 0.12094,-0.7187 0.14648,-1.59349 0.14648,-2.70507 v -8.26954 c 0,-0.32059 -0.01,-0.582 -0.0156,-0.86523 -0.0146,-0.6988 -0.0448,-1.32931 -0.13086,-1.8418 -0.1209,-0.72019 -0.34863,-1.3105 -0.7793,-1.74218 -0.43067,-0.43169 -1.01974,-0.65954 -1.74024,-0.7793 -0.72049,-0.11977 -1.59669,-0.14217 -2.71093,-0.13672 h -6.12309 z"
+         id="path914-3"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="display:inline;opacity:0.3;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 325.46561,191.5 c -1.01298,8.5e-4 -1.81967,0.0247 -2.47917,0.13731 -0.67211,0.11476 -1.22004,0.32963 -1.62239,0.73848 -0.40249,0.409 -0.61442,0.96743 -0.72734,1.65047 -0.0401,0.24314 -0.066,0.51337 -0.0866,0.79786 -0.0371,0.5138 -0.0501,1.09242 -0.0501,1.772 v 8.80617 c 0,1.05587 0.024,1.88803 0.13672,2.57172 0.11289,0.68453 0.3243,1.24296 0.72643,1.65324 0.40221,0.41037 0.95147,0.62652 1.62423,0.74035 0.6716,0.11363 1.48995,0.1369 2.52929,0.13174 l 0.48333,4.7e-4 V 191.5 Z"
+         id="rect1767-6-7-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccssccccccc"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.102;fill:url(#linearGradient2478);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 324.10156,237.50049 c -0.71121,-0.003 -1.27546,0.0103 -1.7539,0.0898 -0.47898,0.0796 -0.89549,0.23655 -1.20508,0.54688 -0.3096,0.31033 -0.46655,0.72851 -0.54688,1.20703 -0.0763,0.45474 -0.0922,0.99487 -0.0937,1.65625 -8e-5,0.0346 -0.002,0.0604 -0.002,0.0957 v 5.8086 c 0,0.71048 0.0153,1.27236 0.0957,1.75 0.0804,0.47763 0.23713,0.89583 0.54688,1.20508 0.30975,0.30921 0.72681,0.46469 1.20508,0.54492 0.47826,0.0802 1.04201,0.0957 1.7539,0.0957 H 328 h 3.89844 c 0.71189,0 1.27564,-0.0155 1.7539,-0.0957 0.47827,-0.0802 0.89533,-0.23572 1.20508,-0.54492 0.30975,-0.30924 0.4665,-0.72745 0.54688,-1.20508 0.0804,-0.47764 0.0957,-1.03952 0.0957,-1.75 v -5.8086 c 0,-0.0353 -0.002,-0.0611 -0.002,-0.0957 -0.002,-0.66138 -0.0174,-1.20152 -0.0937,-1.65625 -0.0803,-0.47851 -0.23728,-0.89671 -0.54688,-1.20703 -0.30959,-0.31032 -0.7261,-0.46726 -1.20508,-0.54688 -0.47897,-0.0796 -1.04352,-0.0933 -1.75586,-0.0898 H 328 Z"
+         id="path918-6"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="display:inline;opacity:0.3;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 323.65995,237.5 c -0.64462,5.9e-4 -1.15797,0.0169 -1.57766,0.094 -0.42771,0.0785 -0.77639,0.22554 -1.03244,0.50528 -0.25613,0.27983 -0.39099,0.66192 -0.46286,1.12926 -0.0256,0.16636 -0.042,0.35126 -0.0551,0.54591 -0.0236,0.35154 -0.0319,0.74744 -0.0319,1.21242 v 6.02528 c 0,0.72243 0.0152,1.29181 0.087,1.75959 0.0718,0.46836 0.20638,0.85045 0.46229,1.13117 0.25595,0.28077 0.60548,0.42867 1.0336,0.50655 0.42739,0.0777 0.94816,0.0937 1.60956,0.0901 l 0.30758,3.2e-4 V 237.5 Z"
+         id="rect1767-6-7-6-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccssccccccc"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="M 200.00386,68.003804 263.998,131.99795 v -22.99805 -1 -0.53711 c 0,-35.294288 -3.62603,-39.631964 -38.99414,-39.458986 z"
+         id="rect4158-0"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient15026);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter15084);enable-background:accumulate"
+         d="M 263.998,131.99315 200.00386,67.998998 v 22.998052 1 0.53711 c 0,35.29429 3.62603,39.63197 38.99414,39.45899 z"
+         id="rect4158-0-3-6" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="M 263.998,131.99315 200.00386,67.998998 v 22.998052 1 0.53711 c 0,35.29429 3.62603,39.63197 38.99414,39.45899 z"
+         id="rect4158-0-3" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.250023;marker:none;enable-background:accumulate"
+         d="m 351,65 16,16 V 75.730469 C 367,74.299833 366.9727,73.081645 366.89258,72 c -0.0444,-0.598936 -0.10136,-1.167789 -0.1875,-1.679688 -0.24198,-1.43796 -0.69415,-2.613586 -1.55664,-3.474609 -0.86218,-0.860726 -2.03824,-1.313084 -3.47852,-1.554687 C 360.23999,65.051137 358.7096,65 356.25195,65 Z"
+         id="rect4158-0-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsccccsc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.124267;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.250023;marker:none;enable-background:accumulate"
+         d="m 349.99989,65.500746 0.5,0.5 1.1e-4,5.747899 v 0.25 0.134765 c 0,8.824381 0.40719,9.410436 9.25,9.367188 h 6.24978 l 0.5,0.5 v -0.5 -4.769531 c 0,-1.430636 -0.0273,-2.648824 -0.10742,-3.730469 -0.0444,-0.598936 -0.10136,-1.167789 -0.1875,-1.679688 -0.24198,-1.43796 -0.69426,-3.113438 -1.55675,-3.97446 -0.86218,-0.860726 -2.53802,-1.313084 -3.9783,-1.554687 -1.42993,-0.23988 -2.96032,-0.291017 -5.41797,-0.291017 h -4.75 -0.002 z"
+         id="rect4158-0-0-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccsccccsccccsccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.250023;marker:none;enable-background:accumulate"
+         d="m 367,80.500602 -15.5,-15.5012 v 5.75004 0.250023 0.13428 c 0,8.82438 0.4066,9.410096 9.24941,9.366848 z"
+         id="rect4158-0-3-62"
+         sodipodi:nodetypes="ccccscc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.187517;marker:none;enable-background:accumulate"
+         d="m 337.875,137.01644 v 4.8125 0.1875 0.0996 c 0,6.61829 0.30539,7.05783 6.9375,7.02539 H 350 V 138.5887 c -0.30477,-0.74885 -0.78017,-1.25916 -1.55273,-1.57227 z"
+         id="rect4158-0-3-62-3-3" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.187517;marker:none;enable-background:accumulate"
+         d="m 338.5,136.51644 12,12 v -5.42578 c 0,-4.48043 -0.38324,-6.00687 -3.51172,-6.43164 -0.198,0.0611 -0.36844,0.0959 -0.48633,0.0762 -1.07245,-0.1799 -2.21926,-0.21875 -4.0625,-0.21875 z"
+         id="rect4158-0-0-5" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.187517;marker:none;enable-background:accumulate"
+         d="M 350.5,148.1419 338.875,136.516 v 4.31253 0.18751 0.10071 c 0,6.61829 0.30495,7.05758 6.93706,7.02514 z"
+         id="rect4158-0-3-62-3"
+         sodipodi:nodetypes="ccccscc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.187517;marker:none;enable-background:accumulate"
+         d="m 338.5,136.51644 12,12 v -5.42578 c 0,-4.48043 -0.38324,-6.00687 -3.51172,-6.43164 0,0 0,0 -0.31631,-0.0596 -0.0841,-0.0158 -0.27567,-0.0228 -0.38323,-0.0355 0,0 -0.37446,-0.0383 -0.93663,-0.0489 -0.68886,-0.0129 -1.68359,0.001 -2.91266,0.001 z"
+         id="rect4158-0-0-5-0"
+         sodipodi:nodetypes="ccscscssc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.187517;marker:none;enable-background:accumulate"
+         d="m 334.484,191.48272 9,9 v -3.126 c 0,-4.48043 0.11648,-5.30665 -3.012,-5.73142 -1.5505,-0.0801 -1.04855,-0.14255 -1.04855,-0.14255 z"
+         id="rect4158-0-0-5-0-5"
+         sodipodi:nodetypes="ccsccc" />
+      <path
+         style="display:inline;opacity:0.3;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:8.00126;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:new"
+         d="m 335.3258,191.48272 c -0.80915,0.53622 -1.3418,1.45249 -1.3418,2.5 v 4 c 0,1.662 1.338,3 3,3 h 4 c 1.04751,0 1.96378,-0.53265 2.5,-1.3418 v -3.02343 c 0,-4.65703 -0.47373,-5.15767 -5.0957,-5.13477 z"
+         id="rect16756" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.187517;marker:none;enable-background:accumulate"
+         d="m 342.98456,199.98272 -8,-8 v 2.126 c 0,4.48043 -0.11648,5.30665 3.012,5.73142 1.5505,0.0801 1.04855,0.14255 1.04855,0.14255 z"
+         id="rect4158-0-0-5-0-5-5"
+         sodipodi:nodetypes="ccsccc" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer3"
+       inkscape:label="Folds"
+       style="display:inline">
+      <g
+         id="g1034"
+         transform="matrix(0,1,1,0,83.99978,-83.99978)"
+         style="opacity:0.05" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline">
+      <path
+         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;opacity:0.2"
+         d="M 78.990234 68.001953 C 43.622114 67.828963 39.998047 71.627098 39.998047 106.92383 L 39.998047 108.92383 C 39.998047 73.627098 43.622114 69.828963 78.990234 70.001953 L 151.99805 70.001953 L 225.00391 70.001953 C 260.37202 69.828963 263.99805 73.627098 263.99805 108.92383 L 263.99805 106.92383 C 263.99805 71.627098 260.37202 67.828963 225.00391 68.001953 L 151.99805 68.001953 L 78.990234 68.001953 z "
+         id="path923"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer9"
+       inkscape:label="Borders"
+       style="display:inline"
+       sodipodi:insensitive="true">
+      <path
+         id="path901"
+         d="m 321.49931,94.268843 c 0,2.21461 0.0547,3.94722 0.28711,5.33203 0.23246,1.384807 0.65434,2.445507 1.41797,3.210937 0.76363,0.76543 1.82234,1.1878 3.20703,1.41797 1.38469,0.23017 3.1184,0.28039 5.33789,0.26953 h 12.25 12.25196 c 2.21833,0.0108 3.95175,-0.0394 5.33593,-0.26953 1.38469,-0.23017 2.4434,-0.65253 3.20703,-1.41797 0.76363,-0.76544 1.18551,-1.82612 1.41797,-3.210937 0.23246,-1.38481 0.28711,-3.11742 0.28711,-5.33203 v -18.53906 c 0,-2.2146 -0.0546,-3.94454 -0.28711,-5.32617 -0.2325,-1.38163 -0.65418,-2.44064 -1.41797,-3.20313 -0.76378,-0.76249 -1.82305,-1.18385 -3.20703,-1.41601 -1.38398,-0.23217 -2.88549,-0.28516 -5.33593,-0.28516 h -12.25196 -12.25195 c -2.21907,0 -3.95196,0.053 -5.33594,0.28516 -1.38398,0.23216 -2.44325,0.65352 -3.20703,1.41601 -0.76378,0.76249 -1.18546,1.8215 -1.41797,3.20313 -0.2325,1.38163 -0.28711,3.11157 -0.28711,5.32617 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient945);stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scssccccsssscccscssscss" />
+      <path
+         id="path1089"
+         d="m 321.49954,154.80618 c 0,1.41241 0.0342,2.52238 0.18555,3.42383 0.15132,0.90145 0.43164,1.61987 0.95312,2.14258 0.52148,0.5227 1.23898,0.80325 2.14063,0.95312 0.90164,0.14988 2.0101,0.18075 3.42578,0.17383 h 7.79492 7.79688 c 1.41452,0.007 2.52269,-0.024 3.42382,-0.17383 0.90165,-0.14987 1.61915,-0.43041 2.14063,-0.95312 0.52148,-0.52272 0.8018,-1.24112 0.95312,-2.14258 0.15132,-0.90146 0.18555,-2.01142 0.18555,-3.42383 v -11.61523 c 0,-1.41241 -0.0342,-2.51847 -0.18555,-3.41797 -0.15137,-0.8995 -0.43149,-1.61597 -0.95312,-2.13672 -0.52163,-0.52075 -1.23774,-0.80004 -2.13867,-0.95117 -0.90094,-0.15113 -2.01055,-0.18555 -3.42578,-0.18555 h -7.79688 -7.79688 c -1.41524,0 -2.52484,0.0344 -3.42578,0.18555 -0.90093,0.15113 -1.61703,0.43042 -2.13867,0.95117 -0.52163,0.52075 -0.80175,1.23722 -0.95312,2.13672 -0.15137,0.8995 -0.18555,2.00556 -0.18555,3.41797 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-opacity:1;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path1085"
+         d="m 320.49963,205.1344 c 0,1.11158 0.0256,1.98683 0.14648,2.70703 0.1209,0.72019 0.34863,1.3105 0.7793,1.74218 0.43067,0.43169 1.01974,0.65954 1.74024,0.7793 0.72049,0.11977 1.59669,0.14217 2.71093,0.13672 h 6.12305 6.125 c 1.1131,0.005 1.989,-0.017 2.70898,-0.13672 0.72051,-0.11976 1.30957,-0.3476 1.74024,-0.7793 0.43067,-0.43169 0.6584,-1.02199 0.7793,-1.74218 0.12089,-0.7202 0.14648,-1.59545 0.14648,-2.70703 v -8.26954 c 0,-1.11158 -0.0255,-1.98637 -0.14648,-2.70507 -0.12095,-0.7187 -0.34848,-1.30623 -0.7793,-1.73633 -0.43083,-0.4301 -1.01849,-0.6566 -1.73828,-0.77735 -0.71979,-0.12074 -1.59713,-0.14648 -2.71094,-0.14648 h -6.125 -6.125 c -1.11381,0 -1.99115,0.0257 -2.71094,0.14648 -0.71979,0.12075 -1.30745,0.34725 -1.73828,0.77735 -0.43082,0.4301 -0.65835,1.01763 -0.7793,1.73633 -0.12094,0.7187 -0.14648,1.59349 -0.14648,2.70507 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path1087"
+         d="m 320.49977,246.90407 c 0,0.71048 0.0154,1.27344 0.0957,1.75195 0.0803,0.47851 0.23728,0.89671 0.54688,1.20703 0.30959,0.31032 0.7261,0.46726 1.20508,0.54688 0.47897,0.0796 1.04352,0.0933 1.75586,0.0898 h 3.89648 3.89844 c 0.71121,0.003 1.27546,-0.0103 1.7539,-0.0898 0.47898,-0.0796 0.89549,-0.23655 1.20508,-0.54688 0.3096,-0.31033 0.46655,-0.72851 0.54688,-1.20703 0.0803,-0.47852 0.0957,-1.04147 0.0957,-1.75195 v -5.8086 c 0,-0.71048 -0.0153,-1.27236 -0.0957,-1.75 -0.0804,-0.47763 -0.23713,-0.89584 -0.54688,-1.20508 -0.30975,-0.30921 -0.72681,-0.46469 -1.20508,-0.54492 -0.47826,-0.0802 -1.04201,-0.0957 -1.7539,-0.0957 h -3.89844 -3.89844 c -0.71189,0 -1.27564,0.0155 -1.7539,0.0957 -0.47827,0.0802 -0.89533,0.2357 -1.20508,0.54492 -0.30975,0.30924 -0.4665,0.72745 -0.54688,1.20508 -0.0804,0.47764 -0.0957,1.03952 -0.0957,1.75 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer5"
+       inkscape:label="Highlights"
+       style="display:inline">
+      <path
+         transform="rotate(-90,332.49966,200.5)"
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path935"
+         d="m 327.8652,189 c -4.41209,0 -4.88682,0.45318 -4.8652,4.87419 V 200 206.12581 C 322.9783,210.54682 323.45311,211 327.8652,211 h 8.2696 C 340.54689,211 341,210.54688 341,206.12581 V 200 193.87419 C 341,189.45313 340.54688,189 336.13479,189 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient981);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         clip-path="url(#clipPath971)"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         transform="rotate(-90,328,244)"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient993);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 325.09646,237 c -2.80769,0 -3.10979,0.28839 -3.09603,3.10176 V 244 v 3.89824 c -0.0138,2.81337 0.28834,3.10176 3.09603,3.10176 h 5.8075 C 333.71166,251 334,250.71165 334,247.89824 V 244 240.10176 C 334,237.28836 333.71165,237 330.90396,237 Z"
+         id="path937"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccssscsss"
+         clip-path="url(#clipPath983)"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         transform="rotate(-90,336.49998,148.49998)"
+         sodipodi:nodetypes="scccssscsss"
+         inkscape:connector-curvature="0"
+         id="path939"
+         d="m 330.1929,133.99999 c -5.61538,0 -6.21958,0.57678 -6.19206,6.20352 v 7.79648 7.79648 c -0.0276,5.62673 0.57668,6.20351 6.19206,6.20351 h 11.615 c 5.6154,0 6.19208,-0.5767 6.19208,-6.20351 v -7.79648 -7.79648 c 0,-5.6268 -0.5767,-6.20352 -6.19208,-6.20352 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient969);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         clip-path="url(#clipPath959)"
+         inkscape:export-xdpi="95.996666"
+         inkscape:export-ydpi="95.996666" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 326.99977,237.49977 v 5.5 c 0,1.662 1.338,3 3,3 h 5.5 v -5.14648 c 0,-3.04166 -0.30795,-3.36842 -3.32227,-3.35352 h -4.17773 z"
+         id="path918-1-4"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#faf8f6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.187517;marker:none;enable-background:accumulate"
+         d="m 335.49949,244.96277 -7.49972,-7.463 v 1.126 c 0,5.36431 0.52032,6.1794 2.76495,6.339 1.5505,0.0801 1.79532,-0.002 1.79532,-0.002 z"
+         id="rect4158-0-0-5-0-5-6-4"
+         sodipodi:nodetypes="ccsccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.187517;marker:none;enable-background:accumulate"
+         d="m 327.99977,237.49977 7.49972,7.5 v -1.626 c 0,-5.36431 -0.0206,-5.7164 -2.26523,-5.876 -1.5505,-0.0801 -1.79532,0.002 -1.79532,0.002 z"
+         id="rect4158-0-0-5-0-5-6"
+         sodipodi:nodetypes="ccsccc" />
+    </g>
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-speaker-center-back-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-speaker-center-back-testing.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-speaker-center-back-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568544"
+     inkscape:cx="16.882174"
+     inkscape:cy="25.897785"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 1.0583333,290.91458 2.9098875,2.77813 v 2.08676 c 0,0 0.7096125,0.69136 2.3828375,0.69136 1.6732249,0 2.3796624,-0.69136 2.3796624,-0.69136 v -2.08676 l 2.9098873,-2.77813 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 3.9094833,288.91116 0.5611812,0.56118 0.2809875,-0.28099 a 2.3804562,2.3804562 0 0 1 3.3670875,0 l 0.2801937,0.28099 0.5611813,-0.56118 -0.2801938,-0.28099 a 3.175,3.175 0 0 0 -4.4894499,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 2.2259396,287.22761 0.5611812,0.56118 0.2801938,-0.28098 a 4.7617062,4.7617062 0 0 1 6.7349686,0 l 0.2801938,0.28098 0.561181,-0.56118 -0.280194,-0.28099 a 5.5562499,5.5562499 0 0 0 -7.8573307,0 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-speaker-center-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-speaker-center-testing.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-speaker-center-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="1.625"
+     inkscape:cy="40.875"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 1.0583333,290.9286 2.9098875,-2.77813 v -2.08676 c 0,0 0.7096125,-0.69136 2.3828375,-0.69136 1.6732249,0 2.3796624,0.69136 2.3796624,0.69136 v 2.08676 l 2.9098873,2.77813 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 3.9094833,292.93202 0.5611812,-0.56118 0.2809875,0.28099 a 2.3804562,2.3804562 0 0 0 3.3670875,0 l 0.2801937,-0.28099 0.5611813,0.56118 -0.2801938,0.28099 a 3.175,3.175 0 0 1 -4.4894499,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 2.2259396,294.61557 0.5611812,-0.56118 0.2801938,0.28098 a 4.7617062,4.7617062 0 0 0 6.7349686,0 l 0.2801938,-0.28098 0.561181,0.56118 -0.280194,0.28099 a 5.5562499,5.5562499 0 0 1 -7.8573307,0 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-speaker-left-back-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-speaker-left-back-testing.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-speaker-left-back-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="55.419494"
+     inkscape:cy="21.124815"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 2.40083,287.23092 v 3.96875 l -1.45282791,1.50484 c 0,0 0.0129091,0.99064 1.19605781,2.17378 1.1831488,1.18315 2.1715382,1.19382 2.1715382,1.19382 l 1.5248175,-1.43285 h 3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404131,287.76009 2e-7,0.79363 h 0.3973761 c 1.3150293,-2.4e-4 2.2492587,1.19869 2.2490186,2.51372 l -5.61e-4,0.39682 h 0.7936299 l 5.612e-4,-0.39682 c -2.648e-4,-1.75313 -1.2895189,-3.30709 -3.0426487,-3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8404133,285.37896 v 0.79363 l 0.3968151,-5.6e-4 c 2.6303146,-3.5e-4 4.6311806,2.2651 4.6308296,4.89541 l -5.61e-4,0.39682 h 0.79363 l 5.61e-4,-0.39682 c -1.54e-4,-3.06841 -2.3560445,-5.68889 -5.4244596,-5.68904 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-speaker-left-side-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-speaker-left-side-testing.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-speaker-left-side-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="60.015689"
+     inkscape:cy="26.958446"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="M 6.3499999,295.94167 3.571875,293.03178 H 1.4851062 c 0,0 -0.69135621,-0.70961 -0.69135621,-2.38284 0,-1.67322 0.69135621,-2.37966 0.69135621,-2.37966 H 3.571875 l 2.7781249,-2.90989 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 8.3534249,293.09052 -0.5611812,-0.56118 0.2809874,-0.28099 a 2.3804562,2.3804562 0 0 0 0,-3.36709 l -0.2809874,-0.28019 0.5611812,-0.56118 0.2809875,0.28019 a 3.175,3.175 0 0 1 0,4.48945 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 10.036969,294.77406 -0.5611816,-0.56118 0.2809875,-0.28019 a 4.7617062,4.7617062 0 0 0 0,-6.73497 l -0.2809875,-0.2802 0.5611816,-0.56118 0.280987,0.2802 a 5.5562499,5.5562499 0 0 1 0,7.85733 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-speaker-left-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-speaker-left-testing.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-speaker-left-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="56.718753"
+     inkscape:cy="23.781251"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 2.3812508,294.08915 v -3.96875 l -1.45282791,-1.50484 c 0,0 0.0129091,-0.99064 1.19605781,-2.17378 1.1831488,-1.18315 2.1715382,-1.19382 2.1715382,-1.19382 l 1.5248175,1.43285 h 3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8208339,293.55998 2e-7,-0.79363 h 0.3973761 c 1.3150293,2.4e-4 2.2492587,-1.19869 2.2490186,-2.51372 l -5.61e-4,-0.39682 h 0.7936299 l 5.612e-4,0.39682 c -2.648e-4,1.75313 -1.2895189,3.30709 -3.0426487,3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 5.8208341,295.94111 v -0.79363 l 0.3968151,5.6e-4 c 2.6303146,3.5e-4 4.6311808,-2.2651 4.6308298,-4.89541 l -5.61e-4,-0.39682 h 0.79363 l 5.61e-4,0.39682 c -1.54e-4,3.06841 -2.3560447,5.68889 -5.4244598,5.68904 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-speaker-mono-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-speaker-mono-testing.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-speaker-mono-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="35.797281"
+     inkscape:cy="18.473165"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       d="m 8.2072508,285.69785 -0.2800861,0.74569 a 4.4979166,4.4979166 0 0 1 2.9207513,4.20646 4.4979166,4.4979166 0 0 1 -2.9197178,4.20905 l 0.2775024,0.74 A 5.2916663,5.2916663 0 0 0 11.641666,290.65 5.2916663,5.2916663 0 0 0 8.2072508,285.69785 Z m -3.7129516,0.003 A 5.2916663,5.2916663 0 0 0 1.0583333,290.65 5.2916663,5.2916663 0 0 0 4.492749,295.60215 l 0.2800861,-0.74569 A 4.4979166,4.4979166 0 0 1 1.8520833,290.65 4.4979166,4.4979166 0 0 1 4.7718016,286.44095 Z m 2.876827,2.22519 -0.2790526,0.74414 a 2.1166665,2.1166665 0 0 1 1.3745929,1.97972 2.1166665,2.1166665 0 0 1 -1.3735595,1.98076 l 0.2775024,0.74104 A 2.9104166,2.9104166 0 0 0 9.2604165,290.65 2.9104166,2.9104166 0 0 0 7.3711262,287.92614 Z m -2.0417359,0.002 a 2.9104166,2.9104166 0 0 0 -1.889807,2.7218 2.9104166,2.9104166 0 0 0 1.8892903,2.72386 l 0.2790526,-0.74414 A 2.1166665,2.1166665 0 0 1 4.2333332,290.65 2.1166665,2.1166665 0 0 1 5.6068927,288.66924 Z"
+       id="path12788"
+       inkscape:connector-curvature="0" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path13370"
+       cx="6.3499999"
+       cy="290.64999"
+       r="0.52916664" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-speaker-right-back-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-speaker-right-back-testing.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-speaker-right-back-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="18.163806"
+     inkscape:cy="23.643884"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 10.31875,287.21041 v 3.96875 l 1.452828,1.50484 c 0,0 -0.01291,0.99064 -1.196058,2.17378 -1.1831483,1.18315 -2.1715377,1.19382 -2.1715377,1.19382 l -1.5248175,-1.43285 h -3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8791673,287.73958 -2e-7,0.79363 H 6.481791 c -1.3150293,-2.4e-4 -2.2492587,1.19869 -2.2490186,2.51372 l 5.61e-4,0.39682 H 3.4397035 l -5.612e-4,-0.39682 c 2.648e-4,-1.75313 1.2895189,-3.30709 3.0426487,-3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8791671,285.35845 v 0.79363 l -0.3968151,-5.6e-4 c -2.6303146,-3.5e-4 -4.6311805,2.2651 -4.6308298,4.89541 l 5.613e-4,0.39682 H 1.0584534 l -5.613e-4,-0.39682 c 1.538e-4,-3.06841 2.3560448,-5.68889 5.4244599,-5.68904 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-speaker-right-side-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-speaker-right-side-testing.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-speaker-right-side-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="45.875"
+     inkscape:cy="31.375"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 6.3500041,295.94167 2.7781249,-2.90989 h 2.086769 c 0,0 0.691356,-0.70961 0.691356,-2.38284 0,-1.67322 -0.691356,-2.37966 -0.691356,-2.37966 H 9.128129 l -2.7781249,-2.90989 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 4.3465791,293.09052 0.5611812,-0.56118 -0.2809874,-0.28099 a 2.3804562,2.3804562 0 0 1 0,-3.36709 l 0.2809874,-0.28019 -0.5611812,-0.56118 -0.2809875,0.28019 a 3.175,3.175 0 0 0 0,4.48945 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 2.6630354,294.77406 0.5611812,-0.56118 -0.2809875,-0.28019 a 4.7617062,4.7617062 0 0 1 0,-6.73497 l 0.2809875,-0.2802 -0.5611812,-0.56118 -0.2809875,0.2802 a 5.5562499,5.5562499 0 0 0 0,7.85733 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-speaker-right-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-speaker-right-testing.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-speaker-right-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.656854"
+     inkscape:cx="-30.140428"
+     inkscape:cy="25.72101"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       sodipodi:nodetypes="cccscccc"
+       style="fill:#808080;stroke-width:0.26458335"
+       inkscape:connector-curvature="0"
+       id="path7100"
+       d="m 10.319191,294.08915 v -3.96875 l 1.452828,-1.50484 c 0,0 -0.01291,-0.99064 -1.196058,-2.17378 -1.1831483,-1.18315 -2.1715377,-1.19382 -2.1715377,-1.19382 l -1.5248175,1.43285 h -3.96875 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7102"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8796083,293.55998 -2e-7,-0.79363 H 6.482232 c -1.3150293,2.4e-4 -2.2492587,-1.19869 -2.2490186,-2.51372 l 5.61e-4,-0.39682 H 3.4401445 l -5.612e-4,0.39682 c 2.648e-4,1.75313 1.2895189,3.30709 3.0426487,3.30735 z" />
+    <path
+       sodipodi:nodetypes="ccccccccc"
+       inkscape:connector-curvature="0"
+       id="path7104"
+       overflow="visible"
+       font-weight="400"
+       style="color:#000000;font-weight:400;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#00ff01;stroke-width:0.26458335;fill-opacity:1"
+       d="m 6.8796081,295.94111 v -0.79363 l -0.3968151,5.6e-4 c -2.6303146,3.5e-4 -4.6311805,-2.2651 -4.6308298,-4.89541 l 5.613e-4,-0.39682 H 1.0588944 l -5.613e-4,0.39682 c 1.538e-4,3.06841 2.3560448,5.68889 5.4244599,5.68904 z" />
+  </g>
+</svg>

--- a/icons/src/fullcolor/accented/devices/audio-subwoofer-testing.svg
+++ b/icons/src/fullcolor/accented/devices/audio-subwoofer-testing.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11382"
+   inkscape:version="1.1.1 (eb90963e84, 2021-10-02)"
+   sodipodi:docname="audio-subwoofer-testing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs11376" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="61.783456"
+     inkscape:cy="38.625708"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11927" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata11379">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:1.00199997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       d="M 24 11 A 12.999999 12.999999 0 0 0 19.441406 11.84375 L 19.441406 11.841797 A 12.999999 12.999999 0 0 0 19.404297 11.861328 A 12.999999 12.999999 0 0 0 18.316406 12.332031 A 12.999999 12.999999 0 0 0 18.201172 12.386719 A 12.999999 12.999999 0 0 0 17.171875 12.962891 A 12.999999 12.999999 0 0 0 17.078125 13.019531 A 12.999999 12.999999 0 0 0 16.142578 13.669922 A 12.999999 12.999999 0 0 0 15.980469 13.792969 A 12.999999 12.999999 0 0 0 15.203125 14.458984 A 12.999999 12.999999 0 0 0 14.960938 14.683594 A 12.999999 12.999999 0 0 0 14.308594 15.369141 A 12.999999 12.999999 0 0 0 14.072266 15.636719 A 12.999999 12.999999 0 0 0 13.523438 16.341797 A 12.999999 12.999999 0 0 0 13.257812 16.712891 A 12.999999 12.999999 0 0 0 12.826172 17.398438 A 12.999999 12.999999 0 0 0 12.576172 17.832031 A 12.999999 12.999999 0 0 0 12.246094 18.490234 A 12.999999 12.999999 0 0 0 11.998047 19.048828 A 12.999999 12.999999 0 0 0 11.833984 19.441406 L 11.847656 19.445312 A 12.999999 12.999999 0 0 0 11 24.001953 A 12.999999 12.999999 0 0 0 11.845703 28.560547 L 11.841797 28.560547 A 12.999999 12.999999 0 0 0 11.859375 28.59375 A 12.999999 12.999999 0 0 0 12.308594 29.640625 A 12.999999 12.999999 0 0 0 12.400391 29.828125 A 12.999999 12.999999 0 0 0 12.933594 30.785156 A 12.999999 12.999999 0 0 0 13.033203 30.949219 A 12.999999 12.999999 0 0 0 13.666016 31.853516 A 12.999999 12.999999 0 0 0 13.791016 32.017578 A 12.999999 12.999999 0 0 0 14.455078 32.796875 A 12.999999 12.999999 0 0 0 14.683594 33.041016 A 12.999999 12.999999 0 0 0 15.341797 33.671875 A 12.999999 12.999999 0 0 0 15.650391 33.941406 A 12.999999 12.999999 0 0 0 16.332031 34.472656 A 12.999999 12.999999 0 0 0 16.712891 34.744141 A 12.999999 12.999999 0 0 0 17.375 35.162109 A 12.999999 12.999999 0 0 0 17.84375 35.429688 A 12.999999 12.999999 0 0 0 18.46875 35.744141 A 12.999999 12.999999 0 0 0 19.072266 36.011719 A 12.999999 12.999999 0 0 0 19.439453 36.166016 L 19.443359 36.150391 A 12.999999 12.999999 0 0 0 24 36.998047 A 12.999999 12.999999 0 0 0 28.558594 36.154297 L 28.558594 36.15625 A 12.999999 12.999999 0 0 0 28.595703 36.136719 A 12.999999 12.999999 0 0 0 29.671875 35.669922 A 12.999999 12.999999 0 0 0 29.806641 35.605469 A 12.999999 12.999999 0 0 0 30.802734 35.048828 A 12.999999 12.999999 0 0 0 30.941406 34.966797 A 12.999999 12.999999 0 0 0 31.832031 34.345703 A 12.999999 12.999999 0 0 0 32.037109 34.189453 A 12.999999 12.999999 0 0 0 32.78125 33.554688 A 12.999999 12.999999 0 0 0 33.042969 33.308594 A 12.999999 12.999999 0 0 0 33.677734 32.642578 A 12.999999 12.999999 0 0 0 33.941406 32.34375 A 12.999999 12.999999 0 0 0 34.451172 31.691406 A 12.999999 12.999999 0 0 0 34.757812 31.257812 A 12.999999 12.999999 0 0 0 35.146484 30.640625 A 12.999999 12.999999 0 0 0 35.439453 30.132812 A 12.999999 12.999999 0 0 0 35.730469 29.548828 A 12.999999 12.999999 0 0 0 36.013672 28.916016 A 12.999999 12.999999 0 0 0 36.166016 28.556641 L 36.152344 28.552734 A 12.999999 12.999999 0 0 0 37 23.996094 A 12.999999 12.999999 0 0 0 36.154297 19.4375 L 36.158203 19.4375 A 12.999999 12.999999 0 0 0 36.140625 19.404297 A 12.999999 12.999999 0 0 0 35.669922 18.316406 A 12.999999 12.999999 0 0 0 35.615234 18.201172 A 12.999999 12.999999 0 0 0 35.041016 17.171875 A 12.999999 12.999999 0 0 0 34.982422 17.076172 A 12.999999 12.999999 0 0 0 34.332031 16.142578 A 12.999999 12.999999 0 0 0 34.210938 15.982422 A 12.999999 12.999999 0 0 0 33.521484 15.177734 A 12.999999 12.999999 0 0 0 33.335938 14.978516 A 12.999999 12.999999 0 0 0 32.628906 14.302734 A 12.999999 12.999999 0 0 0 32.367188 14.074219 A 12.999999 12.999999 0 0 0 31.640625 13.505859 A 12.999999 12.999999 0 0 0 31.304688 13.267578 A 12.999999 12.999999 0 0 0 30.597656 12.822266 A 12.999999 12.999999 0 0 0 30.171875 12.578125 A 12.999999 12.999999 0 0 0 29.509766 12.246094 A 12.999999 12.999999 0 0 0 28.9375 11.992188 A 12.999999 12.999999 0 0 0 28.560547 11.832031 L 28.556641 11.847656 A 12.999999 12.999999 0 0 0 24 11 z M 24 14 A 9.9999997 9.9999997 0 0 1 34 24 A 9.9999997 9.9999997 0 0 1 24 34 A 9.9999997 9.9999997 0 0 1 14 24 A 9.9999997 9.9999997 0 0 1 24 14 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,284.3)"
+       id="path13990" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#00ff01;fill-opacity:1;stroke:none;stroke-width:0.26511249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path13370"
+       cx="6.3499999"
+       cy="290.64999"
+       r="1.0583333" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#808080;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="rect13997"
+       width="9.7895832"
+       height="9.7895832"
+       x="1.4552083"
+       y="285.75522"
+       rx="0.97895831"
+       ry="0.97895831" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004"
+       cx="3.175"
+       cy="287.47501"
+       r="0.5291667" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004-1"
+       cx="9.5249996"
+       cy="287.47501"
+       r="0.52916676" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004-2"
+       cx="3.175"
+       cy="293.82501"
+       r="0.52916676" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.79374999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+       id="path14004-1-7"
+       cx="9.5249996"
+       cy="293.82501"
+       r="0.52916682" />
+  </g>
+</svg>


### PR DESCRIPTION
Make possible to add accent to more icons, we were not including them.

I've simply replaced the color with the accent "magic", but more tuning could be done. But I think they look good enough this way.

I simply didn't find the right shades to apply so far, but I feel that using a scss transformation to get some better colors could be still used (as per `common/yaru-colors-defs.scss`).