### PR TITLE
gtksourceview: Support gedit's forked library

### DIFF
--- a/debian/yaru-theme-gtk.install
+++ b/debian/yaru-theme-gtk.install
@@ -1,4 +1,4 @@
-usr/share/gtksourceview-*/styles/Yaru*.xml
+usr/share/*gtksourceview-*/styles/Yaru*.xml
 usr/share/themes/Yaru/gtk-*/
 usr/share/themes/Yaru/metacity-1
 usr/share/themes/Yaru/xfwm4

--- a/gtksourceview/gtksourceview/meson.build
+++ b/gtksourceview/gtksourceview/meson.build
@@ -8,9 +8,11 @@ foreach flavour: flavours
       'FlavourThemeName': theme_name,
     })
 
-  foreach version: ['2.0', '3.0', '4']
-    gtksourceview_dir = 'gtksourceview-' + version
-    style_dir = join_paths(get_option('datadir'), gtksourceview_dir, 'styles')
+  foreach version: ['gtksourceview-2.0',
+                    'gtksourceview-3.0',
+                    'gtksourceview-4',
+                    'libgedit-gtksourceview-300']
+    style_dir = get_option('datadir') / version / 'styles'
     install_data(theme_file, install_dir: style_dir)
   endforeach
 endforeach


### PR DESCRIPTION
Test Case
-------
- Install Ubuntu 24.04 LTS. Choose the dark style option.
- After the install, install gedit (as a .deb)
- Run gedit

What Happens
---------------------
gedit's text area has major readable issues. When run from the command-line, this warning appears:

`Style scheme 'Yaru-dark' cannot be found, falling back to 'tango' default style scheme.`

Other Info
---------------
The gedit maintainer has forked gtksourceview to a new libgedit-gtksourceview library, ignoring advice from several that it was not ideal. Ubuntu 24.04 LTS has gedit 46 where that change has been made.