### PR TITLE
Revert progress color to pure accent

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
@@ -36,4 +36,4 @@ $checkradio_bg_color: $accent_bg_color;
 $checkradio_fg_color: $accent_fg_color;
 $switch_bg_color: if($variant=='light', $accent_bg_color, darken($accent_bg_color, 8%));
 $switch_border_color: if($variant=='light', darken($accent_bg_color, 15%), darken($borders_color, 5%));
-$progress_bg_color: if($variant=='light', lighten($accent_bg_color, 10%), lighten($accent_bg_color, 5%));
+$progress_bg_color: $accent_bg_color;


### PR DESCRIPTION
Revert the progress track color to pure accent, like before #3974 (https://github.com/ubuntu/yaru/pull/3974/files#diff-d2ffad6a03458277f589a156a75cd154971ba0a9f85fe2890159f703e6217597L101)

| | Before | After |
| --- | --- | --- |
| Light | ![image](https://github.com/ubuntu/yaru/assets/36476595/ab66a952-3565-4490-ad56-45cd24d844ac) | ![Capture d’écran du 2023-09-09 22-59-41](https://github.com/ubuntu/yaru/assets/36476595/de5738a2-a9e8-4a44-9c21-a731c89688ee) |
| Dark | ![Capture d’écran du 2023-09-09 22-49-36](https://github.com/ubuntu/yaru/assets/36476595/d569d787-a2e7-434d-bff6-b19d323dc18e) | ![Capture d’écran du 2023-09-09 22-59-21](https://github.com/ubuntu/yaru/assets/36476595/34b53717-0ce7-4c47-88dd-fec5423ebabd)









