### PR TITLE
Gtk: remove windowcontrols button background on backdrop

### DIFF
--- a/gtk/src/default/gtk-3.0/_tweaks.scss
+++ b/gtk/src/default/gtk-3.0/_tweaks.scss
@@ -102,28 +102,33 @@ button.titlebutton:not(.appmenu) {
   & {
     &.maximize, &.minimize, &.close {
       @include draw_circle($_close_button_color);
-      &, &:backdrop {
-        &:hover {
-          @include draw_circle($_base_hover_color);
-        }
 
-        &:active {
-          @include draw_circle($_base_active_color);
-        }
+      &:hover {
+        @include draw_circle($_base_hover_color);
+      }
+
+      &:active {
+        @include draw_circle($_base_active_color);
+      }
+
+      &:backdrop {
+        background: none;
       }
     }
 
     window.toolbox &.close { // Special selector to target unified window (see #2980)
       color: $fg_color;
 
-      &, &:backdrop {
-        &:hover {
-          @include draw_circle($_base_hover_color);
-        }
+      &:hover {
+        @include draw_circle($_base_hover_color);
+      }
 
-        &:active {
-          @include draw_circle($_base_active_color);
-        }
+      &:active {
+        @include draw_circle($_base_active_color);
+      }
+
+      &:backdrop {
+        background: none;
       }
     }
   }


### PR DESCRIPTION
**Before:**

![Capture d’écran du 2022-04-12 12-20-37](https://user-images.githubusercontent.com/36476595/162939535-ce2d0e25-8fae-42e5-87ad-d1de779d36f5.png)

**After:**

![Capture d’écran du 2022-04-12 12-09-57](https://user-images.githubusercontent.com/36476595/162939223-8cdd2163-a363-4203-bb2d-5bdd738ebab1.png)

Closes #3588