### PR TITLE
gnome-shell: Add keyboard-brightness-off-symbolic implementation

### DIFF
--- a/gnome-shell/src/data/gnome-shell-icons.gresource.xml
+++ b/gnome-shell/src/data/gnome-shell-icons.gresource.xml
@@ -23,8 +23,8 @@
     <file>scalable/actions/screenshot-recorded-symbolic.svg</file>
     <file>scalable/status/background-app-ghost-symbolic.svg</file>
     <file>scalable/status/keyboard-brightness-high-symbolic.svg</file>
-    <file>scalable/status/keyboard-brightness-low-symbolic.svg</file>
     <file>scalable/status/keyboard-brightness-medium-symbolic.svg</file>
+    <file>scalable/status/keyboard-brightness-off-symbolic.svg</file>
     <file>scalable/status/keyboard-caps-lock-symbolic.svg</file>
     <file>scalable/status/keyboard-enter-symbolic.svg</file>
     <file>scalable/status/keyboard-hide-symbolic.svg</file>

--- a/gnome-shell/src/data/icons/scalable/status/keyboard-brightness-high-symbolic.svg
+++ b/gnome-shell/src/data/icons/scalable/status/keyboard-brightness-high-symbolic.svg
@@ -1,1 +1,62 @@
-<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg"><path style="opacity:1;fill:gray;stroke-width:.597614;stroke-linecap:square;stroke-linejoin:round" d="M7 10h1c2 0 2 0 2 2H5c0-2 0-2 2-2z"/><path style="opacity:1;fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" d="M0 11h3v1H0zM12 11h3v1h-3z"/><path style="opacity:1;fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(30)" d="M4.745 5.709h3v1h-3z"/><path style="opacity:1;fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(90)" d="M4-8h3v1H4z"/><path style="opacity:1;fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(150)" d="M-8.245-14.209h3v1h-3z"/><path style="opacity:1;fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(60)" d="M6.209-1.245h3v1h-3z"/><path style="opacity:1;fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(120)" d="M-1.291-12.745h3v1h-3z"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg7064"
+   sodipodi:docname="keyboard-brightness-high-symbolic.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs7068" />
+  <sodipodi:namedview
+     id="namedview7066"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="53.125"
+     inkscape:cx="8.0094118"
+     inkscape:cy="8.0094118"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7064" />
+  <path
+     style="opacity:1;fill:#808080;stroke-width:0.597614;stroke-linecap:square;stroke-linejoin:round"
+     d="m 7.5,10 h 1 c 2,0 2,0 2,2 h -5 c 0,-2 0,-2 2,-2 z"
+     id="path7050" />
+  <path
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 0.5,11 h 3 v 1 h -3 z m 12,0 h 3 v 1 h -3 z"
+     id="path7052" />
+  <path
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 1.7547905,7.316639 2.5980763,1.5 -0.5,0.8660254 -2.5980763,-1.5 z"
+     id="path7054" />
+  <path
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 8.5,4 v 3 h -1 V 4 Z"
+     id="path7056" />
+  <path
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 14.744879,8.182855 -2.598076,1.5 -0.5,-0.8660254 2.598076,-1.5 z"
+     id="path7058" />
+  <path
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 4.6827016,4.7546517 1.5,2.5980762 -0.8660254,0.5 -1.5,-2.5980762 z"
+     id="path7060" />
+  <path
+     style="opacity:1;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 12.182994,5.2544612 -1.5,2.5980762 -0.8660256,-0.5 1.4999996,-2.5980762 z"
+     id="path7062" />
+</svg>

--- a/gnome-shell/src/data/icons/scalable/status/keyboard-brightness-low-symbolic.svg
+++ b/gnome-shell/src/data/icons/scalable/status/keyboard-brightness-low-symbolic.svg
@@ -1,1 +1,62 @@
-<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg"><path style="fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round;opacity:.5" d="M0 11h3v1H0zM12 11h3v1h-3z"/><path style="opacity:.5;fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(30)" d="M4.745 5.709h3v1h-3z"/><path style="opacity:.5;fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(90)" d="M4-8h3v1H4z"/><path style="opacity:.5;fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(150)" d="M-8.245-14.209h3v1h-3z"/><path style="fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round;opacity:.5" transform="rotate(60)" d="M6.209-1.245h3v1h-3z"/><path style="fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round;opacity:.5" transform="rotate(120)" d="M-1.291-12.745h3v1h-3z"/><path style="fill:gray;stroke-width:.597614;stroke-linecap:square;stroke-linejoin:round" d="M7 10h1c2 0 2 0 2 2H5c0-2 0-2 2-2z"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2003"
+   sodipodi:docname="keyboard-brightness-low-symbolic.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2007" />
+  <sodipodi:namedview
+     id="namedview2005"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="53.125"
+     inkscape:cx="7.9717647"
+     inkscape:cy="10.588235"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2003" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 0.5,11 h 3 v 1 h -3 z m 12,0 h 3 v 1 h -3 z"
+     id="path1989" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 1.7547905,7.316639 2.5980763,1.5 -0.5,0.8660254 -2.5980763,-1.5 z"
+     id="path1991" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 8.5,4 v 3 h -1 V 4 Z"
+     id="path1993" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 14.744879,8.182855 -2.598076,1.5 -0.5,-0.8660254 2.598076,-1.5 z"
+     id="path1995" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 4.6827016,4.7546517 1.5,2.5980762 -0.8660254,0.5 -1.5,-2.5980762 z"
+     id="path1997" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 12.182994,5.2544612 -1.5,2.5980762 -0.866026,-0.5 1.5,-2.5980762 z"
+     id="path1999" />
+  <path
+     style="fill:#808080;stroke-width:0.597614;stroke-linecap:square;stroke-linejoin:round"
+     d="m 7.5,10 h 1 c 2,0 2,0 2,2 h -5 c 0,-2 0,-2 2,-2 z"
+     id="path2001" />
+</svg>

--- a/gnome-shell/src/data/icons/scalable/status/keyboard-brightness-medium-symbolic.svg
+++ b/gnome-shell/src/data/icons/scalable/status/keyboard-brightness-medium-symbolic.svg
@@ -1,1 +1,62 @@
-<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg"><path style="fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" d="M0 11h3v1H0zM12 11h3v1h-3z"/><path style="fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round;opacity:.5" transform="rotate(30)" d="M4.745 5.709h3v1h-3z"/><path style="fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round;opacity:.5" transform="rotate(90)" d="M4-8h3v1H4z"/><path style="fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round;opacity:.5" transform="rotate(150)" d="M-8.245-14.209h3v1h-3z"/><path style="fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(60)" d="M6.209-1.245h3v1h-3z"/><path style="fill:gray;stroke:none;stroke-width:.5;stroke-linecap:square;stroke-linejoin:round" transform="rotate(120)" d="M-1.291-12.745h3v1h-3z"/><path style="fill:gray;stroke-width:.597614;stroke-linecap:square;stroke-linejoin:round" d="M7 10h1c2 0 2 0 2 2H5c0-2 0-2 2-2z"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg6175"
+   sodipodi:docname="keyboard-brightness-medium-symbolic.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6179" />
+  <sodipodi:namedview
+     id="namedview6177"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="53.125"
+     inkscape:cx="8.0094118"
+     inkscape:cy="8.0094118"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6175" />
+  <path
+     style="fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 0.5,11 h 3 v 1 h -3 z m 12,0 h 3 v 1 h -3 z"
+     id="path6161" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 1.7547905,7.316639 2.5980763,1.5 -0.5,0.8660254 -2.5980763,-1.5 z"
+     id="path6163" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 8.5,4 v 3 h -1 V 4 Z"
+     id="path6165" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 14.744879,8.182855 -2.598076,1.5 -0.5,-0.8660254 2.598076,-1.5 z"
+     id="path6167" />
+  <path
+     style="fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 4.6827016,4.7546517 1.5,2.5980762 -0.8660254,0.5 -1.5,-2.5980762 z"
+     id="path6169" />
+  <path
+     style="fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 12.182994,5.2544612 -1.5,2.5980762 -0.8660256,-0.5 1.4999996,-2.5980762 z"
+     id="path6171" />
+  <path
+     style="fill:#808080;stroke-width:0.597614;stroke-linecap:square;stroke-linejoin:round"
+     d="m 7.5,10 h 1 c 2,0 2,0 2,2 h -5 c 0,-2 0,-2 2,-2 z"
+     id="path6173" />
+</svg>

--- a/gnome-shell/src/data/icons/scalable/status/keyboard-brightness-off-symbolic.svg
+++ b/gnome-shell/src/data/icons/scalable/status/keyboard-brightness-off-symbolic.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg2003"
+   sodipodi:docname="keyboard-brightness-off-symbolic.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2007" />
+  <sodipodi:namedview
+     id="namedview2005"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="25.893422"
+     inkscape:cx="-2.7420092"
+     inkscape:cy="11.141826"
+     inkscape:window-width="1651"
+     inkscape:window-height="752"
+     inkscape:window-x="108"
+     inkscape:window-y="40"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2003" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 0.5,11 h 3 v 1 h -3 z m 12,0 h 3 v 1 l -1.973627,-0.02843 -0.462437,-0.428725 z"
+     id="path1989"
+     sodipodi:nodetypes="ccccccccccc" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 1.7547905,7.316639 2.5980763,1.5 -0.5,0.8660254 -2.5980763,-1.5 z"
+     id="path1991" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="M 8.5,4 8.4977471,6.964054 7.5041831,5.9962472 7.5,4 Z"
+     id="path1993"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 14.744879,8.182855 -2.598076,1.5 -0.5,-0.8660254 2.598076,-1.5 z"
+     id="path1995" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="M 5.0203337,6.593682 5.9184162,7.5394122 5.3166762,7.8527279 4.1531456,5.7042651 Z"
+     id="path1997"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="opacity:0.5;fill:#808080;stroke:none;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:round"
+     d="m 12.182994,5.2544612 -1.5,2.5980762 -0.866026,-0.5 1.5,-2.5980762 z"
+     id="path1999" />
+  <path
+     style="fill:#808080;stroke-width:0.597614;stroke-linecap:square;stroke-linejoin:round"
+     d="m 7.5,10 0.8766843,0.01094 c 0,0 -0.00412,0.02361 1.9999997,2 L 5.5,12 c 0,-2 1.557e-4,-2.0249579 2,-2 z"
+     id="path2001"
+     sodipodi:nodetypes="scccs" />
+  <path
+     d="m 1.5315,0.469 -1.0625,1.0625 14,14 1.0625,-1.0625 z m 0,0"
+     id="path22"
+     style="fill:#5d5d5d;fill-opacity:1" />
+</svg>


### PR DESCRIPTION
This is an initial version, made by a non-designer at least to fill the void.

Related to #3966