### PR TITLE
Update Yaru to new Dash-to-Dock code

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -15,6 +15,8 @@ $dock_edge_items_padding: $dash_padding - $dock_spacing;
 $dock_fixed_inner_margin: $dock_side_margin;
 $dock_icons_distance: 4px;
 
+$remark_color: rgba(238, 238, 236, 0.2);
+
 @function shrink($val) {
     @return round($val / 4);
 }
@@ -186,7 +188,8 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
                     0, $dock_icons_distance / 2);
 
                 .app-well-app,
-                .show-apps {
+                .show-apps,
+                .overview-tile {
                     @include set-internal-children-property($side, padding, $spacing);
                     padding-#{$side}: $padding + $side_margin;
                     padding-#{opposite($side)}: $padding;
@@ -197,7 +200,7 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
                         background-image: none;
                     }
                     &.focused .overview-icon {
-                        background-color: rgba(238, 238, 236, 0.2);
+                        background-color: $remark_color;
                     }
 
                     .app-well-app-running-dot {
@@ -228,6 +231,20 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
             }
         }
     }
+}
+
+.overview-tile {
+    margin: 0px;
+    padding: 0px;
+    border: 0px;
+}
+
+.overview-tile .overview-icon, .show-apps .overview-icon {
+    background-color: rgba(255,255,255,0);
+}
+
+.overview-tile:hover .overview-icon, .overview-tile.focused .overview-icon, .show-apps:hover .overview-icon {
+    background-color: $remark_color;
 }
 
 @each $side in $dock_sides {


### PR DESCRIPTION
Some changes were required in the scss to make Dash to Dock compatible with Gnome Shell 46, while also keeping compatibility with Gnome Shell 45. These are those changes. This is the PR in DashToDock: https://github.com/micheleg/dash-to-dock/pull/2146