### PR TITLE
gnome-shell: Don't give login-dialog another background-color

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
@@ -14,7 +14,6 @@ $_gdm_dialog_width: 23em;
 
 /* Login Dialog */
 .login-dialog {
-  background-color: $_gdm_bg;
 }
 
 // buttons


### PR DESCRIPTION
Its parent `lockDialogGroup` has exactly the same background-color set in the same file. Giving them both the same wasted render time on overdraw, and caused multi-layer blending artifacts (slight flickering of the grey background) when the login dialog fades in/out.

While the flicker can also be fixed using `set_offscreen_redirect`, there's no point adding that overhead when the extra layer doesn't need to be painted. Removing it halves the average render time of the login animation.

Closes: #4048
Copied-from: https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/d09509b2cbce