### PR TITLE
gnome-shell: Webauth qrcode light theme fixes

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -314,7 +314,7 @@ stage {
   @include fontsize(8pt);
 }
 
-%monospace {font-family: monospace;}
+%monospace {font-family: 'Ubuntu Mono 15', monospace;}
 %numeric { font-feature-settings: "tnum";}
 
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
@@ -224,32 +224,32 @@ $_gdm_dialog_width: 25em;
 }
 
 .web-login-spinner {
-  background-color: rgba(0, 0, 0, 0.5);
-  border: 5px rgba(0, 0, 0, 0.0);
+  color: $osd_fg_color;
+  background-color: transparentize($osd_bg_color, 0.5);
+  border: 5px transparent;
   border-radius: 50px;
 }
 
 .web-login-title-label {
   @include fontsize($base_font_size);
-  color: darken($_gdm_fg, 30%);
+  color: if($variant =='dark', darken($fg_color, 30%), lighten($fg_color, 20%));
 }
 
 .web-login-url-label {
   @include fontsize($base_font_size);
   @extend %monospace;
-  color: $_gdm_fg;
+  color: $fg_color;
   text-align: center;
 }
 
 .web-login-code-title-label {
   @include fontsize($base_font_size);
-  @include fontsize($base_font_size);
-  color: $_gdm_fg;
+  color: $fg_color;
 }
 
 .web-login-code-label {
   @include fontsize($base_font_size);
-  color: $_gdm_fg;
+  color: $fg_color;
   font-weight: bold;
 }
 
@@ -264,7 +264,7 @@ $_gdm_dialog_width: 25em;
 
 .web-login-intro-button-label {
   @include fontsize($base_font_size + 5);
-  color: $_gdm_fg;
+  color: $fg_color;
   height: 3em;
   text-align: center;
   font-weight: bold;
@@ -272,7 +272,7 @@ $_gdm_dialog_width: 25em;
 
 .web-login-intro-button {
   @include fontsize($base_font_size);
-  color: $_gdm_fg;
+  color: $fg_color;
   height: 3em;
   text-align: center;
   border-radius: $base_border_radius * 4;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
@@ -196,7 +196,6 @@ $_gdm_dialog_width: 25em;
       }
 
       &:logged-in {
-        // color border for logged-in user
         .user-icon {
           border-color: $selected_bg_color;
           StIcon {
@@ -503,8 +502,16 @@ $_gdm_dialog_width: 25em;
 
 // QR Code
 .qr-code {
-  background: black;
+  @if ($variant == 'light') {
+    $qrcode_bg_color: mix($fg_color, $bg_color, 8%);
+    background-color: $qrcode_bg_color;
+    border-color: $qrcode_bg_color;
+    color: $fg_color;
+  } @else {
+    background-color: $_gdm_fg;
+    border-color: $_gdm_fg;
+    color: $_gdm_bg;
+  }
   border-radius: $base_border_radius * .5;
-  border-color: white;
   border-width: 1em;
 }

--- a/gnome-shell/upstream/theme/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/upstream/theme/gnome-shell-sass/widgets/_login-lock.scss
@@ -444,8 +444,16 @@ $_gdm_dialog_width: 25em;
 
 // QR Code
 .qr-code {
-  background: black;
+  @if ($variant == 'light') {
+    $qrcode_bg_color: mix($fg_color, $bg_color, 8%);
+    background-color: $qrcode_bg_color;
+    border-color: $qrcode_bg_color;
+    color: $fg_color;
+  } @else {
+    background-color: $_gdm_fg;
+    border-color: $_gdm_fg;
+    color: $_gdm_bg;
+  }
   border-radius: $base_border_radius * .5;
-  border-color: white;
   border-width: 1em;
 }

--- a/gnome-shell/upstream/theme/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/upstream/theme/gnome-shell-sass/widgets/_login-lock.scss
@@ -224,32 +224,33 @@ $_gdm_dialog_width: 25em;
 }
 
 .web-login-spinner {
-  background-color: rgba(0, 0, 0, 0.5);
-  border: 5px rgba(0, 0, 0, 0.0);
+  color: $osd_fg_color;
+  background-color: transparentize($osd_bg_color, 0.5);
+  border: 5px transparent;
   border-radius: 50px;
 }
 
 .web-login-title-label {
   @include fontsize($base_font_size);
-  color: darken($_gdm_fg,30%);
+  color: if($variant == 'dark', darken($fg_color,30%), lighten($fg_color,20%));
 }
 
 .web-login-url-label {
   @include fontsize($base_font_size);
   @extend %monospace;
-  color: $_gdm_fg;
+  color: $fg_color;
   text-align: center;
 }
 
 .web-login-code-title-label {
   @include fontsize($base_font_size);
   @include fontsize($base_font_size);
-  color: $_gdm_fg;
+  color: $fg_color;
 }
 
 .web-login-code-label {
   @include fontsize($base_font_size);
-  color: $_gdm_fg;
+  color: $fg_color;
   font-weight: bold;
 }
 
@@ -264,7 +265,7 @@ $_gdm_dialog_width: 25em;
 
 .web-login-intro-button-label {
   @include fontsize($base_font_size + 5);
-  color: $_gdm_fg;
+  color: $fg_color;
   height: 3em;
   text-align: center;
   font-weight: bold;
@@ -272,7 +273,7 @@ $_gdm_dialog_width: 25em;
 
 .web-login-intro-button {
   @include fontsize($base_font_size);
-  color: $_gdm_fg;
+  color: $fg_color;
   height: 3em;
   text-align: center;
   border-radius: $base_border_radius * 4;
@@ -376,6 +377,7 @@ $_gdm_dialog_width: 25em;
   background-color: transparentize($_gdm_fg, .9);
   border-radius: $forced_circular_radius;
 }
+
 
 .login-dialog,
 .unlock-dialog {


### PR DESCRIPTION
Before:

![immagine](https://github.com/ubuntu/yaru/assets/345675/32bb1bd2-6dba-402d-9c56-a01eaac91d66)


After:

![image](https://github.com/ubuntu/yaru/assets/345675/87527628-7ce4-4333-a4bd-8d2e9e234ebf)



