### PR TITLE
metacity: Define the base button dimensions and ensure dialog windows have a close button. Close #3602

### DIFF
--- a/metacity/src/default/metacity-theme-1.xml.in
+++ b/metacity/src/default/metacity-theme-1.xml.in
@@ -653,7 +653,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="dialog_focused" geometry="nobuttons">
+	<frame_style name="dialog_focused" geometry="normal">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
@@ -686,7 +686,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="dialog_unfocused" geometry="nobuttons">
+	<frame_style name="dialog_unfocused" geometry="normal">
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
@@ -719,7 +719,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="dialog_shaded_focused" geometry="nobuttons_shaded">
+	<frame_style name="dialog_shaded_focused" geometry="normal_shaded">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
@@ -752,7 +752,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="dialog_shaded_unfocused" geometry="nobuttons_shaded">
+	<frame_style name="dialog_shaded_unfocused" geometry="normal_shaded">
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />

--- a/metacity/src/default/metacity-theme-1.xml.in
+++ b/metacity/src/default/metacity-theme-1.xml.in
@@ -4,7 +4,7 @@
 		<name>@FlavourThemeName@</name>
 		<author>Martin Wimpress</author>
 		<copyright>Martin Wimpress, 2021-2022</copyright>
-		<date>March 24, 2022</date>
+		<date>April 11, 2022</date>
 		<description>@FlavourThemeName@ Metacity (Marco) Theme</description>
 	</info>
 
@@ -290,102 +290,102 @@
 
 	<!-- Close icon -->
 	<draw_ops name="close_focused">
-		<image filename="close_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="close_focused_normal.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="close_focused_prelight">
-		<image filename="close_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="close_focused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="close_focused_pressed">
-		<image filename="close_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="close_focused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="close_unfocused">
-		<image filename="close_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="close_unfocused.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="close_unfocused_prelight">
-		<image filename="close_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="close_unfocused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="close_unfocused_pressed">
-		<image filename="close_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="close_unfocused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 
 	<!-- Maximize icon -->
 	<draw_ops name="maximize_focused">
-		<image filename="maximize_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="maximize_focused_normal.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="maximize_focused_prelight">
-		<image filename="maximize_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="maximize_focused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="maximize_focused_pressed">
-		<image filename="maximize_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="maximize_focused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="maximize_unfocused">
-		<image filename="maximize_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="maximize_unfocused.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="maximize_unfocused_prelight">
-		<image filename="maximize_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="maximize_unfocused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="maximize_unfocused_pressed">
-		<image filename="maximize_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="maximize_unfocused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 
 	<!-- Unmaximize icon -->
 	<draw_ops name="unmaximize_focused">
-		<image filename="unmaximize_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="unmaximize_focused_normal.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="unmaximize_focused_prelight">
-		<image filename="unmaximize_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="unmaximize_focused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="unmaximize_focused_pressed">
-		<image filename="unmaximize_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="unmaximize_focused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="unmaximize_unfocused">
-		<image filename="unmaximize_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="unmaximize_unfocused.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="unmaximize_unfocused_prelight">
-		<image filename="unmaximize_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="unmaximize_unfocused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="unmaximize_unfocused_pressed">
-		<image filename="unmaximize_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="unmaximize_unfocused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 
 	<!-- Minimize icon -->
 	<draw_ops name="minimize_focused">
-		<image filename="minimize_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="minimize_focused_normal.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="minimize_focused_prelight">
-		<image filename="minimize_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="minimize_focused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="minimize_focused_pressed">
-		<image filename="minimize_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="minimize_focused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="minimize_unfocused">
-		<image filename="minimize_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="minimize_unfocused.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="minimize_unfocused_prelight">
-		<image filename="minimize_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="minimize_unfocused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="minimize_unfocused_pressed">
-		<image filename="minimize_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="minimize_unfocused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 
 	<!-- Menu icon -->
 	<draw_ops name="menu_focused">
-		<image filename="menu_focused_normal.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="menu_focused_normal.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="menu_focused_prelight">
-		<image filename="menu_focused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="menu_focused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="menu_focused_pressed">
-		<image filename="menu_focused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="menu_focused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="menu_unfocused">
-		<image filename="menu_unfocused.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="menu_unfocused.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="menu_unfocused_prelight">
-		<image filename="menu_unfocused_prelight.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="menu_unfocused_prelight.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 	<draw_ops name="menu_unfocused_pressed">
-		<image filename="menu_unfocused_pressed.svg" x="0" y="2" width="object_width" height="object_height" />
+		<image filename="menu_unfocused_pressed.svg" x="0" y="3" width="24" height="24" />
 	</draw_ops>
 
 	<!-- FRAME STYLES -->


### PR DESCRIPTION
This pull request defines the base window button dimensions and is used to determine whether the image needs to be re-scaled when rendering on different DPI densities. See https://pad.lv/1967507 Tested on regular DPI displays and Thinkpad P1 with 3840x2160 HiDPI using Intel iGP and NVIDIA dGPU. Close #3602

It also adds window buttons to dialog windows ensuring they will always have a close window button.