### PR TITLE
Sync icon theme with upstream

### DIFF
--- a/icons/Yaru/scalable/devices/computer-chip-symbolic.svg
+++ b/icons/Yaru/scalable/devices/computer-chip-symbolic.svg
@@ -1,0 +1,1 @@
+../apps/jockey-symbolic.svg

--- a/icons/src/symlinks/symbolic/devices.list
+++ b/icons/src/symlinks/symbolic/devices.list
@@ -1,6 +1,7 @@
 audio-speakers-rtl-symbolic.svg audio-speakers-symbolic-rtl.svg
 audio-speakers-bluetooth-rtl-symbolic.svg audio-speakers-bluetooth-symbolic-rtl.svg
 auth-fingerprint-symbolic.svg fingerprint-detection-symbolic.svg
+../apps/jockey-symbolic.svg computer-chip-symbolic.svg
 drive-harddisk-symbolic.svg drive-harddisk-system-symbolic.svg
 media-optical-symbolic.svg media-optical-bd-symbolic.svg
 media-optical-symbolic.svg media-optical-cd-audio-symbolic.svg


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36476595/221896050-86eecc7d-5575-4358-8fa1-7fbd796f9d06.png)

[Upstream icon](https://github.com/GNOME/gnome-software/blob/main/data/icons/computer-chip-symbolic.svg)

Related to #3826 