### PR TITLE
gtksourceview: Add support for new libgedit-gtksourceview 299.2 xml scheme

### DIFF
--- a/gtksourceview/gtksourceview/dark.xml.in
+++ b/gtksourceview/gtksourceview/dark.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" version="1.0">
+<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" kind="dark">
   <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
 
   <!-- Yaru palette -->
@@ -94,7 +94,7 @@
   <style name="def:strong-emphasis"        bold="true"/>
   <style name="def:type"                   foreground="blue_2" bold="true"/>
   <style name="def:underlined"             underline="single"/>
-  <style name="def:warning"                underline="error" underline-color="yellow_4"/>
+  <style name="def:warning"                underline="error"/>
   
   <!-- C# -->
   <style name="c-sharp:format"             foreground="purple_2"/>

--- a/gtksourceview/gtksourceview/default.xml.in
+++ b/gtksourceview/gtksourceview/default.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" version="1.0">
+<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" kind="light">
   <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
 
   <!-- Yaru palette -->
@@ -92,7 +92,7 @@
   <style name="def:strong-emphasis"        bold="true"/>
   <style name="def:type"                   foreground="blue_4" bold="true"/>
   <style name="def:underlined"             underline="single"/>
-  <style name="def:warning"                underline="error" underline-color="yellow_4"/>
+  <style name="def:warning"                underline="error"/>
 
   <!-- C# -->
   <style name="c-sharp:format"             foreground="purple_4"/>


### PR DESCRIPTION
The `version` attribute was removed in `libgedit-gtksourceview` 299.2 https://gedit-technology.github.io/developer-docs/libgedit-gtksourceview-300/porting-guide-299-0-to-299-2.html

The same release also made the `kind` attribute mandatory

The underline-color attribute for style elements was apparently removed in 299.0.2, but the parser previously wasn't as strict https://github.com/gedit-technology/libgedit-gtksourceview/commit/4575db49b48b67c0898716995fbc4c68072873a6