### PR TITLE
Metacity: add missing dialog window controls in dark theme

### DIFF
--- a/metacity/src/dark/metacity-theme-1.xml.in
+++ b/metacity/src/dark/metacity-theme-1.xml.in
@@ -653,7 +653,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="dialog_focused" geometry="nobuttons">
+	<frame_style name="dialog_focused" geometry="normal">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
@@ -686,7 +686,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="dialog_unfocused" geometry="nobuttons">
+	<frame_style name="dialog_unfocused" geometry="normal">
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />
@@ -719,7 +719,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="dialog_shaded_focused" geometry="nobuttons_shaded">
+	<frame_style name="dialog_shaded_focused" geometry="normal_shaded">
 		<piece position="entire_background" draw_ops="entire_background_focused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_focused" />
 		<piece position="title" draw_ops="title_focused" />
@@ -752,7 +752,7 @@
 		<button function="unstick" state="pressed"><draw_ops></draw_ops></button>
 	</frame_style>
 
-	<frame_style name="dialog_shaded_unfocused" geometry="nobuttons_shaded">
+	<frame_style name="dialog_shaded_unfocused" geometry="normal_shaded">
 		<piece position="entire_background" draw_ops="entire_background_unfocused" />
 		<piece position="titlebar" draw_ops="titlebar_fill_unfocused" />
 		<piece position="title" draw_ops="title_unfocused" />


### PR DESCRIPTION
I'm setup a MATE VM to test this, but I'm 100% sure it will solve the problem.

Closes #3675