### PR TITLE
GS: calendar text not distinguishable in light style

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -41,7 +41,7 @@ $shadow_color: transparentize(black, 0.9);
 $button_mix_factor: 7%;
 
 // cards
-$card_bg_color: if($variant =='light', darken($bg_color, 5%), lighten($bg_color, 2%));
+$card_bg_color: if($variant =='light', darken($bg_color, 2%), lighten($bg_color, 2%));
 
 // notifications
 $bubble_buttons_color: if($variant =='light', darken($bg_color, 12%), lighten($bg_color, 10%));
@@ -50,7 +50,7 @@ $bubble_buttons_color: if($variant =='light', darken($bg_color, 12%), lighten($b
 $system_bg_color: lighten($jet, 4%); // Lighten than dash but darken than bg-color
 
 //insensitive state derived colors
-$insensitive_fg_color: mix($fg_color, $bg_color, 50%);
+$insensitive_fg_color: mix($fg_color, $bg_color, 65%);
 $insensitive_bg_color: mix($bg_color, $base_color, 60%);
 $insensitive_borders_color: $borders_color;
 


### PR DESCRIPTION
Fix text color accessibility problem in calendar.

- Increase a bit `$insensitive_fg_color` contrast ;
- Decrease a bit card bg color darkness in light theme.

**Before:**

![Capture d’écran du 2022-10-04 19-54-24](https://user-images.githubusercontent.com/36476595/193894450-82a2ca1e-d519-491b-83d8-b13530e6c5a1.png)
![Capture d’écran du 2022-10-04 20-11-19](https://user-images.githubusercontent.com/36476595/193894454-fecbdf1e-ab91-4df3-b1ad-81e6907772e9.png)

**After:**

![Capture d’écran du 2022-10-04 20-24-08](https://user-images.githubusercontent.com/36476595/193896906-033f46d6-d50f-4bce-88f2-523d5e11aa15.png)
![Capture d’écran du 2022-10-04 20-26-22](https://user-images.githubusercontent.com/36476595/193896896-7652f72b-5c59-4e35-8280-9918cdbca042.png)

Fixes #3748