### PR TITLE
Add missing dark-mode-symbolic entry to gnome-shell-icons.gresource.xml

### DIFF
--- a/gnome-shell/src/data/gnome-shell-icons.gresource.xml
+++ b/gnome-shell/src/data/gnome-shell-icons.gresource.xml
@@ -4,6 +4,7 @@
     <file>scalable/actions/color-pick.svg</file>
     <file>scalable/actions/carousel-arrow-next-symbolic.svg</file>
     <file>scalable/actions/carousel-arrow-previous-symbolic.svg</file>
+    <file>scalable/actions/dark-mode-symbolic.svg</file>
     <file>scalable/actions/pointer-double-click-symbolic.svg</file>
     <file>scalable/actions/pointer-drag-symbolic.svg</file>
     <file>scalable/actions/pointer-primary-click-symbolic.svg</file>


### PR DESCRIPTION
Related to #3688