### PR TITLE
Sync icon theme with upstream

### DIFF
--- a/icons/Yaru/scalable/ui/pan-down-large-symbolic.svg
+++ b/icons/Yaru/scalable/ui/pan-down-large-symbolic.svg
@@ -1,0 +1,3 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m1.4805 5a0.5 0.5 0 0 0-0.34766 0.16016 0.5 0.5 0 0 0 0.027344 0.70703l6.5 6a0.50005 0.50005 0 0 0 0.67969 0l6.5-6a0.5 0.5 0 0 0 0.02734-0.70703 0.5 0.5 0 0 0-0.70703-0.027344l-6.1602 5.6875-6.1602-5.6875a0.5 0.5 0 0 0-0.35938-0.13281z" color="#000000" fill="#808080" stroke-linecap="round" stroke-linejoin="round" style="-inkscape-stroke:none"/>
+</svg>

--- a/icons/Yaru/scalable/ui/pan-end-large-symbolic.svg
+++ b/icons/Yaru/scalable/ui/pan-end-large-symbolic.svg
@@ -1,0 +1,3 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m5.5195 1a0.5 0.5 0 0 0-0.35938 0.13281 0.5 0.5 0 0 0-0.027344 0.70703l5.6875 6.1602-5.6875 6.1602a0.5 0.5 0 0 0 0.027344 0.70703 0.5 0.5 0 0 0 0.70703-0.02734l6-6.5a0.50005 0.50005 0 0 0 0-0.67969l-6-6.5a0.5 0.5 0 0 0-0.34766-0.16016z" color="#000000" fill="#808080" stroke-linecap="round" stroke-linejoin="round" style="-inkscape-stroke:none"/>
+</svg>

--- a/icons/Yaru/scalable/ui/pan-start-large-symbolic.svg
+++ b/icons/Yaru/scalable/ui/pan-start-large-symbolic.svg
@@ -1,0 +1,3 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m11 1.4805a0.5 0.5 0 0 0-0.16016-0.34766 0.5 0.5 0 0 0-0.70703 0.027344l-6 6.5a0.50005 0.50005 0 0 0 0 0.67969l6 6.5a0.5 0.5 0 0 0 0.70703 0.02734 0.5 0.5 0 0 0 0.02734-0.70703l-5.6875-6.1602 5.6875-6.1602a0.5 0.5 0 0 0 0.13281-0.35938z" color="#000000" fill="#808080" stroke-linecap="round" stroke-linejoin="round" style="-inkscape-stroke:none"/>
+</svg>

--- a/icons/Yaru/scalable/ui/pan-up-large-symbolic.svg
+++ b/icons/Yaru/scalable/ui/pan-up-large-symbolic.svg
@@ -1,0 +1,3 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m1.4805 11a0.5 0.5 0 0 1-0.34766-0.16016 0.5 0.5 0 0 1 0.027344-0.70703l6.5-6a0.50005 0.50005 0 0 1 0.67969 0l6.5 6a0.5 0.5 0 0 1 0.02734 0.70703 0.5 0.5 0 0 1-0.70703 0.02734l-6.1602-5.6875-6.1602 5.6875a0.5 0.5 0 0 1-0.35938 0.13281z" color="#000000" fill="#808080" stroke-linecap="round" stroke-linejoin="round" style="-inkscape-stroke:none"/>
+</svg>

--- a/icons/Yaru/scalable/ui/right-large-symbolic.svg
+++ b/icons/Yaru/scalable/ui/right-large-symbolic.svg
@@ -1,0 +1,1 @@
+pan-end-large-symbolic.svg

--- a/icons/src/scalable/default/ui/pan-down-large-symbolic.svg
+++ b/icons/src/scalable/default/ui/pan-down-large-symbolic.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="pan-down-large-symbolic.svg"
+   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="38.890873"
+     inkscape:cx="4.9883169"
+     inkscape:cy="6.1711137"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid835" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid843"
+       dotted="true"
+       spacingx="0.5"
+       spacingy="0.5"
+       empspacing="10" />
+  </sodipodi:namedview>
+  <path
+     style="color:#000000;fill:#808080;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 1.4804687,5 a 0.5,0.5 0 0 0 -0.3476562,0.1601562 0.5,0.5 0 0 0 0.027344,0.7070313 l 6.5,6.0000005 a 0.50005,0.50005 0 0 0 0.6796876,0 l 6.5000002,-6.0000005 a 0.5,0.5 0 0 0 0.02734,-0.7070313 0.5,0.5 0 0 0 -0.707032,-0.027344 l -6.160156,5.6875005 -6.1601563,-5.6875005 a 0.5,0.5 0 0 0 -0.359375,-0.1328125 z"
+     id="path299" />
+</svg>

--- a/icons/src/scalable/default/ui/pan-end-large-symbolic.svg
+++ b/icons/src/scalable/default/ui/pan-end-large-symbolic.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="pan-end-large-symbolic.svg"
+   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="27.5"
+     inkscape:cx="4.3454545"
+     inkscape:cy="4.2727273"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid835" />
+  </sodipodi:namedview>
+  <path
+     style="color:#000000;fill:#808080;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 5.5195312,1 a 0.5,0.5 0 0 0 -0.359375,0.1328125 0.5,0.5 0 0 0 -0.027344,0.7070312 l 5.6875005,6.1601563 -5.6875005,6.160156 a 0.5,0.5 0 0 0 0.027344,0.707032 0.5,0.5 0 0 0 0.7070313,-0.02734 l 6.0000005,-6.5000002 a 0.50005,0.50005 0 0 0 0,-0.6796876 l -6.0000005,-6.5 a 0.5,0.5 0 0 0 -0.3476563,-0.1601562 z"
+     id="path299" />
+</svg>

--- a/icons/src/scalable/default/ui/pan-start-large-symbolic.svg
+++ b/icons/src/scalable/default/ui/pan-start-large-symbolic.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="pan-start-large-symbolic.svg"
+   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="27.5"
+     inkscape:cx="4.3454545"
+     inkscape:cy="4.2727273"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid835" />
+  </sodipodi:namedview>
+  <path
+     style="color:#000000;fill:#808080;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 11.000419,1.4804695 a 0.5,0.5 0 0 0 -0.160156,-0.3476562 0.5,0.5 0 0 0 -0.707032,0.027344 l -6,6.5000001 a 0.50005,0.50005 0 0 0 0,0.6796876 l 6,6.5 a 0.5,0.5 0 0 0 0.707032,0.02734 0.5,0.5 0 0 0 0.02734,-0.707032 l -5.687501,-6.1601558 5.687501,-6.1601564 a 0.5,0.5 0 0 0 0.132812,-0.359375 z"
+     id="path299" />
+</svg>

--- a/icons/src/scalable/default/ui/pan-up-large-symbolic.svg
+++ b/icons/src/scalable/default/ui/pan-up-large-symbolic.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="pan-up-large-symbolic.svg"
+   inkscape:version="1.2 (1:1.2.1+202207142221+cd75a1ee6d)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="27.5"
+     inkscape:cx="4.3454545"
+     inkscape:cy="4.2727273"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid835" />
+  </sodipodi:namedview>
+  <path
+     style="color:#000000;fill:#808080;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 1.4804695,11.000419 a 0.5,0.5 0 0 1 -0.3476562,-0.160156 0.5,0.5 0 0 1 0.027344,-0.707032 l 6.4999995,-5.9999998 a 0.50005,0.50005 0 0 1 0.679688,0 l 6.5000002,5.9999998 a 0.5,0.5 0 0 1 0.02734,0.707032 0.5,0.5 0 0 1 -0.707032,0.02734 l -6.1601562,-5.6875008 -6.160156,5.6875008 a 0.5,0.5 0 0 1 -0.359375,0.132812 z"
+     id="path299" />
+</svg>

--- a/icons/src/symlinks/symbolic/ui.list
+++ b/icons/src/symlinks/symbolic/ui.list
@@ -3,5 +3,6 @@ pan-end-symbolic.svg pan-start-symbolic-rtl.svg
 pan-start-symbolic.svg pan-end-symbolic-rtl.svg
 pan-down-symbolic.svg hdy-expander-arrow-symbolic.svg
 pan-down-symbolic.svg adw-expander-arrow-symbolic.svg
+pan-end-large-symbolic.svg right-large-symbolic.svg
 selection-end-symbolic.svg selection-start-symbolic-rtl.svg
 selection-start-symbolic.svg selection-end-symbolic-rtl.svg


### PR DESCRIPTION
I added large variant of pan icons, then symlinked one to the new simple scan icon.

![Capture d’écran du 2023-03-20 13-53-31](https://user-images.githubusercontent.com/36476595/226344975-b9d769ad-7fa2-4ff4-9f54-ec481555a601.png)

Reference: https://github.com/GNOME/simple-scan/blob/37caec48932ae1f91b166ddf94c44c6e9066e431/data/icons/scalable/actions/right-large-symbolic.svg

Related to #3858