### PR TITLE
icons: Add symlinks for fullcolor printer and printers icons

### DIFF
--- a/icons/Yaru/16x16/actions/printer.png
+++ b/icons/Yaru/16x16/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/16x16/actions/printers.png
+++ b/icons/Yaru/16x16/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/16x16@2x/actions/printer.png
+++ b/icons/Yaru/16x16@2x/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/16x16@2x/actions/printers.png
+++ b/icons/Yaru/16x16@2x/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/22x22/actions/printer.png
+++ b/icons/Yaru/22x22/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/22x22/actions/printers.png
+++ b/icons/Yaru/22x22/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/24x24/actions/printer.png
+++ b/icons/Yaru/24x24/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/24x24/actions/printers.png
+++ b/icons/Yaru/24x24/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/24x24@2x/actions/printer.png
+++ b/icons/Yaru/24x24@2x/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/24x24@2x/actions/printers.png
+++ b/icons/Yaru/24x24@2x/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/256x256/actions/printer.png
+++ b/icons/Yaru/256x256/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/256x256/actions/printers.png
+++ b/icons/Yaru/256x256/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/256x256@2x/actions/printer.png
+++ b/icons/Yaru/256x256@2x/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/256x256@2x/actions/printers.png
+++ b/icons/Yaru/256x256@2x/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/32x32/actions/printer.png
+++ b/icons/Yaru/32x32/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/32x32/actions/printers.png
+++ b/icons/Yaru/32x32/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/32x32@2x/actions/printer.png
+++ b/icons/Yaru/32x32@2x/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/32x32@2x/actions/printers.png
+++ b/icons/Yaru/32x32@2x/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/48x48/actions/printer.png
+++ b/icons/Yaru/48x48/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/48x48/actions/printers.png
+++ b/icons/Yaru/48x48/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/48x48@2x/actions/printer.png
+++ b/icons/Yaru/48x48@2x/actions/printer.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/Yaru/48x48@2x/actions/printers.png
+++ b/icons/Yaru/48x48@2x/actions/printers.png
@@ -1,0 +1,1 @@
+document-print.png

--- a/icons/src/symlinks/fullcolor/actions.list
+++ b/icons/src/symlinks/fullcolor/actions.list
@@ -28,6 +28,8 @@ document-open.png gtk-open.png
 document-print.png fileprint.png
 document-print.png gtk-print.png
 document-print.png stock_print.png
+document-print.png printer.png
+document-print.png printers.png
 document-print-preview.png gtk-print-preview.png
 document-print-preview.png stock_print-preview.png
 document-properties.png gtk-properties.png


### PR DESCRIPTION
The pull request adds symlinks for fullcolour `printer` and `printers` icons used by `system-config-printer`. 

`system-config-printer.desktop` is hidden from GNOME and KDE so this fix is for other desktop environments, such as MATE.