### PR TITLE
Fix dash separator color in light theme

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -155,7 +155,7 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
             }
 
             .dash-separator {
-                background-color: $borders_color;
+                background-color: $borders_color_dark;
                 @if is_horizontal($side) {
                     margin: 0 $margin;
                     width: 1px;


### PR DESCRIPTION
The dash separator was white in the light theme.
This PR use the dark variant of the border colour.

| Before | After 
| --- | ---
| ![Capture d’écran du 2023-03-17 12-35-58](https://user-images.githubusercontent.com/36476595/225894008-ad96ff2a-3ed8-4699-a014-a264a91add55.png) | ![Capture d’écran du 2023-03-17 12-34-51](https://user-images.githubusercontent.com/36476595/225894015-3519391d-08c2-4304-9303-3eba7dd3f212.png)
