### PR TITLE
Sync with Libadwaita symbolics 3614

### DIFF
--- a/icons/Yaru/scalable/actions/adw-entry-apply-symbolic.svg
+++ b/icons/Yaru/scalable/actions/adw-entry-apply-symbolic.svg
@@ -1,0 +1,1 @@
+object-select-symbolic.svg

--- a/icons/src/symlinks/symbolic/actions.list
+++ b/icons/src/symlinks/symbolic/actions.list
@@ -48,6 +48,7 @@ media-view-subtitles-symbolic.svg annotations-text-symbolic.svg
 multimedia-equalizer-symbolic.svg media-eq-symbolic.svg
 multimedia-equalizer-symbolic.svg org.gnome.Lollypop-equalizer-symbolic.svg
 object-select-symbolic.svg background-selected-symbolic.svg
+object-select-symbolic.svg adw-entry-apply-symbolic.svg
 scan-type-batch-symbolic.svg slideshow-symbolic.svg
 sidebar-show-right-symbolic.svg sidebar-show-rtl-symbolic.svg
 sidebar-show-symbolic.svg builder-view-left-pane-symbolic.svg


### PR DESCRIPTION
Symlink new `adw-entry-apply-symbolic` with `object-select-symbolic`.

Related to #3614 