### PR TITLE
Wrong quick action button color on click

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_quick-settings.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_quick-settings.scss
@@ -75,7 +75,10 @@
       padding: 1.5 * $base_padding;
       background-color: lighten($bg_color, 10%);
 
-      &.active { background-color: $selected_bg_color; }
+      &.active {
+        background-color: $selected_bg_color;
+        color: $selected_fg_color; // Yaru change: fix for light theme
+      }
     }
 
     & .title {
@@ -85,6 +88,11 @@
     & .subtitle {
       @extend %caption_heading;
     }
+  }
+  
+  // Yaru change: fix for light theme
+  :active {
+    color: $fg_color !important;
   }
 }
 


### PR DESCRIPTION
**Before**

![Capture d’écran du 2022-08-29 15-35-30](https://user-images.githubusercontent.com/36476595/187213796-2902c1ff-0d4c-4383-9321-5e54c9d423f9.png)

**After:**

![Capture d’écran du 2022-08-29 15-36-38](https://user-images.githubusercontent.com/36476595/187214060-ee726eeb-b308-4c47-883b-18f6b0e17753.png)

Fixes #3706