### PR TITLE
gnome-shell: Ensure accent color is used in shell variants

### DIFF
--- a/common/accent-colors.scss.in
+++ b/common/accent-colors.scss.in
@@ -42,6 +42,7 @@ $yaru_accent_color: optimize-contrast($yaru_bg_color,
 @debug("Contrast optimized accent is " + $yaru_accent_color);
 
 $accent_bg_color: $yaru_accent_bg_color;
+$accent_fg_color: white;
 $accent_color: $yaru_accent_color;
 
 @import '@yaru_theme_entry_point@'

--- a/gnome-shell/src/gnome-shell.scss.in
+++ b/gnome-shell/src/gnome-shell.scss.in
@@ -53,6 +53,11 @@ $UPSTREAM_VARIANTS: ['dark', 'light'];
     @return url(quote($url));
 }
 
+@if not list-index(["dark", "light"], $yaru_variant) and
+    not variable-exists("accent_bg_color") {
+    @error "Missing definition for accent color variable: $accent_bg_color";
+}
+
 @debug 'Generating GNOME Shell ' + $yaru_variant + ' theme (' + $variant +' variant, hc: '+ $is_highcontrast+')';
 
 @import "gnome-shell-sass/_@Colors@";

--- a/gnome-shell/src/meson.build
+++ b/gnome-shell/src/meson.build
@@ -194,7 +194,8 @@ foreach variant: variants
       },
     )
 
-    if is_custom_accent and (variant == DEFAULT_HIGH_CONTRAST_VARIANT or
+    if is_custom_accent and (not high_contrast or
+      variant == DEFAULT_HIGH_CONTRAST_VARIANT or
       INCLUDE_HIGH_CONTRAST_VARIANTS)
       theme_sources += theme_main_file
       theme_main_file = configure_file(


### PR DESCRIPTION
We did not generate the shell accent color loader files anymore causing the accent color not being used for color variants.

Avoid ending up in the same situation again by adding a sssc check at compile time.

LP: #2033688
Closes: #3978