### PR TITLE
gitattributes: Exclude .github from tarball releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitattributes   export-ignore
+.github          export-ignore


### PR DESCRIPTION
The Debian package excludes this folder but I think it makes sense to do it here instead (so that tarball releases don't have this folder).