### PR TITLE
Shell: use native accent color

### DIFF
--- a/common/accent-colors.scss.in
+++ b/common/accent-colors.scss.in
@@ -40,7 +40,7 @@ $yaru_accent_bg_color: get_accent_color('@yaru_accent_color@', $yaru_is_dark_var
 $is_warty_nostalgia: '@yaru_accent_color@' == 'wartybrown' and not $yaru_is_dark_variant;
 $warty_nostalgia_bg: #eeeeee;
 
-$contrast_target: if($yaru_is_dark_variant, 4.5, 4.8);
+$contrast_target: if($yaru_is_dark_variant, 4.8, 4.51);
 $yaru_accent_color: optimize-contrast($yaru_bg_color,
     $yaru_accent_bg_color, $target: $contrast_target);
 

--- a/common/accent-colors.scss.in
+++ b/common/accent-colors.scss.in
@@ -37,8 +37,6 @@ $yaru_is_dark_variant: @yaru_dark_variant@;
 $jet: #181818;
 $yaru_bg_color: if($yaru_is_dark_variant, #FAFAFA, lighten($jet, 8%));
 $yaru_accent_bg_color: get_accent_color('@yaru_accent_color@', $yaru_is_dark_variant);
-$is_warty_nostalgia: '@yaru_accent_color@' == 'wartybrown' and not $yaru_is_dark_variant;
-$warty_nostalgia_bg: #eeeeee;
 
 $contrast_target: if($yaru_is_dark_variant, 4.8, 4.51);
 $yaru_accent_color: optimize-contrast($yaru_bg_color,

--- a/common/yaru-colors-defs.scss
+++ b/common/yaru-colors-defs.scss
@@ -3,7 +3,6 @@
 
 $variant: if($yaru_is_dark_variant, 'dark', 'light');
 $hc_contrast_target: 5.5;
-$is_warty_nostalgia: $yaru_accent_color == 'wartybrown' and $variant =='light';
 
 @import 'colors';
 

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Package: yaru-theme-gnome-shell
 Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-Breaks: gnome-shell (<< 46~)
+Breaks: gnome-shell (<< 47~)
 Description: Yaru GNOME Shell desktop theme from the Ubuntu Community
  This is the theme, better than a burrito, that is shaped by the community
  on the Ubuntu discourse.

--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -4,7 +4,7 @@
 // When color definition differs for dark and light variant, it gets @if-ed depending on $variant
 
 @import '_palette.scss';
-//@import '_default-colors.scss';
+@import '_default-colors.scss';
 @import '_yaru-default-colors.scss';
 
 // global colors

--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -81,7 +81,7 @@ $hover_borders_color: lighten($borders_color, 5%);
 $active_bg_color: if($variant=='light', darken($bg_color, 11%), lighten($bg_color, 12%));
 $active_fg_color: if($variant=='light', darken($fg_color, 11%), lighten($fg_color, 12%));
 
-// selection colors
-$selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), lighten($selected_bg_color, 15%));
+// accent colors
+$accent_borders_color: if($variant== 'light', st-darken(-st-accent-color, 15%), st-lighten(-st-accent-color, 15%));
 
 @import '_yaru-colors.scss';

--- a/gnome-shell/src/gnome-shell-sass/_colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_colors.scss
@@ -18,11 +18,6 @@ $bg_color: if($variant=='light', #FAFAFA, $bg_color_dark);
 $fg_color_dark: $porcelain;
 $fg_color: if($variant=='light', $inkstone, $fg_color_dark);
 
-$is_warty_nostalgia: false !default;
-@if $is_warty_nostalgia {
-    $bg_color: $warty_nostalgia_bg;
-}
-
 // OSD elements
 $osd_fg_color: $light_1;
 $osd_bg_color: lighten($_base_color_dark, 5%);

--- a/gnome-shell/src/gnome-shell-sass/_common.scss
+++ b/gnome-shell/src/gnome-shell-sass/_common.scss
@@ -126,11 +126,11 @@ stage {
 }
 
 %default_button {
-  @include button(normal, $c:$selected_bg_color, $tc:$selected_fg_color, $style: default);
-  &:focus { @include button(focus, $c:$selected_bg_color, $tc:$selected_fg_color, $style: default);}
-  &:hover { @include button(hover, $c:$selected_bg_color, $tc:$selected_fg_color, $style: default);}
-  &:insensitive { @include button(insensitive, $c:$selected_bg_color, $tc:$selected_fg_color, $style: default);}
-  &:active { @include button(active, $c:$selected_bg_color, $tc:$selected_fg_color, $style: default);}
+  @include button(normal, $c:-st-accent-color, $tc:-st-accent-fg-color, $style: default);
+  &:focus { @include button(focus, $c:-st-accent-color, $tc:-st-accent-fg-color, $style: default);}
+  &:hover { @include button(hover, $c:-st-accent-color, $tc:-st-accent-fg-color, $style: default);}
+  &:insensitive { @include button(insensitive, $c:-st-accent-color, $tc:-st-accent-fg-color, $style: default);}
+  &:active { @include button(active, $c:-st-accent-color, $tc:-st-accent-fg-color, $style: default);}
 }
 
 // items in popover menus
@@ -195,10 +195,8 @@ stage {
   padding: $base_padding * 1.5 $base_padding * 1.5;
   selection-background-color: st-transparentize(-st-accent-color, 0.7);
   selected-color: $fg_color;
-  // Yaru: Use legacy accent color. TODO: drop.
-  selection-background-color: $selected_bg_color;
-  selected-color: $selected_fg_color;
 
+  selection-background-color: -st-accent-color; // Yaru change: we want solid focus-ring.
   border-width: 1px; // Yaru change: we want bordered entries
 }
 

--- a/gnome-shell/src/gnome-shell-sass/_default-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_default-colors.scss
@@ -22,13 +22,9 @@ $error_bg_color: if($variant == 'light', $red_3, $red_4);
 $error_fg_color: $light_1;
 $error_color: $error_bg_color;
 
-// colors for selected or default elements
-$selected_bg_color: if($variant == 'light', $blue_4, $blue_3);
-$selected_fg_color: $light_1;
-
 // link colors
-$link_color: if($variant == 'light', $blue_4, $blue_2);
-$link_visited_color: transparentize($link_color, .6);
+$link_color: if($variant =='light', st-darken(-st-accent-color, 10%), st-lighten(-st-accent-color, 20%));
+$link_visited_color: st-transparentize($link_color, .6);
 
 // special cased widget definitions
 $background_mix_factor: if($variant == 'light', 12%, 9%); // used to boost the color of backgrounds in different variants
@@ -39,7 +35,7 @@ $shadow_color: if($variant == 'light', rgba(0,0,0,.05), rgba(0,0,0,0.2));
 $text_shadow_color: if($variant == 'light', rgba(255,255,255,0.3), rgba(0,0,0,0.2));
 
 // focus colors
-$focus_color: $selected_bg_color;
+$focus_color: -st-accent-color;
 $focus_border_color: st-transparentize($focus_color, 0.5);
 
 // High Contrast overrides

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -574,7 +574,7 @@ $dock_color: $panel_bg_color;
                 margin-bottom: $dash_padding + $dash_edge_offset - 3px; // 3px = size of dot (5px) subtracted from its translationY from appDisplay.js
 
                 // margin-bottom: 13px; // hardcoded - Yaru change: move dot a bit down
-                background-color: $selected_bg_color; // Yaru: we want an accented dot
+                background-color: -st-accent-color; // Yaru: we want an accented dot
             }
         }
     }

--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -488,9 +488,6 @@ $dock_style_modes: [null, shrink, extended, extended-shrink];
 /* Yaru Dock styling */
 
 $dock_color: $panel_bg_color;
-@if $is_warty_nostalgia {
-    $dock_color: darken($jet, 2%);
-}
 
 @each $side in bottom, top, left, right {
     #dashtodockContainer.#{$side} {

--- a/gnome-shell/src/gnome-shell-sass/_drawing.scss
+++ b/gnome-shell/src/gnome-shell-sass/_drawing.scss
@@ -372,8 +372,8 @@
   }
 
   &:drop {
-    background-color: transparentize($selected_bg_color, .8);
-    box-shadow: inset 0 0 0 2px transparentize($selected_bg_color, .2);
+    background-color: st-transparentize(-st-accent-color, .8);
+    box-shadow: inset 0 0 0 2px st-transparentize(-st-accent-color, .2);
   }
 }
 

--- a/gnome-shell/src/gnome-shell-sass/_high-contrast-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_high-contrast-colors.scss
@@ -113,8 +113,8 @@ $hover_fg_color: lighten($fg_color, 20%);
 $active_bg_color: lighten($bg_color, 22%);
 $active_fg_color: lighten($fg_color, 22%);
 
-// selection colors
-$selected_borders_color: lighten($selected_bg_color, 30%);
+// accent colors
+$accent_borders_color: st-lighten(-st-accent-color, 30%);
 
 //
 // High Contrast specific definitions
@@ -128,15 +128,6 @@ $hc_mix_color: $light_1;
 
 // the mix factor used to boost contrast of a color in the above mixin
 $hc_mix_factor: 87%;
-
-// Yaru, Add accent also in high-contrast, but with higher contrast ratio.
-@import 'sass-utils';
-
-$accent_bg_color: optimize-contrast($base_color,
-    $accent_bg_color, $target: 5.5);
-
-$selected_fg_color: $accent_fg_color;
-$selected_bg_color: $accent_bg_color;
 
 $fg_color_dark: $porcelain;
 $bg_color_dark: lighten($jet, 2%);

--- a/gnome-shell/src/gnome-shell-sass/_palette.scss
+++ b/gnome-shell/src/gnome-shell-sass/_palette.scss
@@ -34,8 +34,3 @@ $green: #0e8420;
 $blue: #19B6EE;
 $linkblue: #007aa6;
 $darkblue: #335280;
-
-
-// Semantic colors
-$accent_bg_color: $orange !default;
-$accent_fg_color: $white !default;

--- a/gnome-shell/src/gnome-shell-sass/_palette.scss
+++ b/gnome-shell/src/gnome-shell-sass/_palette.scss
@@ -34,3 +34,19 @@ $green: #0e8420;
 $blue: #19B6EE;
 $linkblue: #007aa6;
 $darkblue: #335280;
+
+// Redefine some GNOME colors we are ok with
+$light_1: white;
+$light_2: $porcelain;
+
+$dark_4: lighten($jet, 4%);
+$dark_5: black;
+
+$red_3: $red;
+$red_4: darken($red, 10%);
+
+$green_4: lighten($green, 5%);
+$green_5: darken($green, 5%);
+
+$yellow_4: darken($yellow, 1%);
+$yellow_3: $yellow;

--- a/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
@@ -12,11 +12,6 @@ $accent_borders_color: if($variant=='light', darken($selected_bg_color, 15%), da
 $panel_bg_color: darken($jet, 2%);
 $panel_fg_color: darken($porcelain, 2%);
 
-@if $is_warty_nostalgia {
-    $panel_bg_color: darken($bg_color, 3%);
-    $panel_fg_color: $_base_color_dark;
-}
-
 $panel-alpha-value: 0.6;
 $panel_opaque_value: 0.0;
 

--- a/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
@@ -5,10 +5,6 @@ $base_active_color: transparentize(white, 0.75);
 $active_bg_color: transparentize($fg_color, 0.8);
 $active_fg_color: darken($fg_color, if($variant=='light', 5%, 3%));
 
-// accent colors, using legacy accent color definition
-// TODO: Remove when using upstream only.
-$accent_borders_color: if($variant=='light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));
-
 $panel_bg_color: darken($jet, 2%);
 $panel_fg_color: darken($porcelain, 2%);
 
@@ -22,7 +18,6 @@ $dash-opaque-alpha-value: 0.0;
 $suggested_bg_color: if($variant=='light', lighten($green, 5%), darken($green, 5%));
 $suggested_border_color: if($variant=='light', darken($suggested_bg_color, 5%), darken($suggested_bg_color, 10%));
 
-$focus_border_color: lighten($accent_bg_color, 14%);
 $alt_borders_color: if($variant=='light', darken($bg_color, 24%), darken($bg_color, 10%));
 
 $system_borders_color: $yaru_borders_color_dark; // Yaru: use our definition
@@ -40,10 +35,3 @@ $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_col
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 $osd_borders_color: transparentize(black, 0.3);
 $osd_outer_borders_color: transparentize(white, 0.84);
-
-// Assets colors
-$checkradio_bg_color: $accent_bg_color;
-$checkradio_fg_color: $accent_fg_color;
-$switch_bg_color: if($variant=='light', $accent_bg_color, darken($accent_bg_color, 8%));
-$switch_border_color: if($variant=='light', darken($accent_bg_color, 15%), darken($borders_color, 5%));
-$progress_bg_color: $accent_bg_color;

--- a/gnome-shell/src/gnome-shell-sass/_yaru-default-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-default-colors.scss
@@ -1,57 +1,6 @@
-// Named Colors
-
-// Redefine some GNOME colors we are ok with
-$light_1: white !default;
-$dark_5: black !default;
-
-// base colors
+// override base colors
 $_base_color_dark: lighten($jet, 4%); // Yaru: use our colors
 $_base_color_light: $light_1; // Yaru: use our colors
 
-// colors for destructive elements
-$destructive_bg_color: if($variant=='light', $red, darken($red, 10%)); // Yaru: use our colors
-$destructive_fg_color: $light_1;
-$destructive_color: $destructive_bg_color;
-
-// colors for levelbars, entries, labels and infobars
-$success_bg_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%)); // Yaru: use our colors
-$success_fg_color: $light_1;
-$success_color: $success_bg_color;
-
-$warning_bg_color: if($variant == 'light', darken($yellow, 1%), $yellow); // Yaru: use our colors
-$warning_fg_color: transparentize(black, .2);
-$warning_color: $warning_bg_color;
-
-$error_bg_color: $red; // Yaru: use our colors
-$error_fg_color: $light_1;
-$error_color: $error_bg_color;
-
-// link colors
-$link_color: if($variant =='light', st-darken(-st-accent-color, 10%), st-lighten(-st-accent-color, 20%));
-$link_visited_color: st-transparentize($link_color, .6);
-
-// special cased widget definitions
-$background_mix_factor: if($variant == 'light', 12%, 9%); // used to boost the color of backgrounds in different variants
-$border_opacity: if($variant == 'light', .85, .9); // change the border opacity in different variants
-
-// shadows
-$shadow_color: if($variant == 'light', rgba(0,0,0,.05), rgba(0,0,0,0.2));
-$text_shadow_color: if($variant == 'light', rgba(255,255,255,0.3), rgba(0,0,0,0.2));
-
-// focus colors
-$focus_color: -st-accent-color;
-$focus_border_color: st-transparentize($focus_color, 0.5);
-
 // Used for dash and other dark elements on light theme
 $yaru_borders_color_dark: lighten(desaturate(lighten($jet, 4%), 100%), 14%);
-
-// High Contrast overrides
-@if $contrast == 'high' {
-    // increase border opacity
-    $border_opacity: .5;
-    // remove shadows
-    $shadow_color: transparent;
-    $text_shadow_color: transparent;
-    // less transparent focus color
-    $focus_border_color: st-transparentize($focus_color, 0.2);
-}

--- a/gnome-shell/src/gnome-shell-sass/_yaru-default-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-default-colors.scss
@@ -1,6 +1,3 @@
-$is_highcontrast: false !default; // Yaru: already defined in gnome-shell.scss.in
-$contrast: if($is_highcontrast, 'normal', 'high') !default;
-
 // Named Colors
 
 // Redefine some GNOME colors we are ok with
@@ -29,21 +26,9 @@ $error_bg_color: $red;
 $error_fg_color: $light_1;
 $error_color: $error_bg_color;
 
-// colors for selected or default elements
-$selected_fg_color: $accent_fg_color;
-$selected_bg_color: $accent_bg_color;
-
-// Yaru: Use contrast-optimized color as background color
-@if $contrast =='high' {
-  $selected_bg_color: optimize-contrast($selected_fg_color, $selected_bg_color,
-    $target: 5.5);
-} @else {
-  $selected_bg_color: optimize-contrast($selected_fg_color, $selected_bg_color);
-}
-
 // link colors
-$link_color: if($variant =='light', darken($selected_bg_color, 10%), lighten($selected_bg_color, 20%));
-$link_visited_color: if($variant =='light', darken($selected_bg_color, 20%), lighten($selected_bg_color, 10%));
+$link_color: if($variant =='light', st-darken(-st-accent-color, 10%), st-lighten(-st-accent-color, 20%));
+$link_visited_color: st-transparentize($link_color, .6);
 
 // special cased widget definitions
 $background_mix_factor: if($variant == 'light', 12%, 9%); // used to boost the color of backgrounds in different variants
@@ -54,8 +39,8 @@ $shadow_color: if($variant == 'light', rgba(0,0,0,.05), rgba(0,0,0,0.2));
 $text_shadow_color: if($variant == 'light', rgba(255,255,255,0.3), rgba(0,0,0,0.2));
 
 // focus colors
-$focus_color: $selected_bg_color;
-$focus_border_color: transparentize($focus_color, 0.5);
+$focus_color: -st-accent-color;
+$focus_border_color: st-transparentize($focus_color, 0.5);
 
 // Used for dash and other dark elements on light theme
 $yaru_borders_color_dark: lighten(desaturate(lighten($jet, 4%), 100%), 14%);
@@ -68,5 +53,5 @@ $yaru_borders_color_dark: lighten(desaturate(lighten($jet, 4%), 100%), 14%);
     $shadow_color: transparent;
     $text_shadow_color: transparent;
     // less transparent focus color
-    $focus_border_color: transparentize($focus_color, 0.2);
+    $focus_border_color: st-transparentize($focus_color, 0.2);
 }

--- a/gnome-shell/src/gnome-shell-sass/_yaru-default-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-default-colors.scss
@@ -5,24 +5,24 @@ $light_1: white !default;
 $dark_5: black !default;
 
 // base colors
-$_base_color_dark: lighten($jet, 4%);
-$_base_color_light: $light_1;
+$_base_color_dark: lighten($jet, 4%); // Yaru: use our colors
+$_base_color_light: $light_1; // Yaru: use our colors
 
 // colors for destructive elements
-$destructive_bg_color: if($variant=='light', $red, darken($red, 10%));
+$destructive_bg_color: if($variant=='light', $red, darken($red, 10%)); // Yaru: use our colors
 $destructive_fg_color: $light_1;
 $destructive_color: $destructive_bg_color;
 
 // colors for levelbars, entries, labels and infobars
-$success_bg_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%));
+$success_bg_color: if($variant == 'light', lighten($green, 5%), darken($green, 5%)); // Yaru: use our colors
 $success_fg_color: $light_1;
 $success_color: $success_bg_color;
 
-$warning_bg_color: if($variant == 'light', darken($yellow, 1%), $yellow);
+$warning_bg_color: if($variant == 'light', darken($yellow, 1%), $yellow); // Yaru: use our colors
 $warning_fg_color: transparentize(black, .2);
 $warning_color: $warning_bg_color;
 
-$error_bg_color: $red;
+$error_bg_color: $red; // Yaru: use our colors
 $error_fg_color: $light_1;
 $error_color: $error_bg_color;
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_a11y.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_a11y.scss
@@ -3,8 +3,8 @@
   width: $ripple_size;
   height: $ripple_size;
   border-radius: $ripple_size * 0.5; // radius equals the size of the box to give us the curve
-  background-color: lighten(transparentize($selected_bg_color, 0.7), 30%);
-  box-shadow: 0 0 2px 2px lighten($selected_bg_color, 20%);
+  background-color: st-lighten(st-transparentize(-st-accent-color, 0.7), 30%);
+  box-shadow: 0 0 2px 2px st-lighten(-st-accent-color, 20%);
 }
 
 // Pointer accessibility notifications
@@ -12,13 +12,13 @@
   width: 60px;
   height: 60px;
   -pie-border-width: 3px;
-  -pie-border-color: $selected_bg_color;
-  -pie-background-color: lighten(transparentize($selected_bg_color, 0.7), 40%);
+  -pie-border-color: -st-accent-color;
+  -pie-background-color: st-lighten(st-transparentize(-st-accent-color, 0.7), 40%);
 }
 
 // Screen zoom/Magnifier
 .magnifier-zoom-region {
-  border: 2px solid $selected_bg_color;
+  border: 2px solid -st-accent-color;
 
   &.full-screen { border-width: 0; }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_calendar.scss
@@ -118,7 +118,7 @@
     &.calendar-today {
       @extend %default_button;
       // override colors above for when today is a weekend
-      color: $selected_fg_color !important;
+      color: -st-accent-fg-color !important;
       &.calendar-day-with-events {
         background-image: url("resource:///org/gnome/shell/theme/calendar-today.svg") !important; // always use light asset with .default style
       }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_check-box.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_check-box.scss
@@ -12,9 +12,6 @@
     // Trick due to St limitations. It needs a background to draw a box-shadow
     background-color: rgba(0, 0, 0, 0.01);
     box-shadow: inset 0 0 0 2px st-transparentize(-st-accent-color, .65);
-
-    // Yaru: keep the accent as we may override it in CSS
-    box-shadow: inset 0 0 0 2px st-transparentize($selected_bg_color, .65);
   }
 
   StIcon {
@@ -37,22 +34,16 @@
   &:checked StIcon {
     background-color: -st-accent-color;
     color: -st-accent-fg-color;
-    background-color: $selected_bg_color; // Yaru: keep the accent as we may override it in CSS
-    color: $selected_fg_color; // Yaru: keep the accent as we may override it in CSS
     border-color: transparent;
   }
 
   &:checked:hover StIcon {
     background-color: st-lighten(-st-accent-color, 5%);
     color: st-lighten(-st-accent-fg-color, 5%);
-    background-color: st-lighten($selected_bg_color, 5%); // Yaru: keep the accent as we may override it in CSS
-    color: st-lighten($selected_fg_color, 5%); // Yaru: keep the accent as we may override it in CSS
   }
 
   &:checked:active StIcon {
     background-color: st-darken(-st-accent-color, 7%);
     color: st-darken(-st-accent-fg-color, 7%);
-    background-color: st-lighten($selected_bg_color, 5%); // Yaru: keep the accent as we may override it in CSS
-    color: st-darken($selected_fg_color, 7%); // Yaru: keep the accent as we may override it in CSS
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dash.scss
@@ -80,7 +80,7 @@ $dash_spacing: $base_margin * 0.5;
       margin-bottom: $dash_padding + $dash_edge_offset - 3px; // 3px = size of dot (5px) subtracted from its translationY from appDisplay.js
 
       // margin-bottom: 13px; // hardcoded - Yaru change: move dot a bit down
-      background-color: $selected_bg_color; // Yaru: we want an accented dot
+      background-color: -st-accent-color; // Yaru: we want an accented dot
     }
   }
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
@@ -147,8 +147,8 @@
   border-radius: $base_border_radius * 2;
   &:hover,&:focus { background-color: $hover_bg_color; }
   &:active {
-    background-color: $selected_bg_color;
-    color: $selected_fg_color;
+    background-color: -st-accent-color;
+    color: -st-accent-fg-color;
   }
 }
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_ibus-popup.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_ibus-popup.scss
@@ -19,7 +19,7 @@
 .candidate-box {
   padding: $base_padding $base_padding * 2 $base_padding $base_padding * 2;
   border-radius: $base_border_radius;
-  &:selected { background-color: $selected_bg_color; color: $selected_fg_color; }
+  &:selected { background-color: -st-accent-color; color: -st-accent-fg-color; }
   &:hover { background-color: $hover_bg_color; color: $hover_fg_color; }
 }
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_keyboard.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_keyboard.scss
@@ -67,8 +67,8 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
 
     // keys that may be latched: ctrl/alt/shift
     &:latched {
-      border-color: lighten($selected_bg_color, 5%);
-      background-color: $selected_bg_color;
+      border-color: st-lighten(-st-accent-color, 5%);
+      background-color: -st-accent-color;
     }
   }
 
@@ -84,12 +84,6 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
     &:hover { @include button(hover, $c:$suggested_bg_color, $tc:-st-accent-fg-color);}
     &:active { @include button(active, $c:$suggested_bg_color, $tc:-st-accent-fg-color);}
     &:checked { @include button(checked, $c:$suggested_bg_color, $tc:-st-accent-fg-color);}
-
-    // Yaru: Use legacy accent color. TODO: drop!
-    @include button(normal, $c:$suggested_bg_color, $tc:$selected_fg_color);
-    &:hover { @include button(hover, $c:$suggested_bg_color, $tc:$selected_fg_color);}
-    &:active { @include button(active, $c:$suggested_bg_color, $tc:$selected_fg_color);}
-    &:checked { @include button(checked, $c:$suggested_bg_color, $tc:$selected_fg_color);}
 
     border-radius: $key_border_radius;
     color: $osd_fg_color;
@@ -147,8 +141,8 @@ $default_key_bg_color: $key_bg_color; // Yaru: Make keyboard buttons work on bot
 
 .emoji-panel {
   .keyboard-key:latched {
-    border-color: lighten($selected_bg_color, 5%);
-    background-color: $selected_bg_color;
+    border-color: st-lighten(-st-accent-color, 5%);
+    background-color: -st-accent-color;
   }
 }
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
@@ -158,8 +158,8 @@ $_gdm_dialog_width: 25em;
   color: darken($_gdm_fg,30%);
 
   &:focus, &:selected {
-    background-color: $selected_bg_color;
-    color: $selected_fg_color;
+    background-color: -st-accent-color;
+    color: -st-accent-fg-color;
   }
 }
 */
@@ -234,9 +234,9 @@ $_gdm_dialog_width: 25em;
 
       &:logged-in {
         .user-icon {
-          border-color: $selected_bg_color;
+          border-color: -st-accent-color;
           StIcon {
-            background-color: transparentize($selected_bg_color, .7);
+            background-color: st-transparentize(-st-accent-color, .7);
           }
         }
       }
@@ -372,7 +372,7 @@ $_gdm_dialog_width: 25em;
   StButton#vhandle, StButton#hhandle {
     background-color: transparentize($bg_color,0.7);
     &:hover, &:focus { background-color: transparentize($bg_color,0.5); }
-    &:active { background-color: transparentize($selected_bg_color,0.5); }
+    &:active { background-color: st-transparentize(-st-accent-color,0.5); }
   }
 }
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_looking-glass.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_looking-glass.scss
@@ -10,8 +10,6 @@
 
   // override link color since OSD style
   $lg_link_color: st-lighten(-st-accent-color, 20%);
-    // Yaru: keep the accent as we may override it in CSS
-  $lg_link_color: st-lighten($selected_bg_color, 20%);
   .shell-link {
     color: $lg_link_color;
     &:hover { color: st-lighten($lg_link_color, 10%); }
@@ -226,16 +224,9 @@
       &:checked {
         background: -st-accent-color;
         color: -st-accent-fg-color;
-
-        background-color: $selected_bg_color; // Yaru: keep the accent as we may override it in CSS
-        color: $selected_fg_color; // Yaru: keep the accent as we may override it in CSS
-
         &:hover {
           background-color: st-lighten(-st-accent-color, 5%);
           color: st-lighten(-st-accent-fg-color, 5%);
-
-          background-color: st-lighten($selected_bg_color, 5%); // Yaru: keep the accent as we may override it in CSS
-          color: st-lighten($selected_fg_color, 5%); // Yaru: keep the accent as we may override it in CSS
         }
       }
     }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_misc.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_misc.scss
@@ -53,6 +53,6 @@
 
 /* Tiled window previews */
 .tile-preview {
-  background-color: transparentize($selected_bg_color,0.5);
-  border: 1px solid $selected_bg_color;
+  background-color: st-transparentize(-st-accent-color,0.5);
+  border: 1px solid -st-accent-color;
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_osd.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_osd.scss
@@ -36,8 +36,8 @@ $osd_levelbar_height:6px;
 
 // Monitor number label
 .osd-monitor-label {
-  background-color: $selected_bg_color;
-  color: $selected_fg_color;
+  background-color: -st-accent-color;
+  color: -st-accent-fg-color;
   border-radius: $modal_radius;
   font-size: 3em;
   font-weight: bold;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_panel.scss
@@ -137,9 +137,6 @@ $panel_transition_duration: 250ms; // same as the overview transition duration
 
   // use system text styles for overview panel
   $button-system-panel-fg-color: $system_panel_fg_color;
-  @if $is_warty_nostalgia {
-    $button-system-panel-fg-color: lighten($panel_fg_color, 5%);
-  }
   &:overview {
     .panel-button {
       @include panel_button($fg:$button-system-panel-fg-color);

--- a/gnome-shell/src/gnome-shell-sass/widgets/_quick-settings.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_quick-settings.scss
@@ -120,8 +120,8 @@
       background-color: transparentize($fg_color, 0.8);
 
       &.active {
-        background-color: $selected_bg_color;
-        color: $selected_fg_color;
+        background-color: -st-accent-color;
+        color: -st-accent-fg-color;
       }
 
       // draw hc outline

--- a/gnome-shell/src/gnome-shell-sass/widgets/_screenshot.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_screenshot.scss
@@ -170,18 +170,18 @@ $screenshot_ui_button_red: $red; // Yaru: Use our palette's color
 .screenshot-ui-window-selector-window {
   &:hover {
     .screenshot-ui-window-selector-window-border {
-      border-color: darken($selected_bg_color, 15%);
+      border-color: st-darken(-st-accent-color, 15%);
     }
   }
   &:checked {
     .screenshot-ui-window-selector-window-border {
-      border-color: $selected_bg_color;
-      background-color: transparentize($selected_bg_color, 0.8);
+      border-color: -st-accent-color;
+      background-color: st-transparentize(-st-accent-color, 0.8);
     }
 
     .screenshot-ui-window-selector-check {
-      color: $selected_fg_color;
-      background-color: $selected_bg_color;
+      color: -st-accent-fg-color;
+      background-color: -st-accent-color;
     }
   }
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_slider.scss
@@ -12,7 +12,6 @@ $slider_size: to_em(18px);; // Yaru change: larger slider cause to border in lig
   -barlevel-background-color: transparentize($fg_color, 0.9);
   // fill style
   -barlevel-active-background-color: -st-accent-color;
-  -barlevel-active-background-color: $selected_bg_color; // Yaru: keep the accent as we may override it in CSS
   // overfill style (red in this case)
   -barlevel-overdrive-color: $destructive_color;
   -barlevel-overdrive-separator-width:1px;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_switcher-popup.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_switcher-popup.scss
@@ -77,5 +77,5 @@ $switcher_radius: $modal_radius + $switcher_padding;
 
 // Window cycler highlight
 .cycler-highlight {
-  border: 5px solid $selected_bg_color;
+  border: 5px solid -st-accent-color;
 }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_switches.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_switches.scss
@@ -40,18 +40,9 @@ $switch_handle_size: 20px;
   &:checked {
     background: -st-accent-color;
     color: -st-accent-fg-color;
-
-    // Yaru: keep using scss colors
-    background: $selected_bg_color;
-    color: $selected_fg_color;
-
     &:hover {
       background-color: st-lighten(-st-accent-color, 5%);
       color: st-lighten(-st-accent-fg-color, 5%);
-
-      // Yaru: keep using scss colors
-      background: st-lighten($selected_bg_color, 5%);
-      color: st-lighten($selected_fg_color, 5%);
     }
 
     .handle {

--- a/gnome-shell/src/gnome-shell.scss.in
+++ b/gnome-shell/src/gnome-shell.scss.in
@@ -1,10 +1,6 @@
-$variant: if(@DarkVariant@, 'dark', 'light');
-$yaru_variant: '@YaruVariant@';
-$yaru_accent_color: '@YaruVariant@';
+$variant: @Variant@;
 $use_gresource: @UseGResource@;
-$is_highcontrast: @HighContrast@;
-$UPSTREAM_VARIANTS: ['dark', 'light'];
-$contrast: if($is_highcontrast, 'high', 'normal');
+$contrast: @Contrast@;
 
 @import 'sass-utils';
 
@@ -25,12 +21,7 @@ $contrast: if($is_highcontrast, 'high', 'normal');
     @return url(quote($url));
 }
 
-@if not list-index(["dark", "light"], $yaru_variant) and
-    not variable-exists("accent_bg_color") {
-    @error "Missing definition for accent color variable: $accent_bg_color";
-}
-
-@debug 'Generating GNOME Shell ' + $yaru_variant + ' theme (' + $variant +' variant, hc: '+ $is_highcontrast+')';
+@debug 'Generating GNOME Shell ' + $variant + ' theme (contrast: '+ $contrast + ')';
 
 @import "gnome-shell-sass/_@Colors@";
 @import "gnome-shell-sass/_drawing";

--- a/gnome-shell/src/meson.build
+++ b/gnome-shell/src/meson.build
@@ -6,31 +6,22 @@ styles = [
   'gnome-shell-high-contrast',
 ]
 
-DEFAULT_VARIANT = get_option('gnome-shell-default-variant')
 DEFAULT_GDM_VARIANT = get_option('gdm-default-variant')
 DEFAULT_HIGH_CONTRAST_VARIANT = get_option('gnome-shell-default-high-contrast-variant')
-INCLUDE_HIGH_CONTRAST_VARIANTS = false
 
-variants = []
-foreach variant : yaru_flavours
-  if variant == 'default'
-    variants += DEFAULT_VARIANT
-    continue
-  endif
-
-  if variant.startswith('mate')
-    continue
-  endif
-
-  variants += variant
-endforeach
-
-if not variants.contains(DEFAULT_VARIANT)
-  error('Invalid gnome-shell default variant selected')
-endif
+variants = [
+  'light',
+  'dark',
+]
 
 if not variants.contains(DEFAULT_GDM_VARIANT)
-  error('Invalid default gdm variant selected')
+  error('Invalid default gdm variant selected: @0@'.format(
+    DEFAULT_GDM_VARIANT))
+endif
+
+if not variants.contains(DEFAULT_HIGH_CONTRAST_VARIANT)
+  error('Invalid gnome-shell default high-contrast variant selected: @0@'.format(
+    DEFAULT_HIGH_CONTRAST_VARIANT))
 endif
 
 theme_css = []
@@ -84,19 +75,12 @@ icons_gresource_xml = files('data/gnome-shell-icons.gresource.xml')[0]
 
 foreach variant: variants
   is_dark = variant == 'dark' or variant.endswith('-dark')
-  is_variant = variant != DEFAULT_VARIANT
-  variant_base_name = is_dark ? variant.split('-dark')[0] : variant
+  is_variant = is_dark
   variant_suffix = is_variant ? '-@0@'.format(variant)  : ''
   theme_full_name = meson.project_name() + variant_suffix
-  is_custom_accent = enabled_accent_colors.contains(variant_base_name)
 
   install_theme_sources = not gnomeshell_user_themes_suport.disabled()
   install_dir = gnomeshell_theme_dir + variant_suffix
-
-  accent_configuration = {
-    'yaru_dark_variant': is_dark ? 'true' : 'false',
-    'yaru_accent_color': is_custom_accent ? variant_base_name : 'default',
-  }
 
   # generate .css files
   style_css = []
@@ -110,7 +94,7 @@ foreach variant: variants
     if high_contrast
       if variant == DEFAULT_HIGH_CONTRAST_VARIANT
         stylename = style
-      elif not INCLUDE_HIGH_CONTRAST_VARIANTS
+      else
         continue
       endif
     endif
@@ -122,26 +106,13 @@ foreach variant: variants
       input: 'gnome-shell.scss.in',
       output: '@0@.scss'.format(stylename),
       configuration: {
-        'DarkVariant': is_dark ? 'true' : 'false',
+        'Variant': variant,
         'YaruVariant': variant,
         'UseGResource': gnomeshell_use_gresource ? 'true' : 'false',
-        'HighContrast': high_contrast ? 'true' : 'false',
+        'Contrast': high_contrast ? 'high' : 'normal',
         'Colors': (high_contrast ? 'high-contrast-' : '') + 'colors',
       },
     )
-
-    if is_custom_accent and (not high_contrast or
-      variant == DEFAULT_HIGH_CONTRAST_VARIANT or
-      INCLUDE_HIGH_CONTRAST_VARIANTS)
-      theme_sources += theme_main_file
-      theme_main_file = configure_file(
-        configuration: accent_configuration + {
-          'yaru_theme_entry_point': meson.project_build_root() / '@0@'.format(theme_main_file),
-        },
-        input: accent_colors_definitions_scss,
-        output: '@0@-accent-colors.scss'.format(stylename),
-      )
-    endif
 
     style_css += custom_target(
       'style-@0@'.format(stylename),

--- a/gtk/src/default/gtk-3.0/_colors.scss
+++ b/gtk/src/default/gtk-3.0/_colors.scss
@@ -8,11 +8,6 @@ $caret_color: if($variant == 'light', lighten($text_color, 5%), darken($text_col
 $bg_color: if($variant == 'light', #FAFAFA, lighten($jet, 8%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 
-$is_warty_nostalgia: false !default;
-@if $is_warty_nostalgia and $variant == 'light' {
-    $bg_color: $warty_nostalgia_bg;
-}
-
 $selected_fg_color: $accent_fg_color;
 $selected_bg_color: if($variant == 'light', $accent_bg_color, darken($accent_bg_color, 4%));
 

--- a/gtk/src/default/gtk-4.0/_colors.scss
+++ b/gtk/src/default/gtk-4.0/_colors.scss
@@ -8,11 +8,6 @@ $text_color: if($variant == 'light', black, white);
 $bg_color: if($variant == 'light', #FAFAFA, lighten($jet, 8%));
 $fg_color: if($variant == 'light', $inkstone, $porcelain);
 
-$is_warty_nostalgia: false !default;
-@if $is_warty_nostalgia and $variant == 'light' {
-    $bg_color: $warty_nostalgia_bg;
-}
-
 $selected_fg_color: $accent_fg_color;
 $selected_bg_color: $accent_bg_color;
 $selected_borders_color: if($variant== 'light', darken($selected_bg_color, 15%), darken($selected_bg_color, 30%));

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,6 @@
 option('icons', type: 'boolean', value: true, description:'build icons component')
 option('gnome-shell', type: 'boolean', value: true, description:'build gnome-shell component')
-option('gnome-shell-default-variant', type: 'string', value: 'light', description:'default variant to be used for gnome-shell')
-option('gnome-shell-default-high-contrast-variant', type: 'string', value: 'blue-dark', description:'default variant to be used for gnome-shell high contrast')
+option('gnome-shell-default-high-contrast-variant', type: 'string', value: 'dark', description:'default variant to be used for gnome-shell high contrast')
 option('gnome-shell-gresource', type: 'boolean', value: false, description: 'build gnome-shell component in gresources')
 option('gnome-shell-user-themes-support', type: 'feature', value: 'auto', description: 'install gnome-shell uncompressed CSS themes as User Themes expects')
 option('gdm-default-variant', type: 'string', value: 'dark', description:'default variant to be used in GDM')

--- a/sessions/meson.build
+++ b/sessions/meson.build
@@ -3,8 +3,6 @@ gnomeshell_mode_dir = join_paths(get_option('datadir'), 'gnome-shell', 'modes')
 conf_data = configuration_data()
 conf_data.set('ThemeName', meson.project_name())
 conf_data.set('LowerCaseThemeName', meson.project_name().to_lower())
-conf_data.set('DefaultVariant',
-    get_option('gnome-shell-default-variant').endswith('dark') ? 'dark' : 'light')
 
 resource_path = gnomeshell_use_gresource ? join_paths('theme', meson.project_name(), '') : ''
 conf_data.set('ThemeResourcePath', resource_path)


### PR DESCRIPTION
Drop our custom accent color implementation that based on multiple CSS files by using upstream `-st-accent-color` instead.

Still based on 47, but will simplify the merge.

Based on https://github.com/ubuntu/yaru/pull/4122

Closes #4196