### PR TITLE
Shell 46 fixes

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -57,7 +57,7 @@ $osd_outer_borders_color: transparentize($osd_fg_color, 0.98);
 
 // system colors
 $system_bg_color: lighten($system_base_color, 5%);
-$system_bg_color: lighten($jet, 4%); // Lighten than dash but darken than bg-color
+$system_bg_color: $_base_color_dark; // Yaru - use our definition our definition
 $system_borders_color: transparentize($system_fg_color, .9);
 $system_insensitive_fg_color: mix($system_fg_color, $system_bg_color, 50%);
 $system_overlay_bg_color: mix($system_base_color, $system_fg_color, 90%); // for non-transparent items, e.g. dash

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -63,6 +63,9 @@ $large_scalable_icon_size: $scalable_icon_size * 2;
 // animation definition
 $ease_out_quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);
 
+// Yaru menu radius
+$yaru_menu_border_radius: $modal_radius * 2.25;
+
 // Stage
 stage {
   @include fontsize($base_font_size);

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -531,7 +531,9 @@ $dock_color: $panel_bg_color;
 
                 $fg:$system_fg_color;
                 $normal_bg: transparent;
-                $bg: transparentize(lighten($dock_color, 10%), 0.1);
+                $focus_bg: transparentize($fg, .83);
+                $bg: transparentize($fg, .90);
+                $checked_bg: transparentize($fg, .75);
 
                 .overview-icon {
                     @extend %tile;
@@ -541,8 +543,8 @@ $dock_color: $panel_bg_color;
                 &:focus .overview-icon { @include button(focus, $tc:$fg, $c:$bg, $style: flat, $always_dark: true);}
                 &:hover .overview-icon { @include button(hover, $tc:$fg, $c:$bg, $style: flat, $always_dark: true);}
                 &:active .overview-icon { @include button(active, $tc:$fg, $c:$bg, $style: flat, $always_dark: true);}
-                &:checked .overview-icon { @include button(checked, $tc:$fg, $c:$bg, $style: flat, $always_dark: true);}
-                &.focused .overview-icon { @include button(active, $tc: $fg, $c:$bg, $style: flat, $always_dark: true);}
+                &:checked .overview-icon { @include button(checked, $tc:$fg, $c:$checked_bg, $style: flat, $always_dark: true);}
+                &.focused .overview-icon { @include button(active, $tc: $fg, $c:$focus_bg, $style: flat, $always_dark: true);}
             }
 
             // running app dot

--- a/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
@@ -24,6 +24,7 @@ $focus_border_color: lighten($accent_bg_color, 14%);
 $alt_borders_color: if($variant=='light', darken($bg_color, 24%), darken($bg_color, 10%));
 
 $system_borders_color: $yaru_borders_color_dark; // Yaru: use our definition
+$system_overlay_bg_color: $dash_background_color; // Yaru - Use system bg color for overlay items
 
 // card elements
 $card_bg_color: if($variant =='light', $light_1, lighten($bg_color, 7%));

--- a/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
@@ -7,6 +7,7 @@
 
 .datemenu-popover {
   border-radius: $base_border_radius * 1.5 + $base_padding * 3;
+  border-radius: $yaru_menu_border_radius;
 }
 
 // calendar menu side column

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
@@ -1,7 +1,7 @@
 /* Dash */
 
 // uses system colors
-$dash_background_color: $system_overlay_bg_color !default; // Yaru: we define those colors in _colors.scss for _dock.scss to use it
+$dash_background_color: $system_overlay_bg_color;
 
 $dash_placeholder_size: 32px;
 $dash_padding: $base_padding * 2;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_popovers.scss
@@ -27,6 +27,7 @@ $submenu_bg_color: lighten($menu_bg_color, 7%);
   padding: $base_padding;
   background-color: $bg_color;
   border-radius: $modal_radius * 1.25;
+  border-radius: $yaru_menu_border_radius;
   border: 1px solid $outer_borders_color;
   box-shadow: 0 2px 4px 0 $shadow_color;
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_quick-settings.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_quick-settings.scss
@@ -1,6 +1,7 @@
 .quick-settings {
   padding: $base_padding * 3;
   border-radius: $modal_radius * 2.25;
+  border-radius: $yaru_menu_border_radius;
 
   .icon-button, .button {
     padding: $base_padding * 1.75;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_search-results.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_search-results.scss
@@ -23,7 +23,7 @@
 
 // content
 .search-section-content {
-  background-color: $dash_background_color; // Yaru: use same background as dash
+  background-color: $system_overlay_bg_color;
   color: $system_fg_color;
   border-radius: $modal_radius * 1.5;
   padding: $base_padding * 2;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_workspace-thumbnails.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_workspace-thumbnails.scss
@@ -13,7 +13,7 @@
     border-radius: $base_border_radius * 0.5;
     border: 1px solid transparent;
 
-    background-color: $dash_background_color; // Yaru: use same background as dash
+    background-color: $system_overlay_bg_color; // Yaru: use same background as dash
     border: 1px solid $system_borders_color; // Yaru: use same border as dash
 
     @if $contrast == 'high' {


### PR DESCRIPTION
Various fixes as per latest testing:

 - Tuned the dock icons highlights

![immagine](https://github.com/ubuntu/yaru/assets/345675/f89b03f2-217f-47d4-a40d-5c9d4b46605c)
![immagine](https://github.com/ubuntu/yaru/assets/345675/dbf69e1c-f7a9-4ea4-9499-100eca4941f0)

- Fixed highlighting on search items

![immagine](https://github.com/ubuntu/yaru/assets/345675/a86b0918-eb28-4869-8ccc-8e12cbe6ce8d)

- Reduced the radius on datemenu to match quicksettings

![immagine](https://github.com/ubuntu/yaru/assets/345675/e0783836-0ba6-4bff-8293-de6f606651a6)

