### PR TITLE
Sync symbolic icons with upstream 3657

### DIFF
--- a/icons/Yaru/scalable/actions/adw-mail-send-symbolic.svg
+++ b/icons/Yaru/scalable/actions/adw-mail-send-symbolic.svg
@@ -1,0 +1,1 @@
+document-send-symbolic.svg

--- a/icons/Yaru/scalable/emblems/adw-external-link-symbolic.svg
+++ b/icons/Yaru/scalable/emblems/adw-external-link-symbolic.svg
@@ -1,0 +1,1 @@
+external-link-symbolic.svg

--- a/icons/src/symlinks/symbolic/actions.list
+++ b/icons/src/symlinks/symbolic/actions.list
@@ -42,6 +42,7 @@ mail-reply-all-symbolic-rtl.svg mail-reply-all-rtl-symbolic-rtl.svg
 mail-reply-sender-symbolic-rtl.svg mail-reply-sender-rtl-symbolic.svg
 mail-reply-sender-symbolic.svg mail-forward-rtl-symbolic.svg
 mail-reply-sender-symbolic.svg mail-reply-symbolic.svg
+document-send-symbolic.svg adw-mail-send-symbolic.svg
 mail-send-symbolic-rtl.svg mail-sent-symbolic-rtl.svg
 marker-symbolic.svg mail-flag-symbolic.svg
 media-view-subtitles-symbolic.svg annotations-text-symbolic.svg

--- a/icons/src/symlinks/symbolic/emblems.list
+++ b/icons/src/symlinks/symbolic/emblems.list
@@ -1,2 +1,3 @@
 emblem-videos-symbolic.svg yelp-page-video-symbolic.svg
 explore-symbolic.svg explore2-symbolic.svg
+external-link-symbolic.svg adw-external-link-symbolic.svg


### PR DESCRIPTION
Symlink:
- **document-send-symbolic** to **adw-mail-send-symbolic**
- **external-link-symbolic** to **adw-external-link-symbolic**

Related to #3657