### PR TITLE
Sync Gtk popover/menu bg with GS

### DIFF
--- a/gtk/src/default/gtk-3.0/_colors.scss
+++ b/gtk/src/default/gtk-3.0/_colors.scss
@@ -22,8 +22,8 @@ $link_visited_color: if($variant == 'light', darken($selected_bg_color, 20%), li
 $top_hilight: $borders_edge;
 $dark_fill: mix($borders_color, $bg_color, 50%);
 $headerbar_color: if($variant == 'light', lighten($bg_color, 5%), darken($bg_color, 3%));
-$menu_color: if($variant == 'light', $bg_color, $base_color);
-$popover_bg_color: if($variant == 'light', $bg_color, $base_color);
+$menu_color: if($variant == 'light', $bg_color, lighten($jet, 2%));
+$popover_bg_color: $menu_color;
 $popover_hover_color: transparentize($fg_color, 0.85);
 
 $scrollbar_bg_color: if($variant == 'light', mix($bg_color, $fg_color, 80%), mix($base_color, $bg_color, 50%));

--- a/gtk/src/default/gtk-4.0/_defaults.scss
+++ b/gtk/src/default/gtk-4.0/_defaults.scss
@@ -56,7 +56,7 @@
 @define-color card_shade_color #{if($variant == 'light', transparentize(black, .93), transparentize(black, .64))};
 
 // Popovers
-@define-color popover_bg_color #{if($variant == 'light', #ffffff, #383838)};
+@define-color popover_bg_color #{if($variant == 'light', #ffffff, lighten($dark_4, 2%))};
 @define-color popover_fg_color #{if($variant == 'light', transparentize(black, .2), white)};
 
 // Miscellaneous


### PR DESCRIPTION
![Capture d’écran du 2022-04-02 12-16-36](https://user-images.githubusercontent.com/36476595/161378783-26e3a7b8-48cd-47dc-92a8-ba7ccb794592.png)

**Note:** `$dark_4` = `$jet` in Gtk4 colors.