### PR TITLE
Sync GS with upstream - 3665

### DIFF
--- a/gnome-shell/src/data/icons/scalable/actions/dark-mode-symbolic.svg
+++ b/gnome-shell/src/data/icons/scalable/actions/dark-mode-symbolic.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg547"
+   sodipodi:docname="dark-mode-symbolic.svg"
+   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs551" />
+  <sodipodi:namedview
+     id="namedview549"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="-1.3559322"
+     inkscape:cy="9.9491526"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg547">
+    <inkscape:grid
+       type="xygrid"
+       id="grid670" />
+  </sodipodi:namedview>
+  <path
+     id="path724"
+     style="fill:#808080;fill-rule:evenodd;stroke-width:2;stroke-linecap:round;stroke-linejoin:round"
+     d="m 8,0 c -4.418278,0 -8,3.581722 -8,8 0,4.418278 3.581722,8 8,8 4.418278,0 8,-3.581722 8,-8 0,-4.418278 -3.581722,-8 -8,-8 z m 0,1 c 3.865993,0 7,3.1340068 7,7 0,3.865993 -3.134007,7 -7,7 z"
+     sodipodi:nodetypes="ssssscscc" />
+</svg>


### PR DESCRIPTION
**New icon:**

![Capture d’écran du 2022-08-11 11-46-57](https://user-images.githubusercontent.com/36476595/184107604-faa4b45f-d82d-40f0-9ab3-b70004120d80.png)

Related to #3665