### PR TITLE
Fix apps view

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -240,11 +240,14 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
     border: 0px;
 }
 
-.overview-tile .overview-icon, .show-apps .overview-icon {
+.dash-item-container .overview-tile .overview-icon,
+.dash-item-container .show-apps .overview-icon {
     background-color: rgba(255,255,255,0);
 }
 
-.overview-tile:hover .overview-icon, .overview-tile.focused .overview-icon, .show-apps:hover .overview-icon {
+.dash-item-container .overview-tile:hover .overview-icon,
+.dash-item-container .overview-tile.focused .overview-icon,
+.dash-item-container .show-apps:hover .overview-icon {
     background-color: $remark_color;
 }
 


### PR DESCRIPTION
The apps view shows an extra rectangle in the icons when they are hovered by the cursor.

This patch fixes it (extracted from patch for gnome 46 for Dash to Dock).