### PR TITLE
Sync icon theme with upstream

### DIFF
--- a/icons/Yaru/scalable/mimetypes/application-x-sharedlib-symbolic.svg
+++ b/icons/Yaru/scalable/mimetypes/application-x-sharedlib-symbolic.svg
@@ -1,0 +1,1 @@
+../apps/application-x-executable-symbolic.svg

--- a/icons/src/symlinks/symbolic/mimetypes.list
+++ b/icons/src/symlinks/symbolic/mimetypes.list
@@ -1,0 +1,1 @@
+../apps/application-x-executable-symbolic.svg application-x-sharedlib-symbolic.svg


### PR DESCRIPTION
Sync icon theme with upstream #3765

See [upstream icon](https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/blob/master/Adwaita/scalable/mimetypes/application-x-sharedlib-symbolic.svg).