### PR TITLE
Remove an issue causing ".login-dialog-prompt-entry"

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
@@ -217,6 +217,11 @@ $_gdm_dialog_width: 25em;
   min-width: 30em;
 }
 
+// removed, causes missing entry selection border theming
+/*.login-dialog-prompt-entry {
+  @extend %system_entry;
+}*/
+
 .web-login-dialog-content-overlay {
   background-color: transparentize($bg_color, 0.3);
   border-radius: $modal_radius;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
@@ -217,10 +217,6 @@ $_gdm_dialog_width: 25em;
   min-width: 30em;
 }
 
-.login-dialog-prompt-entry {
-  @extend %system_entry;
-}
-
 .web-login-dialog-content-overlay {
   background-color: transparentize($bg_color, 0.3);
   border-radius: $modal_radius;


### PR DESCRIPTION
This commit removes a part of the scss file, which causes the login entry field focus borders to not be themed correctly.

This part causes ".login-dialog" to be missing in front of ".login-dialog-prompt-entry:focus", which causes the theme to fall back to the default color. If that default color isn't the same as the currently selected Yaru theme color, they mismatch.

closes #4102