### PR TITLE
Timeshift icons overridden with backups icon

### DIFF
--- a/icons/Yaru/16x16/apps/timeshift.png
+++ b/icons/Yaru/16x16/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/16x16@2x/apps/timeshift.png
+++ b/icons/Yaru/16x16@2x/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/24x24/apps/timeshift.png
+++ b/icons/Yaru/24x24/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/24x24@2x/apps/timeshift.png
+++ b/icons/Yaru/24x24@2x/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/256x256/apps/timeshift.png
+++ b/icons/Yaru/256x256/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/256x256@2x/apps/timeshift.png
+++ b/icons/Yaru/256x256@2x/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/32x32/apps/timeshift.png
+++ b/icons/Yaru/32x32/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/32x32@2x/apps/timeshift.png
+++ b/icons/Yaru/32x32@2x/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/48x48/apps/timeshift.png
+++ b/icons/Yaru/48x48/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/48x48@2x/apps/timeshift.png
+++ b/icons/Yaru/48x48@2x/apps/timeshift.png
@@ -1,1 +1,0 @@
-backups-app.png

--- a/icons/Yaru/scalable/apps/timeshift-symbolic.svg
+++ b/icons/Yaru/scalable/apps/timeshift-symbolic.svg
@@ -1,1 +1,0 @@
-backups-app-symbolic.svg

--- a/icons/src/symlinks/fullcolor/apps.list
+++ b/icons/src/symlinks/fullcolor/apps.list
@@ -11,7 +11,6 @@ address-book-app.png x-office-address-book.png
 screenshot-app.png org.gnome.Screenshot.png
 backups-app.png deja-dup.png
 backups-app.png org.gnome.DejaDup.png
-backups-app.png timeshift.png
 disk-usage-app.png org.gnome.baobab.png
 calculator-app.png accessories-calculator.png
 calculator-app.png gnome-calculator.png

--- a/icons/src/symlinks/symbolic/apps.list
+++ b/icons/src/symlinks/symbolic/apps.list
@@ -12,7 +12,6 @@ address-book-app-symbolic.svg x-office-address-book-symbolic.svg
 aptdaemon-download-symbolic.svg synaptic-symbolic.svg
 backups-app-symbolic.svg deja-dup-symbolic.svg
 backups-app-symbolic.svg org.gnome.DejaDup-symbolic.svg
-backups-app-symbolic.svg timeshift-symbolic.svg
 calculator-app-symbolic.svg accessories-calculator-symbolic.svg
 calculator-app-symbolic.svg gnome-calculator-symbolic.svg
 calculator-app-symbolic.svg org.gnome.Calculator-symbolic.svg


### PR DESCRIPTION
@Muqtxdir Timeshift isn't a pre-installed app, and I agree with the linked issue comment that it can be confusing with Déjà-dup, WDYT?

Fixes #3816
Revert #3477