### PR TITLE
App grid arrow use wrong color

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_app-grid.scss
@@ -156,7 +156,9 @@ $app_icon_size: 96px;
     width: 24px;
     height: 24px;
     border-radius: 99px;
+    @include button(undecorated, $osd_fg_color, transparentize($osd_bg_color, 0.5)); // Yaru change: fix for light theme
   }
+
 
   &:insensitive > StIcon { @include button(undecorated, $osd_fg_color, transparentize($osd_bg_color, 0.5));}
   &:hover > StIcon { @include button(hover, $osd_fg_color, transparentize($osd_bg_color, 0.5));}


### PR DESCRIPTION
**Before:**

![Capture d’écran du 2022-08-29 15-38-00](https://user-images.githubusercontent.com/36476595/187214455-8a09fac1-14fb-47d9-97f1-ae4dbc925279.png)

**After:**

![Capture d’écran du 2022-08-29 15-41-55](https://user-images.githubusercontent.com/36476595/187215191-19d1bd52-05bd-40b4-a819-3d534fa5cefa.png)

Fixes #3714