### PR TITLE
gtk: Optimize accent color definition taking background in account

### DIFF
--- a/common/sass-utils.scss
+++ b/common/sass-utils.scss
@@ -92,13 +92,20 @@
     @return null;
 }
 
-@function pow($base, $exponent) {
+@function pow($base, $exponent, $root: 1) {
     @if ($exponent == 0) {
         @return 1;
     }
 
     @if ($base == 0) {
         @return 0;
+    }
+
+    @if ($root != 1) {
+        @if ($exponent == $root) {
+            @return $base;
+        }
+        $base: nth-root($base, $root);
     }
 
     @if $exponent < 0 {
@@ -117,4 +124,39 @@
     }
 
     @return $val;
+}
+
+@function nth-root($value, $n, $max_iterations: 100) {
+    @if ($n <= 0) {
+        @error "Not supported"
+    }
+
+    @if ($n == 1 or $value == 0) {
+        @return $value;
+    }
+
+    $i: 1;
+    $pre-val: 1;
+    @while ($i < $max_iterations) {
+        $val: (1.0 / $n) * ((($n - 1) * $pre-val) + $value / pow($pre-val, $n - 1));
+
+        @if ($pre-val == $val) {
+            @return $val;
+        }
+
+        $pre-val: $val;
+        $i: $i + 1;
+    }
+
+    @error ("Failed to compute " + $n + "th root of " + $value + " in " +
+            $max_iterations + " iterations");
+}
+
+@function truncate($value, $decimals: 10) {
+    @if ($decimals < 0) {
+        @error "Not supported"
+    }
+
+    $multiplier: pow(10, $decimals);
+    @return floor($value * $multiplier) / $multiplier;
 }

--- a/common/sass-utils.scss
+++ b/common/sass-utils.scss
@@ -197,3 +197,16 @@
 
     @return ($lighter-luminance + 0.05) / ($darker-luminance + 0.05);
 }
+
+@function optimize-contrast($bg, $fg, $large-text: false, $target: 4.5) {
+    @if ($large-text and $target == 4.5) {
+        $target: 3;
+    }
+
+    $dark-bg: luminance($bg) < luminance($fg);
+    @while (color-contrast($bg, $fg) < $target) {
+        $fg: if($dark-bg, lighten($fg, 0.1), darken($fg, 0.1));
+    }
+
+    @return $fg;
+}

--- a/common/sass-utils.scss
+++ b/common/sass-utils.scss
@@ -160,3 +160,40 @@
     $multiplier: pow(10, $decimals);
     @return floor($value * $multiplier) / $multiplier;
 }
+
+// Credits to https://css-tricks.com/snippets/sass/luminance-color-function/
+@function luminance($color) {
+    $colors: (
+        'red': red($color),
+        'green': green($color),
+        'blue': blue($color)
+    );
+
+    @each $name, $value in $colors {
+        $adjusted: 0;
+        $value: $value / 255;
+
+        @if $value < 0.03928 {
+            $value: $value / 12.92;
+        } @else {
+            $value: ($value + .055) / 1.055;
+            $value: pow($value, 12, 5);
+        }
+
+        $colors: map-merge($colors, ($name: $value));
+    }
+
+    @return ((map-get($colors, 'red') * .2126) +
+             (map-get($colors, 'green') * .7152) +
+             (map-get($colors, 'blue') * .0722));
+}
+
+@function color-contrast($color1, $color2) {
+    $c1-luminance: luminance($color1);
+    $c2-luminance: luminance($color2);
+
+    $lighter-luminance: max($c1-luminance, $c2-luminance);
+    $darker-luminance: min($c1-luminance, $c2-luminance);
+
+    @return ($lighter-luminance + 0.05) / ($darker-luminance + 0.05);
+}

--- a/common/sass-utils.scss
+++ b/common/sass-utils.scss
@@ -63,30 +63,20 @@
 }
 
 @function list-length($list) {
-    $i: 0;
-    @each $e in $list {
-        $i: $i + 1;
-    }
-
-    @return $i;
+    @return length($list);
 }
 
 @function list-nth($list, $nth) {
-    $i: 0;
-
-    @if $nth < 0 {
-        $nth: list-length($list) + $nth;
+    $length: length($list);
+    @if ($length == 0 or abs($nth) > $length) {
+        @return null;
     }
 
-    @each $e in $list {
-        @if ($i == $nth) {
-            @return $e;
-        }
-
-        $i: $i + 1;
+    @if ($nth >= 0) {
+        $nth: $nth + 1;
     }
 
-    @return null;
+    @return nth($list, $nth);
 }
 
 @function list-index($list, $item) {

--- a/common/sass-utils.scss
+++ b/common/sass-utils.scss
@@ -91,3 +91,30 @@
 
     @return null;
 }
+
+@function pow($base, $exponent) {
+    @if ($exponent == 0) {
+        @return 1;
+    }
+
+    @if ($base == 0) {
+        @return 0;
+    }
+
+    @if $exponent < 0 {
+        $base: 1 / $base;
+        $exponent: -$exponent;
+    } @else if ($exponent % 2 == 0) {
+        $half-pow: pow($base, $exponent / 2);
+        @return $half-pow * $half-pow;
+    }
+
+    $i: 1;
+    $val: $base;
+    @while ($i < $exponent) {
+        $val: $val * $base;
+        $i: $i + 1;
+    }
+
+    @return $val;
+}

--- a/common/test-sass-utils.scss
+++ b/common/test-sass-utils.scss
@@ -129,3 +129,12 @@
 @debug test('truncate 5 0.12345678901234', truncate(0.12345678901234, 1), 0.1);
 @debug test('truncate 5 5.12345678901234', truncate(5.12345678901234, 0), 5);
 
+@debug test('luminance white', luminance(white), 1);
+@debug test('luminance black', luminance(black), 0);
+@debug test('luminance red', luminance(#f00), 0.2126);
+@debug test('luminance green', luminance(#0f0), 0.7152);
+@debug test('luminance blue', luminance(#00f), 0.0722);
+@debug test('luminance Ubuntu orange', truncate(luminance(#dd4814), 6), 0.200573);
+
+@debug test('color contrast black/white', color-contrast(white, black), 21);
+@debug test('color contrast blue/blue', color-contrast(blue, blue), 1);

--- a/common/test-sass-utils.scss
+++ b/common/test-sass-utils.scss
@@ -18,7 +18,12 @@
 @import 'sass-utils';
 
 @function assert($result, $expected: true) {
-    @if $result != $expected {
+    @if (type-of($result) == 'color' and type-of($expected) == 'color') {
+        $result: #{$result};
+        $expected: #{$expected};
+    }
+
+    @if ($result != $expected or type-of($result) != type-of($expected)) {
         $result: if($result == null, 'null', $result);
         $expected: if($expected == null, 'null', $expected);
         @error "Assertion failed, expected '" + $expected + "', got '" + $result + "'";

--- a/common/test-sass-utils.scss
+++ b/common/test-sass-utils.scss
@@ -102,6 +102,12 @@
 @debug test('list-index, Three, valid', list-index([1, '2', false], '2'), 1);
 @debug test('list-index, Three, valid', list-index([1, '2', false], false), 2);
 
+@debug test('nth-root 1-root of 0', nth-root(0, 1), 0);
+@debug test('nth-root 0-root of 0', nth-root(0, 20), 0);
+@debug test('nth-root 2-root of 4', nth-root(4, 2), 2);
+@debug test('nth-root 4-root of 256', nth-root(256, 4), 4);
+@debug test('nth-root 5-root of 4096', nth-root(4096.0, 5), 5.278031643091578);
+
 @debug test('pow 0^0', pow(0, 0), 1);
 @debug test('pow 1^0', pow(1, 0), 1);
 @debug test('pow 10^0', pow(10, 0), 1);
@@ -113,3 +119,13 @@
 
 @debug test('pow 2^-2', pow(2, -2), 1/4);
 @debug test('pow 3^-3', pow(3, -3), 1/27);
+
+@debug test('pow 2^(2/2)', pow(2, 2, 2), 2);
+@debug test('pow 2^(4/2)', pow(2, 4, 2), 4);
+@debug test('pow 2^(12/5)', pow(2, 12, 5), 5.278031643091582);
+
+@debug test('truncate 0.1234567890123456789', truncate(0.123456789123456789), 0.1234567891);
+@debug test('truncate 5 0.12345678901234', truncate(0.12345678901234, 5), 0.12345);
+@debug test('truncate 5 0.12345678901234', truncate(0.12345678901234, 1), 0.1);
+@debug test('truncate 5 5.12345678901234', truncate(5.12345678901234, 0), 5);
+

--- a/common/test-sass-utils.scss
+++ b/common/test-sass-utils.scss
@@ -101,3 +101,15 @@
 @debug test('list-index, Three, valid', list-index([1, '2', false], 1), 0);
 @debug test('list-index, Three, valid', list-index([1, '2', false], '2'), 1);
 @debug test('list-index, Three, valid', list-index([1, '2', false], false), 2);
+
+@debug test('pow 0^0', pow(0, 0), 1);
+@debug test('pow 1^0', pow(1, 0), 1);
+@debug test('pow 10^0', pow(10, 0), 1);
+
+@debug test('pow 0^10', pow(0, 10), 0);
+@debug test('pow 1^20', pow(1, 20), 1);
+@debug test('pow 2^8', pow(2, 8), 256);
+@debug test('pow 10^3', pow(10, 3), 1000);
+
+@debug test('pow 2^-2', pow(2, -2), 1/4);
+@debug test('pow 3^-3', pow(3, -3), 1/27);

--- a/common/test-sass-utils.scss
+++ b/common/test-sass-utils.scss
@@ -138,3 +138,6 @@
 
 @debug test('color contrast black/white', color-contrast(white, black), 21);
 @debug test('color contrast blue/blue', color-contrast(blue, blue), 1);
+
+@debug test('optimize-contrast black/blue', optimize-contrast(black, blue), #5e5eff);
+@debug test('optimize-contrast white/blue', optimize-contrast(white, lightgray), #767676);

--- a/gtk/src/default/gtk-3.0/_colors.scss
+++ b/gtk/src/default/gtk-3.0/_colors.scss
@@ -88,3 +88,8 @@ $coloured_focus_border_color: transparentize(white, 0.3);
 // Yaru: Ignore transformations when using dark accent colors
 $progress_bg_color: $accent_bg_color;
 $checkradio_bg_color: $accent_bg_color;
+
+// Optimize accent-color definition for default background colors
+@import 'sass-utils';
+$link_color: optimize-contrast($bg_color, $accent_bg_color);
+$link_visited_color: if($variant =='light', darken($link_color, 10%), lighten($link_color, 10%));

--- a/gtk/src/default/gtk-4.0/_colors.scss
+++ b/gtk/src/default/gtk-4.0/_colors.scss
@@ -76,3 +76,8 @@ $switch_borders_color: if($variant == 'light', darken($checkradio_bg_color, 10%)
 $focus_border_color: transparentize(lighten($accent_bg_color, 14%), 0.3);
 $alt_focus_border_color: if($variant == 'light', transparentize(white, 0.2), transparentize(white,0.7));
 $dim_label_opacity: 0.55;
+
+// Yaru: Optimize accent-color definition for default background colors
+@import 'sass-utils';
+$link_color: optimize-contrast($bg_color, $accent_bg_color);
+$link_visited_color: if($variant == 'light', darken($link_color, 10%), lighten($link_color, 10%));

--- a/gtk/src/meson.build
+++ b/gtk/src/meson.build
@@ -115,7 +115,7 @@ foreach flavour: flavours
 
       # Look for scss files in the variant dir first, otherwise fallback to
       # base, default or upstream paths, so using reversed order
-      scss_paths = []
+      scss_paths = ['-I', meson.project_source_root() / 'common']
       gtk_scss_dependencies = []
       foreach src: sources_priority
         scss_paths += ['-I', meson.current_source_dir() / src ]


### PR DESCRIPTION
Compute accent-color value (the one used by links, so far) to have a
contrast value to be optimized according to W3C requirements.

See: https://twitter.com/alexm_gnome/status/1526531918166212608