### PR TITLE
Drop CI pre-job and fix 'on' condition

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -1,22 +1,13 @@
 name: Build CI test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
-  pre_job:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-    - id: skip_check
-      uses: fkirc/skip-duplicate-actions@master
-      with:
-        concurrent_skipping: "same_content"
-        do_not_skip: '["pull_request"]'
-
   build:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -1,25 +1,16 @@
 name: Build debian packages
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 env:
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
-  pre_job:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-    - id: skip_check
-      uses: fkirc/skip-duplicate-actions@master
-      with:
-        concurrent_skipping: "same_content"
-        do_not_skip: '["pull_request"]'
-
   check:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Ubuntu Devel
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
I had previously added a pre-job to cancel duplicated runs (#3695).
But we just need to add a better `on` condition.