### PR TITLE
GS: fix entries border radius

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -45,7 +45,7 @@
   @if $t==focus {
     background-color: if($variant == 'light', lighten($bg_color, 5%), $dash_background_color); // Yaru: use same background as dash for dark theme
     border-color: $fc;
-    box-shadow: 0 0 0 1px $fc; // Yaru change: trick to get 2px border on focus without layout shifting
+    box-shadow: 0 0 0 1px $fc inset; // Yaru change: trick to get 2px border on focus without layout shifting
     color: $fg_color;
     &:hover {}
   }


### PR DESCRIPTION
Just use inset box-shadow instead of previous outset one.

**Before:**

![Capture d’écran du 2022-04-02 12-00-57](https://user-images.githubusercontent.com/36476595/161378106-0d2f99b9-bc65-4e39-83a6-d4999b23139f.png)

**After:**

![Capture d’écran du 2022-04-02 11-58-18](https://user-images.githubusercontent.com/36476595/161378082-22e24cd9-39bf-41a2-bd7f-4b8b3e5a8c21.png)

Closes  #3583
