### PR TITLE
icons: Fix preferences-system.png collision and add time-admin.png symlinks

### DIFF
--- a/icons/Yaru/16x16/categories/preferences-system.png
+++ b/icons/Yaru/16x16/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/16x16/categories/time-admin.png
+++ b/icons/Yaru/16x16/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/Yaru/16x16@2x/categories/preferences-system.png
+++ b/icons/Yaru/16x16@2x/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/16x16@2x/categories/time-admin.png
+++ b/icons/Yaru/16x16@2x/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/Yaru/24x24/categories/preferences-system.png
+++ b/icons/Yaru/24x24/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/24x24/categories/time-admin.png
+++ b/icons/Yaru/24x24/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/Yaru/24x24@2x/categories/preferences-system.png
+++ b/icons/Yaru/24x24@2x/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/24x24@2x/categories/time-admin.png
+++ b/icons/Yaru/24x24@2x/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/Yaru/256x256/categories/preferences-system.png
+++ b/icons/Yaru/256x256/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/256x256/categories/time-admin.png
+++ b/icons/Yaru/256x256/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/Yaru/256x256@2x/categories/preferences-system.png
+++ b/icons/Yaru/256x256@2x/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/256x256@2x/categories/time-admin.png
+++ b/icons/Yaru/256x256@2x/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/Yaru/32x32/categories/preferences-system.png
+++ b/icons/Yaru/32x32/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/32x32/categories/time-admin.png
+++ b/icons/Yaru/32x32/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/Yaru/32x32@2x/categories/preferences-system.png
+++ b/icons/Yaru/32x32@2x/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/32x32@2x/categories/time-admin.png
+++ b/icons/Yaru/32x32@2x/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/Yaru/48x48/categories/preferences-system.png
+++ b/icons/Yaru/48x48/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/48x48/categories/time-admin.png
+++ b/icons/Yaru/48x48/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/Yaru/48x48@2x/categories/preferences-system.png
+++ b/icons/Yaru/48x48@2x/categories/preferences-system.png
@@ -1,1 +1,0 @@
-system-component-application.png

--- a/icons/Yaru/48x48@2x/categories/time-admin.png
+++ b/icons/Yaru/48x48@2x/categories/time-admin.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/icons/src/symlinks/fullcolor/categories.list
+++ b/icons/src/symlinks/fullcolor/categories.list
@@ -16,6 +16,7 @@ preferences-system-power.png mate-power-manager.png
 preferences-system-power.png unity-power-panel.png
 preferences-system-sound.png unity-sound-panel.png
 preferences-system-time.png unity-datetime-panel.png
+preferences-system-time.png time-admin.png
 preferences-system-users.png system-users.png
 preferences-system-users.png preferences-desktop-personal.png
 preferences-system-users.png config-users.png

--- a/icons/src/symlinks/fullcolor/categories.list
+++ b/icons/src/symlinks/fullcolor/categories.list
@@ -20,7 +20,6 @@ preferences-system-users.png system-users.png
 preferences-system-users.png preferences-desktop-personal.png
 preferences-system-users.png config-users.png
 system-component-application.png system-component-runtime.png
-system-component-application.png preferences-system.png
 system-component-driver.png system-component-firmware.png
 system-component-addon.png application-x-addon.png
 system-component-input-sources.png preferences-desktop-peripherals.png


### PR DESCRIPTION
This pull request removes a name for `preferences-system.png` introduced by me via:
 
 * https://github.com/ubuntu/yaru/pull/3564/commits/ad8a71e47564455569b019151402ce1d196ca857#diff-69d67af295f2cc984f4cea2a75d69a28965a30c49500ad3ddeecff05db8d52afR23

It also adds a `time-admin.png` symlink.