### PR TITLE
Icon Template: Moved All Objects Related to Respective Icons Sizes to their Own Respective Layers

### DIFF
--- a/icons/src/fullcolor/Horizontal Oblong App Icon Template.svg
+++ b/icons/src/fullcolor/Horizontal Oblong App Icon Template.svg
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="96"
    inkscape:export-xdpi="96"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.4 (1:1.4+202410161351+e7c3feb100)"
    sodipodi:docname="Horizontal Oblong App Icon Template.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Yaru Icon Theme Template</title>
   <sodipodi:namedview
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="306.09954"
-     inkscape:cy="86.820138"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="190.21172"
+     inkscape:cy="208.24295"
+     inkscape:current-layer="g13"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1860"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -72,7 +73,8 @@
        empspacing="4"
        snapvisiblegridlinesonly="true"
        originx="0"
-       originy="0" />
+       originy="0"
+       units="px" />
     <inkscape:grid
        type="xygrid"
        id="grid11592"
@@ -87,7 +89,8 @@
        empopacity="0.25098039"
        snapvisiblegridlinesonly="true"
        originx="0"
-       originy="0" />
+       originy="0"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs3">
@@ -217,9 +220,9 @@
        inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter53827"
-       x="-0.042857721"
+       x="-0.04285772"
        width="1.0857154"
-       y="-0.054544519"
+       y="-0.054544518"
        height="1.109089">
       <feGaussianBlur
          inkscape:collect="always"
@@ -394,162 +397,283 @@
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;filter:url(#filter53855);opacity:0.1"
-         d="m 263.9973,206.07598 c 0,35.29673 -3.62542,39.09461 -38.99353,38.92162 H 151.9973 78.99083 C 43.62271,245.17059 39.9973,241.37271 39.9973,206.07598 v -98.15676 c 0,-35.296716 3.625,-38.921616 38.99353,-38.921616 h 73.00647 73.00647 c 35.36853,0 38.99353,3.6249 38.99353,38.921616 z"
-         id="rect4158-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;filter:url(#filter53827);opacity:0.2"
-         d="m 263.9973,206.07598 c 0,35.29673 -3.62542,39.09461 -38.99353,38.92162 H 151.9973 78.99083 C 43.62271,245.17059 39.9973,241.37271 39.9973,206.07598 v -98.15676 c 0,-35.296716 3.625,-38.921616 38.99353,-38.921616 h 73.00647 73.00647 c 35.36853,0 38.99353,3.6249 38.99353,38.921616 z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 343.99961,196.86562 c 0,-1.12014 -0.0241,-2.01524 -0.1543,-2.79101 -0.13022,-0.77577 -0.38763,-1.48014 -0.91601,-2.00977 -0.52838,-0.52962 -1.23687,-0.79079 -2.01367,-0.91992 -0.77681,-0.12912 -1.67169,-0.15002 -2.79493,-0.14453 h -6.12109 -6.125 c -1.12104,-0.005 -2.01529,0.0156 -2.79102,0.14453 -0.77681,0.12912 -1.48529,0.39029 -2.01367,0.91992 -0.52838,0.52964 -0.78579,1.234 -0.91601,2.00977 -0.13022,0.77577 -0.1543,1.67087 -0.1543,2.79101 v 8.26954 c 0,1.12013 0.024,2.01264 0.1543,2.78711 0.13033,0.77446 0.38927,1.48001 0.91797,2.00781 0.52869,0.5278 1.23438,0.78594 2.00976,0.91601 0.77539,0.13007 1.67062,0.1543 2.79297,0.1543 h 6.125 6.125 c 1.12235,0 2.01758,-0.0242 2.79297,-0.1543 0.77538,-0.13007 1.48107,-0.38821 2.00976,-0.91601 0.5287,-0.5278 0.78764,-1.23334 0.91797,-2.00781 0.13033,-0.77448 0.1543,-1.66697 0.1543,-2.78711 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss"
-         clip-path="none" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 336.00001,242.0957 c 0,-0.71904 -0.0148,-1.30185 -0.11042,-1.83593 -0.0957,-0.53409 -0.2947,-1.0683 -0.72916,-1.47657 -0.43446,-0.40826 -1.00611,-0.59657 -1.57708,-0.68554 -0.57098,-0.089 -1.19518,-0.10119 -1.96459,-0.0977 h -3.08542 -4.15833 c -0.76604,-0.003 -1.38917,0.009 -1.95834,0.0977 -0.57096,0.089 -1.14262,0.27727 -1.57707,0.68554 -0.43447,0.40827 -0.63354,0.94248 -0.72917,1.47657 -0.0957,0.53408 -0.11042,1.11689 -0.11042,1.83593 v 5.8086 c 0,0.71904 0.0146,1.30058 0.11042,1.83398 0.0958,0.53341 0.29645,1.06768 0.73125,1.47461 0.43479,0.40693 1.00555,0.59404 1.57499,0.68359 0.56945,0.0896 1.18988,0.10352 1.95834,0.10352 h 4.15833 3.09167 c 0.76846,0 1.38889,-0.014 1.95834,-0.10352 0.56944,-0.0895 1.1402,-0.27666 1.575,-0.68359 0.43479,-0.40693 0.6355,-0.9412 0.73124,-1.47461 0.0958,-0.5334 0.11042,-1.11494 0.11042,-1.83398 z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss"
-         clip-path="none" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 350.99951,143.19385 c 0,-1.42096 -0.0308,-2.54883 -0.19141,-3.50586 -0.16064,-0.95703 -0.4726,-1.79146 -1.09179,-2.41211 -0.61919,-0.62065 -1.45612,-0.93647 -2.41407,-1.0957 -0.95795,-0.15924 -2.08705,-0.18666 -3.51171,-0.17969 h -7.79102 -7.79688 c -1.42131,-0.007 -2.5495,0.0207 -3.50585,0.17969 -0.95796,0.15923 -1.79488,0.47505 -2.41407,1.0957 -0.61919,0.62065 -0.93115,1.45508 -1.09179,2.41211 -0.16065,0.95703 -0.19141,2.0849 -0.19141,3.50586 v 11.61523 c 0,1.42097 0.0307,2.54669 0.19141,3.50196 0.16075,0.95527 0.47425,1.78779 1.09375,2.40625 0.6195,0.61845 1.45363,0.93134 2.41015,1.09179 0.95653,0.16046 2.08403,0.19141 3.50781,0.19141 h 7.79688 7.79688 c 1.42378,0 2.55128,-0.031 3.50781,-0.19141 0.95653,-0.16045 1.79065,-0.47334 2.41015,-1.09179 0.61951,-0.61846 0.933,-1.45098 1.09375,-2.40625 0.16076,-0.95527 0.19141,-2.08099 0.19141,-3.50196 z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss"
-         clip-path="none" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 367,76.456413 c 0,-2.166089 -0.0501,-3.87167 -0.28674,-5.275073 -0.23663,-1.403413 -0.68049,-2.551815 -1.52351,-3.393031 -0.84301,-0.841206 -1.99607,-1.285198 -3.4064,-1.518579 -1.41033,-0.233381 -3.12735,-0.27894 -5.30841,-0.26832 h -12.47482 -12.48078 c -2.17772,-0.01052 -3.89386,0.03517 -5.30268,0.26832 -1.41034,0.233381 -2.5634,0.677373 -3.40641,1.518579 -0.84301,0.841216 -1.28688,1.989618 -1.52351,3.393031 C 321.05009,72.584753 321,74.290324 321,76.456413 v 17.088582 c 0,2.166097 0.05,3.870773 0.28674,5.271282 0.23674,1.400503 0.68211,2.545393 1.52542,3.383503 0.84331,0.83812 1.99555,1.27948 3.4045,1.51477 1.40894,0.23529 3.12246,0.28545 5.30268,0.28545 h 12.48078 12.48055 c 2.18021,0 3.89374,-0.0502 5.30268,-0.28545 1.40894,-0.23529 2.56118,-0.67666 3.40449,-1.51478 0.84332,-0.83811 1.28869,-1.983 1.52542,-3.383502 C 366.95001,97.415768 367,95.711083 367,93.544995 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss"
-         clip-path="none" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4884);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231078 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229492 0.90625,9.730392 9.74838,9.730392 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730402 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="none" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4886);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 263.9973,205.07568 c 0,35.29673 -3.62542,39.09461 -38.99353,38.92162 H 151.9973 78.99083 C 43.62271,244.17029 39.9973,240.37241 39.9973,205.07568 v -98.15676 c 0,-35.296716 3.625,-38.921616 38.99353,-38.921616 h 73.00647 73.00647 c 35.36853,0 38.99353,3.6249 38.99353,38.921616 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 343.49998,195.636 c 0,-4.65703 -0.47377,-5.15811 -5.09574,-5.13529 h -6.40426 -6.40425 c -4.62197,-0.0229 -5.09574,0.47826 -5.09574,5.13529 v 8.7287 c 0,4.65703 0.47371,5.13529 5.09574,5.13529 h 6.40425 6.40426 c 4.62202,0 5.09574,-0.47827 5.09574,-5.1353 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4880);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         clip-path="none" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4878);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.50001,240.8545 c 0,-3.04166 -0.30899,-3.36894 -3.32331,-3.35403 h -4.17669 -4.17669 c -3.01432,-0.0149 -3.32331,0.31237 -3.32331,3.35403 v 6.29146 c 0,3.04167 0.30895,3.35404 3.32331,3.35404 h 4.17669 4.17669 c 3.01435,0 3.32331,-0.31238 3.32331,-3.35404 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="none" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4882);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="none" />
+       id="layer3"
+       inkscape:label="16x16"
+       style="display:inline;enable-background:new">
+      <g
+         inkscape:groupmode="layer"
+         id="g3"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 336.00001,242.0957 c 0,-0.71904 -0.0148,-1.30185 -0.11042,-1.83593 -0.0957,-0.53409 -0.2947,-1.0683 -0.72916,-1.47657 -0.43446,-0.40826 -1.00611,-0.59657 -1.57708,-0.68554 -0.57098,-0.089 -1.19518,-0.10119 -1.96459,-0.0977 h -3.08542 -4.15833 c -0.76604,-0.003 -1.38917,0.009 -1.95834,0.0977 -0.57096,0.089 -1.14262,0.27727 -1.57707,0.68554 -0.43447,0.40827 -0.63354,0.94248 -0.72917,1.47657 -0.0957,0.53408 -0.11042,1.11689 -0.11042,1.83593 v 5.8086 c 0,0.71904 0.0146,1.30058 0.11042,1.83398 0.0958,0.53341 0.29645,1.06768 0.73125,1.47461 0.43479,0.40693 1.00555,0.59404 1.57499,0.68359 0.56945,0.0896 1.18988,0.10352 1.95834,0.10352 h 4.15833 3.09167 c 0.76846,0 1.38889,-0.014 1.95834,-0.10352 0.56944,-0.0895 1.1402,-0.27666 1.575,-0.68359 0.43479,-0.40693 0.6355,-0.9412 0.73124,-1.47461 0.0958,-0.5334 0.11042,-1.11494 0.11042,-1.83398 z"
+           id="path997"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scscccccccsscscscscscss"
+           clip-path="none" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4878);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 335.50001,240.8545 c 0,-3.04166 -0.30899,-3.36894 -3.32331,-3.35403 h -4.17669 -4.17669 c -3.01432,-0.0149 -3.32331,0.31237 -3.32331,3.35403 v 6.29146 c 0,3.04167 0.30895,3.35404 3.32331,3.35404 h 4.17669 4.17669 c 3.01435,0 3.32331,-0.31238 3.32331,-3.35404 z"
+           id="path918"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss"
+           clip-path="none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="layer4"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g2"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 335.5,240.91906 c 0,-2.89212 -0.30212,-3.43393 -3.24945,-3.41873 h -4.25051 -4.25059 c -2.94734,-0.0152 -3.24945,0.52661 -3.24945,3.41873 v 6.16221 c 0,2.8914 0.30208,3.41873 3.24945,3.41873 h 4.25059 4.25051 c 2.94737,0 3.24945,-0.52733 3.24945,-3.41873 z"
+           id="path958-6-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss"
+           clip-path="none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g1"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4878-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           clip-path="none"
+           d="m 323.74609,238 c -0.72147,-0.004 -1.26525,0.0309 -1.64453,0.11133 -0.37928,0.0804 -0.57351,0.19073 -0.70898,0.34179 -0.27096,0.30216 -0.39258,1.03815 -0.39258,2.4668 v 6.16211 c 0,1.42829 0.11996,2.15824 0.39062,2.45899 0.13534,0.15037 0.33287,0.26059 0.7129,0.34179 C 322.48354,249.964 323.02807,250 323.75,250 h 4.25 4.25 c 0.72193,0 1.26647,-0.036 1.64648,-0.11719 0.38003,-0.0812 0.57756,-0.19142 0.7129,-0.34179 0.27066,-0.30075 0.39062,-1.0307 0.39062,-2.45899 v -6.16211 c 0,-1.42865 -0.12162,-2.16464 -0.39258,-2.4668 -0.13548,-0.15106 -0.3297,-0.26139 -0.70898,-0.34179 -0.37928,-0.0804 -0.92306,-0.11533 -1.64453,-0.11133 h -0.002 H 328 323.74805 Z m 1.72852,1.01367 c 1.78944,-0.002 3.57972,0.006 5.36914,0.0156 0.93326,0.0249 1.87492,-0.0297 2.80273,0.0762 0.24823,-0.012 0.23037,0.25855 0.25977,0.43555 0.0929,1.75156 0.0355,3.50827 0.0527,5.26171 -0.0216,1.28778 0.0446,2.58231 -0.082,3.86524 0.011,0.26053 -0.30576,0.20235 -0.47461,0.25195 -0.93118,0.0703 -1.87701,0.0323 -2.83789,0.0508 -2.63538,-0.002 -5.2827,0.0273 -7.9082,-0.0391 -0.17166,-0.0598 -0.51095,0.0111 -0.53125,-0.23633 -0.132,-1.17024 -0.0633,-2.35521 -0.0859,-3.53125 0.0153,-1.85793 -0.0377,-3.71784 0.043,-5.57422 0.0491,-0.13737 0.004,-0.38481 0.15039,-0.44922 1.06826,-0.19171 2.1625,-0.094 3.24219,-0.12695 z"
+           id="path918-4"
+           inkscape:connector-curvature="0" />
+      </g>
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms and folds"
-       style="display:inline" />
-    <g
-       inkscape:groupmode="layer"
-       id="layer2"
-       inkscape:label="Borders"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.990234,67.998047 c -35.36853,0 -38.992187,3.623202 -38.992187,38.919923 v 98.1582 c 0,0.0882 0.0019,0.16224 0.002,0.25 V 108.91602 C 40,73.6193 43.625611,69.994141 78.994141,69.994141 H 152 225.00586 c 35.28016,0 38.97394,3.621035 38.99219,38.671879 v -1.74805 c 0,-35.296721 -3.62561,-38.919923 -38.99414,-38.919923 h -73.00586 z"
-         id="rect4158-78"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 39.998047,203.07617 v 2 c 0,35.29673 3.624067,39.09487 38.992187,38.92188 h 73.007816 73.00586 c 35.36811,0.17299 38.99414,-3.62515 38.99414,-38.92188 v -2 c 0,35.29673 -3.62603,39.09487 -38.99414,38.92188 H 151.99805 78.990234 c -35.36812,0.17299 -38.992187,-3.62515 -38.992187,-38.92188 z"
-         id="rect4158-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.5,240.91906 c 0,-2.89212 -0.30212,-3.43393 -3.24945,-3.41873 h -4.25051 -4.25059 c -2.94734,-0.0152 -3.24945,0.52661 -3.24945,3.41873 v 6.16221 c 0,2.8914 0.30208,3.41873 3.24945,3.41873 h 4.25059 4.25051 c 2.94737,0 3.24945,-0.52733 3.24945,-3.41873 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="none" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 343.5,195.49707 c 0,-4.22694 -0.46324,-5.01881 -4.98248,-4.9966 h -6.51745 -6.51758 c -4.51925,-0.0222 -4.98249,0.76966 -4.98249,4.9966 v 9.00633 c 0,4.22588 0.46319,4.9966 4.98249,4.9966 h 6.51758 6.51745 c 4.51929,0 4.98248,-0.77072 4.98248,-4.9966 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="none" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="none" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 366.50065,75.231076 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229494 0.90625,9.730394 9.74838,9.730394 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730404 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="none" />
+       id="g25"
+       inkscape:label="24x24"
+       style="display:inline;enable-background:new">
+      <g
+         inkscape:groupmode="layer"
+         id="g21"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 343.99961,196.86562 c 0,-1.12014 -0.0241,-2.01524 -0.1543,-2.79101 -0.13022,-0.77577 -0.38763,-1.48014 -0.91601,-2.00977 -0.52838,-0.52962 -1.23687,-0.79079 -2.01367,-0.91992 -0.77681,-0.12912 -1.67169,-0.15002 -2.79493,-0.14453 h -6.12109 -6.125 c -1.12104,-0.005 -2.01529,0.0156 -2.79102,0.14453 -0.77681,0.12912 -1.48529,0.39029 -2.01367,0.91992 -0.52838,0.52964 -0.78579,1.234 -0.91601,2.00977 -0.13022,0.77577 -0.1543,1.67087 -0.1543,2.79101 v 8.26954 c 0,1.12013 0.024,2.01264 0.1543,2.78711 0.13033,0.77446 0.38927,1.48001 0.91797,2.00781 0.52869,0.5278 1.23438,0.78594 2.00976,0.91601 0.77539,0.13007 1.67062,0.1543 2.79297,0.1543 h 6.125 6.125 c 1.12235,0 2.01758,-0.0242 2.79297,-0.1543 0.77538,-0.13007 1.48107,-0.38821 2.00976,-0.91601 0.5287,-0.5278 0.78764,-1.23334 0.91797,-2.00781 0.13033,-0.77448 0.1543,-1.66697 0.1543,-2.78711 z"
+           id="path995"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccccccccssscccscscccss"
+           clip-path="none" />
+        <path
+           sodipodi:nodetypes="scccssscsss"
+           inkscape:connector-curvature="0"
+           id="path914"
+           d="m 343.49998,195.636 c 0,-4.65703 -0.47377,-5.15811 -5.09574,-5.13529 h -6.40426 -6.40425 c -4.62197,-0.0229 -5.09574,0.47826 -5.09574,5.13529 v 8.7287 c 0,4.65703 0.47371,5.13529 5.09574,5.13529 h 6.40425 6.40426 c 4.62202,0 5.09574,-0.47827 5.09574,-5.1353 z"
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4880);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           clip-path="none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g22"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g23"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 343.5,195.49707 c 0,-4.22694 -0.46324,-5.01881 -4.98248,-4.9966 h -6.51745 -6.51758 c -4.51925,-0.0222 -4.98249,0.76966 -4.98249,4.9966 v 9.00633 c 0,4.22588 0.46319,4.9966 4.98249,4.9966 h 6.51758 6.51745 c 4.51929,0 4.98248,-0.77072 4.98248,-4.9966 z"
+           id="path958-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss"
+           clip-path="none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g24"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4880-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           clip-path="none"
+           d="m 325.48047,191 c -1.11517,-0.005 -1.96593,0.0431 -2.58399,0.16797 -0.61805,0.12486 -0.9851,0.31305 -1.23632,0.58008 C 321.15771,192.28211 321,193.40089 321,195.49609 v 9.00782 c 0,2.09467 0.15795,3.20641 0.66016,3.73828 0.2511,0.26593 0.61757,0.456 1.23632,0.58203 0.61876,0.12598 1.47033,0.17578 2.58594,0.17578 H 332 h 6.51758 c 1.11561,0 1.96718,-0.0498 2.58594,-0.17578 0.61875,-0.12603 0.98522,-0.3161 1.23632,-0.58203 C 342.84205,207.71032 343,206.59858 343,204.50391 v -9.00782 c 0,-2.0952 -0.15771,-3.21398 -0.66016,-3.74804 -0.25122,-0.26704 -0.61827,-0.45522 -1.23632,-0.58008 C 340.48546,191.0431 339.6347,190.995 338.51953,191 H 332 Z m 7.13672,1.01562 c 1.98549,-0.002 3.98733,-0.004 5.96289,0.0195 0.96763,0.0402 1.99118,-0.0256 2.90234,0.34765 0.38183,0.34917 0.35253,0.95778 0.39453,1.4336 0.0768,3.51723 0.0322,7.10036 0.0312,10.65039 -0.0482,0.90085 0.0757,1.7786 -0.15039,2.65625 -0.10866,0.64044 -0.871,0.73134 -1.40039,0.74414 -4.81717,0.0743 -9.63544,0.0481 -14.45312,0.0391 -1.02032,-0.0584 -2.06055,0.10963 -3.0586,-0.16992 -0.66794,-0.12827 -0.69858,-0.9186 -0.73828,-1.46094 -0.1041,-3.00472 -0.0701,-6.07992 -0.084,-9.12695 0.0395,-1.40997 -0.0595,-2.82226 0.19726,-4.22071 0.0532,-0.62993 0.75618,-0.7251 1.24805,-0.8164 3.04692,-0.0947 6.09515,-0.0772 9.14844,-0.0957 z"
+           id="path914-4"
+           inkscape:connector-curvature="0" />
+      </g>
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer12"
-       inkscape:label="Highlights"
-       style="opacity:0.7">
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient4884-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         clip-path="none"
-         d="m 331.24609,66 c -2.19593,-0.01075 -3.8846,0.08102 -5.15234,0.335938 -1.26774,0.254911 -2.09536,0.65956 -2.67187,1.269531 C 322.2688,68.825409 322,71.13305 322,75.230469 v 17.539062 c 0,4.096393 0.26904,6.392197 1.42188,7.607419 0.57641,0.60762 1.40538,1.01239 2.67382,1.26953 1.26844,0.25712 2.95596,0.35352 5.15235,0.35352 H 344 356.75195 c 2.19639,0 3.88586,-0.0964 5.1543,-0.35352 1.26844,-0.25714 2.09741,-0.66191 2.67383,-1.26953 C 365.73291,99.161727 366,96.865929 366,92.769531 V 75.230469 c 0,-4.097419 -0.26879,-6.405065 -1.42188,-7.625 -0.57652,-0.609968 -1.40413,-1.014618 -2.67187,-1.269531 C 360.63851,66.081018 358.94984,65.98926 356.75391,66 H 344 331.24805 Z m 7.64258,1.111328 v 0.002 c 5.78414,0.0012 11.56744,-0.0064 17.35156,0.01172 2.16306,0.08861 4.43365,-0.219927 6.51758,0.550781 1.18132,0.351949 1.68339,1.575768 1.90039,2.681641 0.29614,1.609754 0.13938,3.265652 0.20508,4.894531 0.0125,6.901682 0.10435,13.826035 -0.0156,20.722656 -0.14104,1.367783 -0.20069,2.994806 -1.36133,3.929688 -1.41811,0.905325 -3.16414,0.949595 -4.77735,0.962895 -10.01259,0.0642 -20.0569,0.0737 -30.07031,0.008 -1.4584,-0.0882 -3.0588,-0.18772 -4.27344,-1.093752 -1.05565,-0.989564 -1.14225,-2.565907 -1.18945,-3.923828 -0.1049,-6.839487 -0.0421,-13.697363 -0.0391,-20.546875 0.0958,-2.071508 -0.23393,-4.271796 0.5957,-6.242188 0.57982,-1.398224 2.23618,-1.678169 3.56641,-1.861328 3.86031,-0.15272 7.72272,-0.06502 11.58984,-0.0957 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient4882-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         clip-path="none"
-         d="m 327.7793,136 c -1.40927,-0.007 -2.48645,0.0555 -3.2793,0.22266 -0.79285,0.16714 -1.28265,0.42298 -1.625,0.80273 -0.6847,0.7595 -0.875,2.28546 -0.875,5.04883 v 11.85156 c 0,2.76268 0.19058,4.28069 0.875,5.03711 0.34221,0.37821 0.83141,0.63407 1.625,0.80273 0.79359,0.16868 1.87347,0.23438 3.2832,0.23438 H 336 h 8.2168 c 1.40973,0 2.48961,-0.0657 3.2832,-0.23438 0.79359,-0.16866 1.28279,-0.42452 1.625,-0.80273 0.68442,-0.75642 0.875,-2.27443 0.875,-5.03711 v -11.85156 c 0,-2.76337 -0.1903,-4.28934 -0.875,-5.04883 -0.34235,-0.37974 -0.83215,-0.63559 -1.625,-0.80273 C 346.70715,136.0555 345.62997,135.993 344.2207,136 H 344.2187 336 327.78125 Z m 6.35742,1.04297 c 2.72221,-0.003 5.44385,-0.002 8.16601,0.0156 1.70821,0.0756 3.46996,-0.12508 5.16016,0.24805 0.89252,0.11633 1.3083,1.03521 1.3457,1.83984 0.1306,4.99243 0.0357,10.00437 0.0645,15.00782 -0.065,1.35024 0.25513,2.82596 -0.50586,4.03515 -0.63638,0.68531 -1.70424,0.58192 -2.5586,0.70508 -5.32545,0.1332 -10.65874,0.0725 -15.99218,0.0644 -1.87955,-0.0864 -3.84814,0.16741 -5.67774,-0.40625 -0.91711,-0.35573 -0.90353,-1.53315 -0.98633,-2.35546 -0.13787,-4.66511 -0.0284,-9.3606 -0.0254,-14.03321 0.0729,-1.25154 -0.10561,-2.54476 0.21485,-3.76758 0.18398,-0.91079 1.18819,-1.16038 1.97851,-1.23828 2.9379,-0.15985 5.87168,-0.0797 8.81641,-0.11523 z"
-         id="path964-7-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient4880-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         clip-path="none"
-         d="m 325.48047,191 c -1.11517,-0.005 -1.96593,0.0431 -2.58399,0.16797 -0.61805,0.12486 -0.9851,0.31305 -1.23632,0.58008 C 321.15771,192.28211 321,193.40089 321,195.49609 v 9.00782 c 0,2.09467 0.15795,3.20641 0.66016,3.73828 0.2511,0.26593 0.61757,0.456 1.23632,0.58203 0.61876,0.12598 1.47033,0.17578 2.58594,0.17578 H 332 h 6.51758 c 1.11561,0 1.96718,-0.0498 2.58594,-0.17578 0.61875,-0.12603 0.98522,-0.3161 1.23632,-0.58203 C 342.84205,207.71032 343,206.59858 343,204.50391 v -9.00782 c 0,-2.0952 -0.15771,-3.21398 -0.66016,-3.74804 -0.25122,-0.26704 -0.61827,-0.45522 -1.23632,-0.58008 C 340.48546,191.0431 339.6347,190.995 338.51953,191 H 332 Z m 7.13672,1.01562 c 1.98549,-0.002 3.98733,-0.004 5.96289,0.0195 0.96763,0.0402 1.99118,-0.0256 2.90234,0.34765 0.38183,0.34917 0.35253,0.95778 0.39453,1.4336 0.0768,3.51723 0.0322,7.10036 0.0312,10.65039 -0.0482,0.90085 0.0757,1.7786 -0.15039,2.65625 -0.10866,0.64044 -0.871,0.73134 -1.40039,0.74414 -4.81717,0.0743 -9.63544,0.0481 -14.45312,0.0391 -1.02032,-0.0584 -2.06055,0.10963 -3.0586,-0.16992 -0.66794,-0.12827 -0.69858,-0.9186 -0.73828,-1.46094 -0.1041,-3.00472 -0.0701,-6.07992 -0.084,-9.12695 0.0395,-1.40997 -0.0595,-2.82226 0.19726,-4.22071 0.0532,-0.62993 0.75618,-0.7251 1.24805,-0.8164 3.04692,-0.0947 6.09515,-0.0772 9.14844,-0.0957 z"
-         id="path914-4"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient4878-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         clip-path="none"
-         d="m 323.74609,238 c -0.72147,-0.004 -1.26525,0.0309 -1.64453,0.11133 -0.37928,0.0804 -0.57351,0.19073 -0.70898,0.34179 -0.27096,0.30216 -0.39258,1.03815 -0.39258,2.4668 v 6.16211 c 0,1.42829 0.11996,2.15824 0.39062,2.45899 0.13534,0.15037 0.33287,0.26059 0.7129,0.34179 C 322.48354,249.964 323.02807,250 323.75,250 h 4.25 4.25 c 0.72193,0 1.26647,-0.036 1.64648,-0.11719 0.38003,-0.0812 0.57756,-0.19142 0.7129,-0.34179 0.27066,-0.30075 0.39062,-1.0307 0.39062,-2.45899 v -6.16211 c 0,-1.42865 -0.12162,-2.16464 -0.39258,-2.4668 -0.13548,-0.15106 -0.3297,-0.26139 -0.70898,-0.34179 -0.37928,-0.0804 -0.92306,-0.11533 -1.64453,-0.11133 h -0.002 H 328 323.74805 Z m 1.72852,1.01367 c 1.78944,-0.002 3.57972,0.006 5.36914,0.0156 0.93326,0.0249 1.87492,-0.0297 2.80273,0.0762 0.24823,-0.012 0.23037,0.25855 0.25977,0.43555 0.0929,1.75156 0.0355,3.50827 0.0527,5.26171 -0.0216,1.28778 0.0446,2.58231 -0.082,3.86524 0.011,0.26053 -0.30576,0.20235 -0.47461,0.25195 -0.93118,0.0703 -1.87701,0.0323 -2.83789,0.0508 -2.63538,-0.002 -5.2827,0.0273 -7.9082,-0.0391 -0.17166,-0.0598 -0.51095,0.0111 -0.53125,-0.23633 -0.132,-1.17024 -0.0633,-2.35521 -0.0859,-3.53125 0.0153,-1.85793 -0.0377,-3.71784 0.043,-5.57422 0.0491,-0.13737 0.004,-0.38481 0.15039,-0.44922 1.06826,-0.19171 2.1625,-0.094 3.24219,-0.12695 z"
-         id="path918-4"
-         inkscape:connector-curvature="0" />
+       id="g20"
+       inkscape:label="32x32"
+       style="display:inline;enable-background:new">
+      <g
+         inkscape:groupmode="layer"
+         id="g16"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 350.99951,143.19385 c 0,-1.42096 -0.0308,-2.54883 -0.19141,-3.50586 -0.16064,-0.95703 -0.4726,-1.79146 -1.09179,-2.41211 -0.61919,-0.62065 -1.45612,-0.93647 -2.41407,-1.0957 -0.95795,-0.15924 -2.08705,-0.18666 -3.51171,-0.17969 h -7.79102 -7.79688 c -1.42131,-0.007 -2.5495,0.0207 -3.50585,0.17969 -0.95796,0.15923 -1.79488,0.47505 -2.41407,1.0957 -0.61919,0.62065 -0.93115,1.45508 -1.09179,2.41211 -0.16065,0.95703 -0.19141,2.0849 -0.19141,3.50586 v 11.61523 c 0,1.42097 0.0307,2.54669 0.19141,3.50196 0.16075,0.95527 0.47425,1.78779 1.09375,2.40625 0.6195,0.61845 1.45363,0.93134 2.41015,1.09179 0.95653,0.16046 2.08403,0.19141 3.50781,0.19141 h 7.79688 7.79688 c 1.42378,0 2.55128,-0.031 3.50781,-0.19141 0.95653,-0.16045 1.79065,-0.47334 2.41015,-1.09179 0.61951,-0.61846 0.933,-1.45098 1.09375,-2.40625 0.16076,-0.95527 0.19141,-2.08099 0.19141,-3.50196 z"
+           id="path999"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scscccccscsscccscscscss"
+           clip-path="none" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4882);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
+           id="path964-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss"
+           clip-path="none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g17"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g18"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 350.50001,142.07508 c 0,-5.56175 -0.58409,-6.6037 -6.28227,-6.57447 h -8.21765 -8.21781 c -5.69818,-0.0293 -6.28227,1.01272 -6.28227,6.57447 v 11.85044 c 0,5.56037 0.58403,6.57447 6.28227,6.57447 h 8.21781 8.21765 c 5.69824,0 6.28227,-1.0141 6.28227,-6.57447 z"
+           id="path958-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss"
+           clip-path="none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g19"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4882-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           clip-path="none"
+           d="m 327.7793,136 c -1.40927,-0.007 -2.48645,0.0555 -3.2793,0.22266 -0.79285,0.16714 -1.28265,0.42298 -1.625,0.80273 -0.6847,0.7595 -0.875,2.28546 -0.875,5.04883 v 11.85156 c 0,2.76268 0.19058,4.28069 0.875,5.03711 0.34221,0.37821 0.83141,0.63407 1.625,0.80273 0.79359,0.16868 1.87347,0.23438 3.2832,0.23438 H 336 h 8.2168 c 1.40973,0 2.48961,-0.0657 3.2832,-0.23438 0.79359,-0.16866 1.28279,-0.42452 1.625,-0.80273 0.68442,-0.75642 0.875,-2.27443 0.875,-5.03711 v -11.85156 c 0,-2.76337 -0.1903,-4.28934 -0.875,-5.04883 -0.34235,-0.37974 -0.83215,-0.63559 -1.625,-0.80273 C 346.70715,136.0555 345.62997,135.993 344.2207,136 H 344.2187 336 327.78125 Z m 6.35742,1.04297 c 2.72221,-0.003 5.44385,-0.002 8.16601,0.0156 1.70821,0.0756 3.46996,-0.12508 5.16016,0.24805 0.89252,0.11633 1.3083,1.03521 1.3457,1.83984 0.1306,4.99243 0.0357,10.00437 0.0645,15.00782 -0.065,1.35024 0.25513,2.82596 -0.50586,4.03515 -0.63638,0.68531 -1.70424,0.58192 -2.5586,0.70508 -5.32545,0.1332 -10.65874,0.0725 -15.99218,0.0644 -1.87955,-0.0864 -3.84814,0.16741 -5.67774,-0.40625 -0.91711,-0.35573 -0.90353,-1.53315 -0.98633,-2.35546 -0.13787,-4.66511 -0.0284,-9.3606 -0.0254,-14.03321 0.0729,-1.25154 -0.10561,-2.54476 0.21485,-3.76758 0.18398,-0.91079 1.18819,-1.16038 1.97851,-1.23828 2.9379,-0.15985 5.87168,-0.0797 8.81641,-0.11523 z"
+           id="path964-7-6"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g8"
+       inkscape:label="48x48"
+       style="display:inline;enable-background:new">
+      <g
+         inkscape:groupmode="layer"
+         id="g4"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 367,76.456413 c 0,-2.166089 -0.0501,-3.87167 -0.28674,-5.275073 -0.23663,-1.403413 -0.68049,-2.551815 -1.52351,-3.393031 -0.84301,-0.841206 -1.99607,-1.285198 -3.4064,-1.518579 -1.41033,-0.233381 -3.12735,-0.27894 -5.30841,-0.26832 h -12.47482 -12.48078 c -2.17772,-0.01052 -3.89386,0.03517 -5.30268,0.26832 -1.41034,0.233381 -2.5634,0.677373 -3.40641,1.518579 -0.84301,0.841216 -1.28688,1.989618 -1.52351,3.393031 C 321.05009,72.584753 321,74.290324 321,76.456413 v 17.088582 c 0,2.166097 0.05,3.870773 0.28674,5.271282 0.23674,1.400503 0.68211,2.545393 1.52542,3.383503 0.84331,0.83812 1.99555,1.27948 3.4045,1.51477 1.40894,0.23529 3.12246,0.28545 5.30268,0.28545 h 12.48078 12.48055 c 2.18021,0 3.89374,-0.0502 5.30268,-0.28545 1.40894,-0.23529 2.56118,-0.67666 3.40449,-1.51478 0.84332,-0.83811 1.28869,-1.983 1.52542,-3.383502 C 366.95001,97.415768 367,95.711083 367,93.544995 Z"
+           id="path1020"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccsccccccsscccscsccsss"
+           clip-path="none" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4884);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 366.50065,75.231078 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229492 0.90625,9.730392 9.74838,9.730392 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730402 z"
+           id="path964"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss"
+           clip-path="none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g5"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g6"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 366.50065,75.231076 c 0,-8.23154 -0.90635,-9.77365 -9.74838,-9.7304 H 344.0007 331.24889 c -8.84203,-0.0433 -9.74838,1.49886 -9.74838,9.7304 v 17.53897 c 0,8.229494 0.90625,9.730394 9.74838,9.730394 h 12.75181 12.75157 c 8.84213,0 9.74838,-1.5009 9.74838,-9.730404 z"
+           id="path958"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss"
+           clip-path="none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g7"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4884-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           clip-path="none"
+           d="m 331.24609,66 c -2.19593,-0.01075 -3.8846,0.08102 -5.15234,0.335938 -1.26774,0.254911 -2.09536,0.65956 -2.67187,1.269531 C 322.2688,68.825409 322,71.13305 322,75.230469 v 17.539062 c 0,4.096393 0.26904,6.392197 1.42188,7.607419 0.57641,0.60762 1.40538,1.01239 2.67382,1.26953 1.26844,0.25712 2.95596,0.35352 5.15235,0.35352 H 344 356.75195 c 2.19639,0 3.88586,-0.0964 5.1543,-0.35352 1.26844,-0.25714 2.09741,-0.66191 2.67383,-1.26953 C 365.73291,99.161727 366,96.865929 366,92.769531 V 75.230469 c 0,-4.097419 -0.26879,-6.405065 -1.42188,-7.625 -0.57652,-0.609968 -1.40413,-1.014618 -2.67187,-1.269531 C 360.63851,66.081018 358.94984,65.98926 356.75391,66 H 344 331.24805 Z m 7.64258,1.111328 v 0.002 c 5.78414,0.0012 11.56744,-0.0064 17.35156,0.01172 2.16306,0.08861 4.43365,-0.219927 6.51758,0.550781 1.18132,0.351949 1.68339,1.575768 1.90039,2.681641 0.29614,1.609754 0.13938,3.265652 0.20508,4.894531 0.0125,6.901682 0.10435,13.826035 -0.0156,20.722656 -0.14104,1.367783 -0.20069,2.994806 -1.36133,3.929688 -1.41811,0.905325 -3.16414,0.949595 -4.77735,0.962895 -10.01259,0.0642 -20.0569,0.0737 -30.07031,0.008 -1.4584,-0.0882 -3.0588,-0.18772 -4.27344,-1.093752 -1.05565,-0.989564 -1.14225,-2.565907 -1.18945,-3.923828 -0.1049,-6.839487 -0.0421,-13.697363 -0.0391,-20.546875 0.0958,-2.071508 -0.23393,-4.271796 0.5957,-6.242188 0.57982,-1.398224 2.23618,-1.678169 3.56641,-1.861328 3.86031,-0.15272 7.72272,-0.06502 11.58984,-0.0957 z"
+           id="path964-3"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g13"
+       inkscape:label="256x256"
+       style="display:inline;enable-background:new">
+      <g
+         inkscape:groupmode="layer"
+         id="g9"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter53855);opacity:0.1"
+           d="m 263.9973,206.07598 c 0,35.29673 -3.62542,39.09461 -38.99353,38.92162 H 151.9973 78.99083 C 43.62271,245.17059 39.9973,241.37271 39.9973,206.07598 v -98.15676 c 0,-35.296716 3.625,-38.921616 38.99353,-38.921616 h 73.00647 73.00647 c 35.36853,0 38.99353,3.6249 38.99353,38.921616 z"
+           id="rect4158-8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter53827);opacity:0.2"
+           d="m 263.9973,206.07598 c 0,35.29673 -3.62542,39.09461 -38.99353,38.92162 H 151.9973 78.99083 C 43.62271,245.17059 39.9973,241.37271 39.9973,206.07598 v -98.15676 c 0,-35.296716 3.625,-38.921616 38.99353,-38.921616 h 73.00647 73.00647 c 35.36853,0 38.99353,3.6249 38.99353,38.921616 z"
+           id="rect4158-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4886);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 263.9973,205.07568 c 0,35.29673 -3.62542,39.09461 -38.99353,38.92162 H 151.9973 78.99083 C 43.62271,244.17029 39.9973,240.37241 39.9973,205.07568 v -98.15676 c 0,-35.296716 3.625,-38.921616 38.99353,-38.921616 h 73.00647 73.00647 c 35.36853,0 38.99353,3.6249 38.99353,38.921616 z"
+           id="rect4158"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g10"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g11"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 78.990234,67.998047 c -35.36853,0 -38.992187,3.623202 -38.992187,38.919923 v 98.1582 c 0,0.0882 0.0019,0.16224 0.002,0.25 V 108.91602 C 40,73.6193 43.625611,69.994141 78.994141,69.994141 H 152 225.00586 c 35.28016,0 38.97394,3.621035 38.99219,38.671879 v -1.74805 c 0,-35.296721 -3.62561,-38.919923 -38.99414,-38.919923 h -73.00586 z"
+           id="rect4158-78"
+           inkscape:connector-curvature="0" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 39.998047,203.07617 v 2 c 0,35.29673 3.624067,39.09487 38.992187,38.92188 h 73.007816 73.00586 c 35.36811,0.17299 38.99414,-3.62515 38.99414,-38.92188 v -2 c 0,35.29673 -3.62603,39.09487 -38.99414,38.92188 H 151.99805 78.990234 c -35.36812,0.17299 -38.992187,-3.62515 -38.992187,-38.92188 z"
+           id="rect4158-6"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g12"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/Round App Icon Template.svg
+++ b/icons/src/fullcolor/Round App Icon Template.svg
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="96"
    inkscape:export-xdpi="96"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.4 (1:1.4+202410161351+e7c3feb100)"
    sodipodi:docname="Round App Icon Template.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\preferences-system-network.png">
+   inkscape:export-filename="C:\Users\sblav\Pictures\preferences-system-network.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Yaru Icon Theme Template</title>
   <sodipodi:namedview
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="114.5"
-     inkscape:cy="194.60392"
-     inkscape:current-layer="layer8"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="201.52543"
+     inkscape:cy="259.15464"
+     inkscape:current-layer="g3"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1860"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -72,7 +73,8 @@
        empspacing="4"
        snapvisiblegridlinesonly="true"
        originx="0"
-       originy="0" />
+       originy="0"
+       units="px" />
     <inkscape:grid
        type="xygrid"
        id="grid11592"
@@ -87,7 +89,8 @@
        empopacity="0.25098039"
        snapvisiblegridlinesonly="true"
        originx="0"
-       originy="0" />
+       originy="0"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs3">
@@ -394,162 +397,266 @@
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <circle
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter48967);enable-background:new"
-         id="path11042-4"
-         r="112"
-         cy="157"
-         cx="152" />
-      <circle
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter48952);enable-background:new"
-         id="path11042-9"
-         r="112"
-         cy="157"
-         cx="152" />
-      <circle
-         style="display:inline;opacity:1;fill:url(#linearGradient11065);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042"
-         r="112"
-         cy="155.99998"
-         cx="152" />
-      <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
-      <circle
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0"
-         cx="-344"
-         cy="-85.000015"
-         transform="scale(-1)"
-         r="23" />
-      <circle
-         style="display:inline;opacity:1;fill:url(#linearGradient8588);fill-opacity:1;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-6"
-         cx="344"
-         cy="84"
-         r="22.5" />
-      <circle
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0-2"
-         cx="-336"
-         cy="-149"
-         transform="scale(-1)"
-         r="14.999996" />
-      <circle
-         style="display:inline;opacity:1;fill:url(#linearGradient8588-0);fill-opacity:1;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-6-5"
-         cx="336"
-         cy="148"
-         r="14.5" />
-      <ellipse
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0-2-3"
-         cx="-332"
-         cy="-200.52327"
-         transform="scale(-1)"
-         rx="11.999997"
-         ry="11.476745" />
-      <ellipse
-         style="display:inline;opacity:1;fill:url(#linearGradient8588-0-1);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-6-5-6"
-         cx="332"
-         cy="200"
-         rx="11.499999"
-         ry="11.5" />
-      <ellipse
-         style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437706;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-0-0-2-3-3"
-         cx="-328"
-         cy="-244.5"
-         transform="scale(-1)"
-         rx="6.9999981"
-         ry="6.5" />
-      <circle
-         style="display:inline;opacity:1;fill:url(#linearGradient8588-0-1-5);fill-opacity:1;stroke:none;stroke-width:1.86940384;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path9498-6-5-6-8"
-         cx="328"
-         cy="244"
-         r="7.5" />
+       id="g7"
+       inkscape:label="16x16">
+      <g
+         inkscape:groupmode="layer"
+         id="g3"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <ellipse
+           style="display:inline;enable-background:new;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437706;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path9498-0-0-2-3-3"
+           cx="-328"
+           cy="-244.5"
+           transform="scale(-1)"
+           rx="6.9999981"
+           ry="6.5" />
+        <circle
+           style="display:inline;enable-background:new;opacity:1;fill:url(#linearGradient8588-0-1-5);fill-opacity:1;stroke:none;stroke-width:1.86940384;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path9498-6-5-6-8"
+           cx="328"
+           cy="244"
+           r="7.5" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g4"
+         inkscape:label="Pictrograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g5"
+         inkscape:label="Borders">
+        <circle
+           style="display:inline;enable-background:new;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+           id="path1377"
+           cx="328.00003"
+           cy="244.00002"
+           r="7.5000005" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g6"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:new;opacity:1;fill:url(#linearGradient8590-3-3-4);fill-opacity:1;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 328,237 c -3.86599,0 -7,3.13402 -7,7 0,3.86599 3.13401,7 7,7 3.866,0 7,-3.13401 7,-7 0,-3.86598 -3.134,-7 -7,-7 z m 0,1 a 6,6 0 0 1 6,6 6,6 0 0 1 -6,6 6,6 0 0 1 -6,-6 6,6 0 0 1 6,-6 z"
+           id="path9498-1-6-7-2-0"
+           inkscape:connector-curvature="0" />
+      </g>
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms and folds"
-       style="display:inline" />
-    <g
-       inkscape:groupmode="layer"
-       id="layer2"
-       inkscape:label="Borders"
-       style="display:inline">
-      <circle
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1377"
-         cx="328.00003"
-         cy="244.00002"
-         r="7.5000005" />
-      <ellipse
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1384"
-         cx="332"
-         cy="199.97676"
-         rx="11.454546"
-         ry="11.476745" />
-      <circle
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1389"
-         cx="336"
-         cy="148"
-         r="14.5" />
-      <circle
-         style="display:inline;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1;enable-background:new"
-         id="path1389-3"
-         cx="344"
-         cy="84"
-         r="22.5" />
-      <path
-         inkscape:connector-curvature="0"
-         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 152,267.99999 a 112,112 0 0 1 -112,-112 112,112 0 0 1 0.04102,-1.16992 A 112,112 0 0 0 152,265.99999 112,112 0 0 0 263.95898,155.16991 a 112,112 0 0 1 0.041,0.83008 112,112 0 0 1 -112,112 z"
-         id="path11042-1-7" />
-      <path
-         style="display:inline;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="M 152,43.999994 A 112,112 0 0 0 40,155.99999 112,112 0 0 0 40.04102,157.16991 112,112 0 0 1 152,45.999994 112,112 0 0 1 263.95898,156.83007 a 112,112 0 0 0 0.041,-0.83008 112,112 0 0 0 -112,-111.999996 z"
-         id="path11042-1"
-         inkscape:connector-curvature="0" />
+       id="g22"
+       inkscape:label="24x24">
+      <g
+         inkscape:groupmode="layer"
+         id="g18"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <ellipse
+           style="display:inline;enable-background:new;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path9498-0-0-2-3"
+           cx="-332"
+           cy="-200.52327"
+           transform="scale(-1)"
+           rx="11.999997"
+           ry="11.476745" />
+        <ellipse
+           style="display:inline;enable-background:new;opacity:1;fill:url(#linearGradient8588-0-1);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path9498-6-5-6"
+           cx="332"
+           cy="200"
+           rx="11.499999"
+           ry="11.5" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g19"
+         inkscape:label="Pictrograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g20"
+         inkscape:label="Borders">
+        <ellipse
+           style="display:inline;enable-background:new;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.6;stroke-opacity:1"
+           id="path1384"
+           cx="332"
+           cy="199.97676"
+           rx="11.454546"
+           ry="11.476745" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g21"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:new;opacity:1;fill:url(#linearGradient8590-3-3);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 332,189 c -6.07513,0 -11,4.92488 -11,11 0,6.07513 4.92487,11 11,11 6.07513,0 11,-4.92487 11,-11 0,-6.07512 -4.92487,-11 -11,-11 z m 0,1 a 10,10 0 0 1 10,10 10,10 0 0 1 -10,10 10,10 0 0 1 -10,-10 10,10 0 0 1 10,-10 z"
+           id="path9498-1-6-7-2"
+           inkscape:connector-curvature="0" />
+      </g>
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="display:inline;opacity:0.8">
-      <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="M 344,62.000016 A 22,21.99999 0 0 0 322,84.000013 22,21.99999 0 0 0 344,106 22,21.99999 0 0 0 366,84.000013 22,21.99999 0 0 0 344,62.000016 Z m 0,0.956532 A 21.043478,21.043469 0 0 1 365.04348,84.000013 21.043478,21.043469 0 0 1 344,105.04348 21.043478,21.043469 0 0 1 322.95652,84.000013 21.043478,21.043469 0 0 1 344,62.956548 Z"
-         id="path9498-1-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590-3);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 336,134 c -7.73199,0 -14,6.26802 -14,14 0,7.73198 6.26801,14 14,14 7.73199,0 14,-6.26802 14,-14 0,-7.73198 -6.26801,-14 -14,-14 z m 0,1 a 13,13 0 0 1 13,13 13,13 0 0 1 -13,13 13,13 0 0 1 -13,-13 13,13 0 0 1 13,-13 z"
-         id="path9498-1-6-7"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590-3-3);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 332,189 c -6.07513,0 -11,4.92488 -11,11 0,6.07513 4.92487,11 11,11 6.07513,0 11,-4.92487 11,-11 0,-6.07512 -4.92487,-11 -11,-11 z m 0,1 a 10,10 0 0 1 10,10 10,10 0 0 1 -10,10 10,10 0 0 1 -10,-10 10,10 0 0 1 10,-10 z"
-         id="path9498-1-6-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;opacity:1;fill:url(#linearGradient8590-3-3-4);fill-opacity:1;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         d="m 328,237 c -3.86599,0 -7,3.13402 -7,7 0,3.86599 3.13401,7 7,7 3.866,0 7,-3.13401 7,-7 0,-3.86598 -3.134,-7 -7,-7 z m 0,1 a 6,6 0 0 1 6,6 6,6 0 0 1 -6,6 6,6 0 0 1 -6,-6 6,6 0 0 1 6,-6 z"
-         id="path9498-1-6-7-2-0"
-         inkscape:connector-curvature="0" />
+       id="g17"
+       inkscape:label="32x32">
+      <g
+         inkscape:groupmode="layer"
+         id="g13"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <circle
+           style="display:inline;enable-background:new;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path9498-0-0-2"
+           cx="-336"
+           cy="-149"
+           transform="scale(-1)"
+           r="14.999996" />
+        <circle
+           style="display:inline;enable-background:new;opacity:1;fill:url(#linearGradient8588-0);fill-opacity:1;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path9498-6-5"
+           cx="336"
+           cy="148"
+           r="14.5" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g14"
+         inkscape:label="Pictrograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g15"
+         inkscape:label="Borders">
+        <circle
+           style="display:inline;enable-background:new;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+           id="path1389"
+           cx="336"
+           cy="148"
+           r="14.5" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g16"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:new;opacity:1;fill:url(#linearGradient8590-3);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 336,134 c -7.73199,0 -14,6.26802 -14,14 0,7.73198 6.26801,14 14,14 7.73199,0 14,-6.26802 14,-14 0,-7.73198 -6.26801,-14 -14,-14 z m 0,1 a 13,13 0 0 1 13,13 13,13 0 0 1 -13,13 13,13 0 0 1 -13,-13 13,13 0 0 1 13,-13 z"
+           id="path9498-1-6-7"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g12"
+       inkscape:label="48x48">
+      <g
+         inkscape:groupmode="layer"
+         id="g8"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <circle
+           style="display:inline;enable-background:new;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.95437694;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path9498-0-0"
+           cx="-344"
+           cy="-85.000015"
+           transform="scale(-1)"
+           r="23" />
+        <circle
+           style="display:inline;enable-background:new;opacity:1;fill:url(#linearGradient8588);fill-opacity:1;stroke:none;stroke-width:1.86940372;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path9498-6"
+           cx="344"
+           cy="84"
+           r="22.5" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g9"
+         inkscape:label="Pictrograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g10"
+         inkscape:label="Borders">
+        <circle
+           style="display:inline;enable-background:new;opacity:0.4;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:6.5999999;stroke-opacity:1"
+           id="path1389-3"
+           cx="344"
+           cy="84"
+           r="22.5" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g11"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:new;opacity:1;fill:url(#linearGradient8590);fill-opacity:1;stroke:none;stroke-width:1.8694036;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 344,62.000016 A 22,21.99999 0 0 0 322,84.000013 22,21.99999 0 0 0 344,106 22,21.99999 0 0 0 366,84.000013 22,21.99999 0 0 0 344,62.000016 Z m 0,0.956532 A 21.043478,21.043469 0 0 1 365.04348,84.000013 21.043478,21.043469 0 0 1 344,105.04348 21.043478,21.043469 0 0 1 322.95652,84.000013 21.043478,21.043469 0 0 1 344,62.956548 Z"
+           id="path9498-1-6"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer11"
+       inkscape:label="256x256"
+       style="display:inline;enable-background:new">
+      <g
+         inkscape:groupmode="layer"
+         id="g2"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <circle
+           style="display:inline;enable-background:new;opacity:0.1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter48967)"
+           id="path11042-4"
+           r="112"
+           cy="157"
+           cx="152" />
+        <circle
+           style="display:inline;enable-background:new;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter48952)"
+           id="path11042-9"
+           r="112"
+           cy="157"
+           cx="152" />
+        <circle
+           style="display:inline;enable-background:new;opacity:1;fill:url(#linearGradient11065);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path11042"
+           r="112"
+           cy="155.99998"
+           cx="152" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g1"
+         inkscape:label="Pictrograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="layer13"
+         inkscape:label="Borders">
+        <path
+           inkscape:connector-curvature="0"
+           style="display:inline;enable-background:new;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 152,267.99999 a 112,112 0 0 1 -112,-112 112,112 0 0 1 0.04102,-1.16992 A 112,112 0 0 0 152,265.99999 112,112 0 0 0 263.95898,155.16991 a 112,112 0 0 1 0.041,0.83008 112,112 0 0 1 -112,112 z"
+           id="path11042-1-7" />
+        <path
+           style="display:inline;enable-background:new;opacity:0.3;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 152,43.999994 A 112,112 0 0 0 40,155.99999 112,112 0 0 0 40.04102,157.16991 112,112 0 0 1 152,45.999994 112,112 0 0 1 263.95898,156.83007 a 112,112 0 0 0 0.041,-0.83008 112,112 0 0 0 -112,-111.999996 z"
+           id="path11042-1"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="layer12"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/Square App Icon Template.svg
+++ b/icons/src/fullcolor/Square App Icon Template.svg
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="96"
    inkscape:export-xdpi="96"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.4 (1:1.4+202410161351+e7c3feb100)"
    sodipodi:docname="Square App Icon Template.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Yaru Icon Theme Template</title>
   <sodipodi:namedview
@@ -31,18 +31,18 @@
      borderopacity="0.25490196"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1"
-     inkscape:cx="245.73116"
-     inkscape:cy="62.097561"
-     inkscape:current-layer="layer5"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="178.19091"
+     inkscape:cy="168.64497"
+     inkscape:current-layer="g4"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1860"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -72,7 +73,8 @@
        empspacing="4"
        snapvisiblegridlinesonly="true"
        originx="0"
-       originy="0" />
+       originy="0"
+       units="px" />
     <inkscape:grid
        type="xygrid"
        id="grid11592"
@@ -87,7 +89,8 @@
        empopacity="0.25098039"
        snapvisiblegridlinesonly="true"
        originx="0"
-       originy="0" />
+       originy="0"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs3">
@@ -218,7 +221,7 @@
        style="color-interpolation-filters:sRGB"
        id="filter58449"
        x="-0.047999425"
-       width="1.0959988"
+       width="1.0959989"
        y="-0.048000575"
        height="1.0960012">
       <feGaussianBlur
@@ -394,149 +397,270 @@
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449);enable-background:accumulate"
-         d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
-         id="path918-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500049 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 v 12.75157 12.75181 c -0.0527,8.842031 1.82291,9.748381 11.83407,9.748381 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.748381 v -12.75181 -12.75157 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1694);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 225.07297,43.999694 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.006466 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.993224 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 326.17688,188.49945 c -5.14666,0 -5.70043,0.43262 -5.67521,4.65309 v 5.84793 7.84761 c -0.0253,4.22046 0.52855,4.65307 5.67521,4.65307 h 11.64568 c 5.14665,0 5.67521,-0.43255 5.67521,-4.65307 v -7.84761 -5.84793 c 0,-4.22051 -0.52857,-4.65309 -5.67522,-4.65309 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.4056,236.50001 c -3.47604,0 -3.85006,0.30899 -3.83302,3.32331 v 4.17669 4.17668 c -0.017,3.01433 0.35698,3.32332 3.83302,3.32332 h 7.18996 c 3.47605,0 3.83303,-0.30895 3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.35699,-3.32331 -3.83303,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+       id="g4"
+       inkscape:label="16x16"
+       style="display:inline;enable-background:new;opacity:1">
+      <g
+         inkscape:groupmode="layer"
+         id="g5"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 324.12858,237.00001 c -3.74357,0 -4.14638,0.30899 -4.12803,3.32331 v 4.17669 4.17668 c -0.0183,3.01433 0.38446,3.32332 4.12803,3.32332 h 7.74335 c 3.7436,0 4.12805,-0.30895 4.12805,-3.32332 v -4.17668 -4.17669 c 0,-3.01437 -0.38446,-3.32331 -4.12805,-3.32331 z"
+           id="path918-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1692);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 324.4056,236.50001 c -3.47604,0 -3.85006,0.30899 -3.83302,3.32331 v 4.17669 4.17668 c -0.017,3.01433 0.35698,3.32332 3.83302,3.32332 h 7.18996 c 3.47605,0 3.83303,-0.30895 3.83303,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.35699,-3.32331 -3.83303,-3.32331 z"
+           id="path918"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g6"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g7"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:0.4;color:#000000;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
+           id="path958-6-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="layer14"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new;opacity:0.7">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
+           id="path918-6"
+           inkscape:connector-curvature="0" />
+      </g>
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms and folds"
-       style="display:inline" />
-    <g
-       inkscape:groupmode="layer"
-       id="layer4"
-       inkscape:label="Borders"
-       style="display:inline;opacity:1">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
-         id="path931"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
-         id="path931-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.55494,251.5 c 3.33705,0 3.96221,-0.30212 3.94468,-3.24946 v -4.2505 -4.25059 c 0.0175,-2.94734 -0.60763,-3.24945 -3.94468,-3.24945 h -7.11025 c -3.33622,0 -3.94469,0.30208 -3.94469,3.24945 v 4.25059 4.2505 c 0,2.94738 0.60847,3.24946 3.94469,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+       id="g27"
+       inkscape:label="24x24"
+       style="display:inline;enable-background:new;opacity:1">
+      <g
+         inkscape:groupmode="layer"
+         id="g23"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 326.45275,189.00048 c -1.2321,0 -2.21668,0.0221 -3.06999,0.14144 -0.85332,0.11937 -1.62809,0.35533 -2.21066,0.83967 -0.58256,0.48436 -0.86983,1.13381 -1.01188,1.84587 -0.14202,0.71207 -0.16501,1.53239 -0.15897,2.56202 v 7.61066 4.6143 c -0.006,1.02762 0.0171,1.84735 0.15897,2.55843 0.14203,0.71208 0.42931,1.36152 1.01188,1.84587 0.58258,0.48434 1.35734,0.7203 2.21066,0.83967 0.85331,0.11936 1.83789,0.14144 3.06999,0.14144 h 11.09542 c 1.2321,0 2.21381,-0.022 3.0657,-0.14144 0.85187,-0.11947 1.62795,-0.35683 2.2085,-0.84146 0.58057,-0.48464 0.86451,-1.13152 1.00758,-1.84228 0.14307,-0.71077 0.16972,-1.5314 0.16972,-2.56023 v -4.61429 -7.61425 c 0,-1.02883 -0.0266,-1.84946 -0.16972,-2.56023 -0.14307,-0.71076 -0.42701,-1.35765 -1.00758,-1.84228 -0.58055,-0.48464 -1.35661,-0.722 -2.2085,-0.84147 -0.8519,-0.11947 -1.83359,-0.14144 -3.0657,-0.14144 z"
+           id="path995"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccccccccssscccscscccss" />
+        <path
+           sodipodi:nodetypes="scccssscsss"
+           inkscape:connector-curvature="0"
+           id="path914"
+           d="m 326.17688,188.49945 c -5.14666,0 -5.70043,0.43262 -5.67521,4.65309 v 5.84793 7.84761 c -0.0253,4.22046 0.52855,4.65307 5.67521,4.65307 h 11.64568 c 5.14665,0 5.67521,-0.43255 5.67521,-4.65307 v -7.84761 -5.84793 c 0,-4.22051 -0.52857,-4.65309 -5.67522,-4.65309 z"
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1690);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g24"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g25"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:0.4;color:#000000;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 337.97659,211.50015 c 4.67187,0 5.5471,-0.42296 5.52255,-4.54923 v -7.95037 -5.95084 c 0.0245,-4.12627 -0.85068,-4.54923 -5.52255,-4.54923 h -11.95364 c -4.67071,0 -5.52256,0.42291 -5.52256,4.54923 v 5.95084 7.95037 c 0,4.12632 0.85185,4.54923 5.52256,4.54923 z"
+           id="path958-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g26"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new;opacity:0.7">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none"
+           d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
+           id="path914-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
+      </g>
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Highlights"
-       style="opacity:0.7">
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1692-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 324.44531,237 c -1.65302,0 -2.54604,0.12548 -2.91601,0.41406 -0.18499,0.14429 -0.30479,0.33122 -0.39649,0.70313 C 321.0411,238.4891 321,239.03036 321,239.75 v 4.25 4.25 c 0,0.71964 0.0411,1.26082 0.13281,1.63281 0.0917,0.37191 0.2115,0.55884 0.39649,0.70313 0.36997,0.28858 1.26299,0.41406 2.91601,0.41406 h 7.10938 c 1.65343,0 2.55203,-0.12511 2.92383,-0.41406 0.18589,-0.14448 0.30578,-0.33208 0.39648,-0.70313 0.0907,-0.37105 0.129,-0.90979 0.125,-1.6289 v -0.002 V 244 v -4.25195 -0.002 c 0.004,-0.71911 -0.0343,-1.25785 -0.125,-1.6289 -0.0907,-0.37105 -0.21059,-0.55865 -0.39648,-0.70313 C 334.10673,237.12512 333.20812,237 331.55469,237 Z m 5.32813,1.04688 c 1.10767,-3.4e-4 2.21363,0.008 3.32031,0.0449 0.26616,0.0599 0.75737,-0.0208 0.79297,0.3457 0.13405,1.84438 0.0662,3.68774 0.10156,5.53906 -0.0126,1.86745 0.0543,3.67031 -0.10351,5.49805 0.0642,0.42314 -0.43946,0.35577 -0.70313,0.42187 -3.43277,0.0703 -6.87577,0.0589 -10.29883,0.002 -0.22288,-0.0398 -0.55622,-3.2e-4 -0.71093,-0.1875 -0.19863,-1.12995 -0.12696,-2.26946 -0.16016,-3.41992 0.0138,-2.55648 -0.029,-5.10728 0.0898,-7.65625 -0.03,-0.2727 0.10944,-0.49629 0.40039,-0.48829 1.30659,-0.161 2.63265,-0.0636 3.94727,-0.0976 1.10718,0.006 2.21655,-0.002 3.32422,-0.002 z"
-         id="path918-6"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1690-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none"
-         d="m 326.02383,189.00048 c -2.32027,0 -3.60941,0.15494 -4.20703,0.62109 -0.29882,0.23308 -0.48964,0.54668 -0.625,1.09571 -0.13541,0.54902 -0.19141,1.31765 -0.19141,2.33203 v 5.95117 7.95084 c 0,1.01437 0.056,1.783 0.19141,2.33203 0.13536,0.54903 0.32618,0.86263 0.625,1.09571 0.59762,0.46615 1.88676,0.62109 4.20703,0.62109 h 11.9524 c 2.32085,0 3.61652,-0.15457 4.2168,-0.62109 0.30014,-0.23327 0.49095,-0.54754 0.625,-1.09571 0.13404,-0.54816 0.18764,-1.31623 0.18164,-2.33008 v -7.95279 -5.95312 c 0.006,-1.01386 -0.0476,-1.78191 -0.18164,-2.33008 -0.13406,-0.54817 -0.32486,-0.86244 -0.625,-1.09571 -0.60028,-0.46652 -1.89595,-0.62109 -4.2168,-0.62109 z m 4.95859,1.00977 c 1.5798,-0.002 4.16014,-3.9e-4 5.73991,0.0117 1.50021,0.0511 3.02236,-0.0712 4.5,0.28321 0.55111,0.0919 0.61303,0.71807 0.67773,1.16601 0.1117,4.30832 0.075,10.62608 0.0508,14.94108 -0.0716,0.99089 0.13687,2.07606 -0.30078,3.01366 -0.34356,0.40964 -0.9694,0.35958 -1.45117,0.45509 -3.95407,0.0823 -9.92936,0.0499 -13.89381,0.0371 -1.16908,-0.0622 -2.37292,0.11291 -3.51758,-0.22266 -0.57935,-0.098 -0.6137,-0.75914 -0.6875,-1.2207 -0.1146,-4.11835 -0.0751,-10.24472 -0.0547,-14.36881 0.0572,-1.06305 -0.0797,-2.16734 0.18164,-3.21485 0.10495,-0.6386 0.8614,-0.66043 1.36719,-0.74023 2.1305,-0.19658 5.24071,-0.10662 7.38828,-0.14062 z"
-         id="path914-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccscsccsscccccccssccccccccccccccc" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
-         id="path964-7-2"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
-         id="path964-3"
-         inkscape:connector-curvature="0" />
+       id="g17"
+       inkscape:label="32x32"
+       style="opacity:1">
+      <g
+         inkscape:groupmode="layer"
+         id="g13"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 329.30094,134 c -1.63949,0 -2.94082,0.0308 -4.04505,0.19141 -1.10422,0.16064 -2.06697,0.4726 -2.78308,1.09179 -0.71611,0.61919 -1.0805,1.45612 -1.26421,2.41407 -0.18374,0.95795 -0.21537,2.08705 -0.20733,3.51171 V 149 v 7.79688 c -0.009,1.42131 0.0239,2.5495 0.20733,3.50585 0.18371,0.95796 0.5481,1.79488 1.26421,2.41407 0.71611,0.61919 1.67886,0.93115 2.78308,1.09179 1.10423,0.16065 2.40556,0.19141 4.04505,0.19141 h 13.40164 c 1.63949,0 2.93835,-0.0307 4.04054,-0.19141 1.10219,-0.16075 2.06274,-0.47425 2.77633,-1.09375 0.71357,-0.6195 1.07457,-1.45363 1.25969,-2.41015 C 350.96429,159.34816 351,158.22066 351,156.79688 V 149 141.20312 c 0,-1.42378 -0.0358,-2.55128 -0.22086,-3.50781 -0.18512,-0.95653 -0.54612,-1.79065 -1.25969,-2.41015 -0.71359,-0.61951 -1.67414,-0.933 -2.77633,-1.09375 C 345.64093,134.03065 344.34207,134 342.70258,134 Z"
+           id="path999"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scscccccscsscccscscscss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1688);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
+           id="path964-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g14"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g15"
+         inkscape:label="Border"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:0.4;color:#000000;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 329.12711,133.5 c -6.45163,0 -7.6603,0.58409 -7.62639,6.28227 v 8.21765 8.21781 c -0.034,5.69818 1.17476,6.28227 7.62639,6.28227 h 13.74651 c 6.45003,0 7.62639,-0.58403 7.62639,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.17636,-6.28227 -7.62639,-6.28227 z"
+           id="path958-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g16"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new;opacity:0.7">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1688-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 329.12695,134 c -3.21072,0 -5.03255,0.19514 -5.9375,0.89844 -0.45247,0.35165 -0.74178,0.83286 -0.93359,1.61718 -0.19176,0.78433 -0.26386,1.85686 -0.25586,3.26368 v 0.002 8.21875 8.21875 0.002 c -0.008,1.40682 0.0641,2.47935 0.25586,3.26368 0.1918,0.78431 0.48112,1.26553 0.93359,1.61718 0.90496,0.7033 2.72678,0.89844 5.9375,0.89844 h 13.7461 c 3.20992,0 5.02461,-0.19551 5.92578,-0.89844 0.45058,-0.35146 0.73805,-0.83201 0.93164,-1.61718 C 349.9241,158.69918 350,157.62415 350,156.2168 V 148 139.7832 c 0,-1.40735 -0.0759,-2.48237 -0.26953,-3.26758 -0.19359,-0.78517 -0.48106,-1.26572 -0.93164,-1.61718 C 347.89766,134.19551 346.08297,134 342.87305,134 Z m 6.49805,1.04688 c 3.45647,0.0171 6.9142,-0.0268 10.36133,0.0918 0.8211,0.13276 1.80664,0.14835 2.39062,0.82617 0.67884,1.16473 0.51296,2.58781 0.56446,3.87305 0.0431,6.02893 0.0678,12.06719 -0.0332,18.08789 -0.0775,0.77792 -0.12055,1.67263 -0.67968,2.27539 -0.70249,0.51038 -1.61833,0.59683 -2.45899,0.67383 -4.04742,0.0864 -8.16222,0.0456 -12.24023,0.0606 -2.45188,-0.0199 -4.91402,0.0317 -7.35352,-0.0606 -0.87784,-0.12055 -1.915,-0.14021 -2.56055,-0.83398 -0.64775,-1.02591 -0.50264,-2.30525 -0.56054,-3.46485 -0.035,-5.65575 -0.0351,-11.35518 0,-17.00976 0.0632,-1.22153 -0.10864,-2.57724 0.59179,-3.65235 0.6025,-0.62665 1.55621,-0.63986 2.35938,-0.77344 2.73743,-0.10739 5.48083,-0.0704 8.22656,-0.0918 0.46403,-2.9e-4 0.92855,-0.002 1.39258,-0.002 z"
+           id="path964-7-2"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g22"
+       inkscape:label="48x48"
+       style="display:inline;enable-background:new;opacity:1">
+      <g
+         inkscape:groupmode="layer"
+         id="g18"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 333.65776,62 c -2.6221,0 -4.68675,0.05009 -6.38561,0.286735 -1.69887,0.236639 -3.08904,0.680503 -4.10735,1.523515 -1.0183,0.843013 -1.55577,1.996072 -1.83828,3.406406 -0.28252,1.410336 -0.33767,3.127346 -0.32482,5.308412 v 12.474816 12.480783 c -0.0127,2.177715 0.0426,3.893853 0.32482,5.302673 0.28251,1.41034 0.81998,2.5634 1.83828,3.40641 1.01831,0.84301 2.40848,1.28688 4.10735,1.52351 1.69888,0.23665 3.76351,0.28674 6.38561,0.28674 h 20.68618 c 2.62213,0 4.68568,-0.05 6.38104,-0.28674 1.69534,-0.23674 3.08126,-0.6821 4.09581,-1.52542 1.01457,-0.84331 1.54885,-1.99555 1.83367,-3.4045 C 366.93929,101.37441 367,99.660878 367,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0608,-3.893733 -0.34554,-5.302677 -0.28482,-1.408942 -0.81911,-2.561177 -1.83368,-3.404494 -1.01455,-0.843317 -2.40047,-1.288685 -4.09582,-1.525427 C 359.02962,62.049992 356.96605,62 354.34394,62 Z"
+           id="path1020"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccsccccccsscccscsccsss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1686);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 333.33517,61.500049 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 v 12.75157 12.75181 c -0.0527,8.842031 1.82291,9.748381 11.83407,9.748381 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.748381 v -12.75181 -12.75157 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
+           id="path964"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g19"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g20"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:0.4;color:#000000;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 333.33517,61.500047 c -10.01116,0 -11.88667,0.90635 -11.83407,9.74838 V 84 96.75181 c -0.0527,8.84203 1.82291,9.74838 11.83407,9.74838 h 21.3308 c 10.00866,0 11.83405,-0.90625 11.83405,-9.74838 V 84 71.248427 c 0,-8.84213 -1.82539,-9.74838 -11.83406,-9.74838 z"
+           id="path958"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g21"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new;opacity:0.7">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1686-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 333.33594,62 c -4.99049,0 -7.87051,0.276282 -9.38477,1.453125 -0.75713,0.588421 -1.23761,1.403518 -1.54492,2.660156 -0.3073,1.256638 -0.4173,2.940031 -0.4043,5.132813 V 84 96.753906 c -0.0131,2.19278 0.097,3.876174 0.4043,5.132814 0.30731,1.25663 0.78779,2.07172 1.54492,2.66016 1.51427,1.17683 4.39428,1.45312 9.38477,1.45312 h 21.33008 c 4.98923,0 7.85502,-0.27668 9.36328,-1.45312 0.75412,-0.58824 1.23293,-1.40461 1.54297,-2.66211 C 365.8823,100.62727 366,98.945281 366,96.751953 V 84 71.248047 c 0,-2.193329 -0.1177,-3.875313 -0.42773,-5.132813 -0.31004,-1.257499 -0.78884,-2.073874 -1.54297,-2.662109 C 362.52104,62.276656 359.65526,62 354.66602,62 Z m 2.40234,1.097656 c 6.94737,8.3e-4 13.91063,0.0034 20.84961,0.05469 2.14296,0.08293 4.46431,-0.147701 6.42383,0.93164 1.29609,0.695228 1.54862,2.250325 1.76953,3.564454 0.17551,2.202888 0.0915,4.442228 0.13867,6.669921 0.0227,8.479532 0.077,16.968993 -0.0801,25.447266 -0.16151,1.483233 -0.38135,3.305793 -1.79882,4.142573 -1.6055,0.82871 -3.47551,0.90643 -5.24805,0.95313 -9.49974,0.0678 -19.0243,0.0843 -28.52344,-0.0176 -1.57816,-0.11413 -3.27053,-0.24014 -4.63281,-1.12109 -1.22952,-0.99538 -1.36082,-2.72739 -1.50391,-4.193361 -0.1272,-8.998585 -0.0836,-18.004484 -0.0527,-27.007813 0.0997,-2.381275 -0.24538,-4.900002 0.70508,-7.160156 0.67165,-1.50972 2.46573,-1.859954 3.93945,-2.05664 2.66168,-0.316582 5.34184,-0.147022 8.01367,-0.207032 z"
+           id="path964-3"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g12"
+       inkscape:label="256x256"
+       style="display:inline;enable-background:new;opacity:1">
+      <g
+         inkscape:groupmode="layer"
+         id="g8"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58492)"
+           d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
+           id="rect4158-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter58449)"
+           d="m 225.07297,44.99999 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.00647 73.00648 C 264.16758,265.37459 260.3697,269 225.07297,269 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 156.99999 83.99352 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
+           id="rect4158-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient1694);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 225.07297,43.999694 c 35.29673,0 39.09461,3.62542 38.92162,38.99353 v 73.006466 73.00648 c 0.17299,35.36812 -3.62489,38.99353 -38.92162,38.99353 H 78.916218 c -35.29671,0 -38.92161,-3.625 -38.92161,-38.99353 V 155.99969 82.993224 c 0,-35.36853 3.6249,-38.99353 38.92161,-38.99353 z"
+           id="rect4158"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g10"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g9"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new;opacity:0.7">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:0.3;color:#000000;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 78.92188,43.999698 c -35.296728,0 -39.09487,3.62603 -38.92188,38.99414 v 2 c -0.17299,-35.36811 3.625152,-38.99414 38.92188,-38.99414 h 146.15624 c 35.29673,0 38.92188,3.62561 38.92188,38.99414 v -2 c 0,-35.36853 -3.62515,-38.99414 -38.92188,-38.99414 z"
+           id="path931"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccsscsss" />
+        <path
+           style="display:inline;enable-background:accumulate;opacity:0.2;color:#000000;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 78.92728,267.9997 c -35.296731,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 c -0.17299,35.36811 3.625154,38.99414 38.921885,38.99414 h 146.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 c 0,35.36853 -3.62515,38.99414 -38.92188,38.99414 z"
+           id="path931-8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccsscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g11"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new;opacity:0.7" />
     </g>
   </g>
 </svg>

--- a/icons/src/fullcolor/Vertical Oblong App Icon Template.svg
+++ b/icons/src/fullcolor/Vertical Oblong App Icon Template.svg
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="96"
    inkscape:export-xdpi="96"
    width="400"
    height="300"
    id="svg11300"
    sodipodi:version="0.32"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:version="1.4 (1:1.4+202410161351+e7c3feb100)"
    sodipodi:docname="Vertical Oblong App Icon Template.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.0"
    style="display:inline;enable-background:new"
-   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png">
+   inkscape:export-filename="C:\Users\sblav\Pictures\vertical oblong template.png"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title3004">Yaru Icon Theme Template</title>
   <sodipodi:namedview
@@ -32,17 +32,17 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:zoom="1"
-     inkscape:cx="237.36636"
-     inkscape:cy="124.37647"
-     inkscape:current-layer="layer8"
+     inkscape:cx="112"
+     inkscape:cy="220.5"
+     inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1296"
-     inkscape:window-height="704"
-     inkscape:window-x="70"
-     inkscape:window-y="27"
+     inkscape:window-width="1860"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      width="400px"
      height="300px"
      inkscape:snap-nodes="true"
@@ -61,7 +61,8 @@
      inkscape:snap-smooth-nodes="true"
      inkscape:pagecheckerboard="false"
      showborder="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        spacingy="1"
        spacingx="1"
@@ -72,7 +73,8 @@
        empspacing="4"
        snapvisiblegridlinesonly="true"
        originx="0"
-       originy="0" />
+       originy="0"
+       units="px" />
     <inkscape:grid
        type="xygrid"
        id="grid11592"
@@ -87,7 +89,8 @@
        empopacity="0.25098039"
        snapvisiblegridlinesonly="true"
        originx="0"
-       originy="0" />
+       originy="0"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs3">
@@ -173,10 +176,10 @@
        inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter4346"
-       x="-0.013249796"
-       width="1.0264996"
-       y="-0.010965657"
-       height="1.0219313">
+       x="-0.014454287"
+       width="1.0289086"
+       y="-0.011357288"
+       height="1.0227146">
       <feGaussianBlur
          inkscape:collect="always"
          stdDeviation="2.120027"
@@ -236,9 +239,9 @@
        inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter48920"
-       x="-0.054544518"
+       x="-0.054544517"
        width="1.109089"
-       y="-0.042857721"
+       y="-0.04285772"
        height="1.0857154">
       <feGaussianBlur
          inkscape:collect="always"
@@ -249,7 +252,7 @@
        inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter48924"
-       x="-0.01363613"
+       x="-0.013636129"
        width="1.0272723"
        y="-0.01071443"
        height="1.0214289">
@@ -413,165 +416,273 @@
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer8"
-       inkscape:label="Backgrounds"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;filter:url(#filter48924)"
-         d="m 201.07298,45 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 157 230.00647 C 240.16759,265.37459 236.36971,269 201.07298,269 H 102.91622 C 67.6195,269 63.9946,265.375 63.9946,230.00647 V 157 83.99353 C 63.9946,48.624997 67.6195,45 102.91622,45 Z"
-         id="rect4158-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;filter:url(#filter48920)"
-         d="m 201.07298,45 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 157 230.00647 C 240.16759,265.37459 236.36971,269 201.07298,269 H 102.91622 C 67.6195,269 63.9946,265.375 63.9946,230.00647 V 157 83.99353 C 63.9946,48.624997 67.6195,45 102.91622,45 Z"
-         id="rect4158-1-2"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
-         id="path11042-5"
-         r="112"
-         cy="156"
-         cx="152"
-         d=""
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346);enable-background:accumulate"
-         d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
-         id="rect4158-9"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         transform="matrix(0.5,0,0,0.5,8,8)" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 201.07298,44 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 156 229.00647 C 240.16759,264.37459 236.36971,268 201.07298,268 H 102.91622 C 67.6195,268 63.9946,264.375 63.9946,229.00647 V 156 82.99353 C 63.9946,47.624997 67.6195,44 102.91622,44 Z"
-         id="rect4158"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 327.86523,189 c -1.12014,0 -2.01524,0.0241 -2.79101,0.1543 -0.77577,0.13022 -1.48014,0.38763 -2.00977,0.91601 -0.52962,0.52838 -0.79079,1.23687 -0.91992,2.01367 -0.12912,0.77681 -0.15002,1.67169 -0.14453,2.79493 V 201 v 5.1245 c -0.005,1.12104 0.0156,2.01529 0.14453,2.79102 0.12912,0.77681 0.39029,1.48529 0.91992,2.01367 0.52964,0.52838 1.234,0.78579 2.00977,0.91601 0.77577,0.13022 1.67087,0.1543 2.79101,0.1543 h 8.26954 c 1.12013,0 2.01264,-0.024 2.78711,-0.1543 0.77446,-0.13033 1.48001,-0.38927 2.00781,-0.91797 0.5278,-0.52869 0.78594,-1.23438 0.91601,-2.00976 C 341.97577,208.14208 342,207.24685 342,206.1245 V 201 194.875 c 0,-1.12235 -0.0242,-2.01758 -0.1543,-2.79297 -0.13007,-0.77538 -0.38821,-1.48107 -0.91601,-2.00976 -0.5278,-0.5287 -1.23334,-0.78764 -2.00781,-0.91797 C 338.1474,189.02397 337.25491,189 336.13477,189 Z"
-         id="path995"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccccccccssscccscscccss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
-         id="path997"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccccsscscscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 330.19336,134 c -1.42096,0 -2.54883,0.0308 -3.50586,0.19141 -0.95703,0.16064 -1.79146,0.4726 -2.41211,1.09179 -0.62065,0.61919 -0.93647,1.45612 -1.0957,2.41407 -0.15924,0.95795 -0.18666,2.08705 -0.17969,3.51171 V 149 v 7.79688 c -0.007,1.42131 0.0207,2.5495 0.17969,3.50585 0.15923,0.95796 0.47505,1.79488 1.0957,2.41407 0.62065,0.61919 1.45508,0.93115 2.41211,1.09179 0.95703,0.16065 2.0849,0.19141 3.50586,0.19141 h 11.61523 c 1.42097,0 2.54669,-0.0307 3.50196,-0.19141 0.95527,-0.16075 1.78779,-0.47425 2.40625,-1.09375 0.61845,-0.6195 0.93134,-1.45363 1.09179,-2.41015 C 348.96905,159.34816 349,158.22066 349,156.79688 V 149 141.20312 c 0,-1.42378 -0.031,-2.55128 -0.19141,-3.50781 -0.16045,-0.95653 -0.47334,-1.79065 -1.09179,-2.41015 -0.61846,-0.61951 -1.45098,-0.933 -2.40625,-1.09375 C 344.35528,134.03065 343.22956,134 341.80859,134 Z"
-         id="path999"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scscccccscsscccscscscss" />
-      <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-         d="m 335.45642,62 c -2.16609,0 -3.87167,0.05009 -5.27508,0.286735 -1.40341,0.236639 -2.55181,0.680503 -3.39303,1.523515 -0.8412,0.843013 -1.2852,1.996072 -1.51858,3.406406 -0.23338,1.410336 -0.27894,3.127346 -0.26832,5.308412 v 12.474816 12.480783 c -0.0105,2.177715 0.0352,3.893853 0.26832,5.302673 0.23338,1.41034 0.67738,2.5634 1.51858,3.40641 0.84122,0.84301 1.98962,1.28688 3.39303,1.52351 1.40342,0.23665 3.10899,0.28674 5.27508,0.28674 H 352.545 c 2.1661,0 3.87077,-0.05 5.27128,-0.28674 1.4005,-0.23674 2.5454,-0.6821 3.3835,-1.52542 0.83812,-0.84331 1.27948,-1.99555 1.51477,-3.4045 C 362.94984,101.37441 363,99.660878 363,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0502,-3.893733 -0.28545,-5.302677 -0.23529,-1.408942 -0.67666,-2.561177 -1.51478,-3.404494 -0.8381,-0.843317 -1.983,-1.288685 -3.3835,-1.525427 C 356.41577,62.049992 354.71109,62 352.545,62 Z"
-         id="path1020"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="sccsccccccsscccscsccsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path964"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss"
-         clip-path="none" />
-      <path
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path914"
-         d="m 327.636,188.49999 c -4.65703,0 -5.15812,0.47378 -5.1353,5.09575 v 6.40425 6.40426 c -0.0229,4.62196 0.47827,5.09574 5.1353,5.09574 h 8.72869 c 4.65703,0 5.1353,-0.47372 5.1353,-5.09574 v -6.40426 -6.40425 c 0,-4.62202 -0.47828,-5.09575 -5.13531,-5.09575 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 324.8545,236.50001 c -3.04166,0 -3.36894,0.30899 -3.35403,3.32331 v 4.17669 4.17668 c -0.0149,3.01433 0.31237,3.32332 3.35403,3.32332 h 6.29146 c 3.04167,0 3.35404,-0.30895 3.35404,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.31238,-3.32331 -3.35404,-3.32331 z"
-         id="path918"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3257);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path964-7"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
+       id="layer15"
+       inkscape:label="16x16">
+      <g
+         inkscape:groupmode="layer"
+         id="g7-0"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 325.0957,237 c -0.71904,0 -1.30185,0.0139 -1.83593,0.10352 -0.53409,0.0897 -1.0683,0.27628 -1.47657,0.68359 -0.40826,0.4073 -0.59657,0.94323 -0.68554,1.47851 -0.089,0.53529 -0.10119,1.12048 -0.0977,1.8418 V 244 v 3.89844 c -0.003,0.71816 0.009,1.30235 0.0977,1.83594 0.089,0.53528 0.27727,1.07121 0.68554,1.47851 0.40827,0.40731 0.94248,0.59394 1.47657,0.68359 0.53408,0.0897 1.11689,0.10352 1.83593,0.10352 h 5.8086 c 0.71904,0 1.30058,-0.0137 1.83398,-0.10352 0.53341,-0.0898 1.06768,-0.27792 1.47461,-0.68554 0.40693,-0.40762 0.59404,-0.94271 0.68359,-1.47656 C 334.98604,249.20052 335,248.61887 335,247.89844 V 244 241.10156 c 0,-0.72043 -0.014,-1.30208 -0.10352,-1.83594 -0.0895,-0.53385 -0.27666,-1.06894 -0.68359,-1.47656 -0.40693,-0.40762 -0.9412,-0.59578 -1.47461,-0.68554 C 332.20488,237.01375 331.62334,237 330.9043,237 Z"
+           id="path997"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scscccccccsscscscscscss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient920);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 324.8545,236.50001 c -3.04166,0 -3.36894,0.30899 -3.35403,3.32331 v 4.17669 4.17668 c -0.0149,3.01433 0.31237,3.32332 3.35403,3.32332 h 6.29146 c 3.04167,0 3.35404,-0.30895 3.35404,-3.32332 v -4.17668 -4.17669 c 0,-3.01436 -0.31238,-3.32331 -3.35404,-3.32331 z"
+           id="path918"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g8-3"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g2-6"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 331.08094,251.5 c 2.89212,0 3.43393,-0.30212 3.41873,-3.24946 v -4.25051 -4.25058 c 0.0152,-2.94734 -0.52661,-3.24945 -3.41873,-3.24945 h -6.16221 c -2.8914,0 -3.41873,0.30208 -3.41873,3.24945 v 4.25058 4.25051 c 0,2.94738 0.52733,3.24946 3.41873,3.24946 z"
+           id="path958-6-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g6-1"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient920-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 324.91406,236.98828 c -1.43089,0 -2.16322,0.12118 -2.46484,0.39258 -0.15081,0.1357 -0.26235,0.33219 -0.34375,0.71289 -0.0814,0.3807 -0.11719,0.92536 -0.11719,1.64844 V 244 v 4.25781 c 0,0.72309 0.0358,1.26774 0.11719,1.64844 0.0814,0.3807 0.19294,0.57719 0.34375,0.71289 0.30162,0.2714 1.03395,0.39258 2.46484,0.39258 h 6.17188 c 1.43125,0 2.16767,-0.1209 2.4707,-0.39258 0.15152,-0.13584 0.26315,-0.33097 0.34375,-0.71094 0.0805,-0.37996 0.11533,-0.92581 0.11133,-1.64843 v -0.002 V 244 v -4.25781 -0.002 c 0.004,-0.72262 -0.0308,-1.26847 -0.11133,-1.64843 -0.0806,-0.37997 -0.19224,-0.5751 -0.34375,-0.71094 -0.30303,-0.27167 -1.03945,-0.39258 -2.4707,-0.39258 z m 2.31641,1.0293 c 0.90892,-0.001 1.81765,-0.001 2.72656,0.004 0.91032,0.0328 1.83236,-0.0486 2.73438,0.0996 0.24585,-0.0171 0.20202,0.27429 0.23632,0.4375 0.0753,2.8091 0.0533,5.67804 0.043,8.51368 -0.0226,0.85541 0.0164,1.70681 -0.0684,2.54882 0.0121,0.3147 -0.35695,0.2628 -0.57617,0.3125 -2.08305,0.061 -4.22761,0.0369 -6.33789,0.0371 -0.88599,-0.0302 -1.78126,0.0435 -2.66016,-0.0859 -0.25376,0.0253 -0.21301,-0.26186 -0.25781,-0.42579 -0.0802,-2.89787 -0.0539,-5.83578 -0.043,-8.7539 0.0277,-0.79099 -0.0254,-1.57718 0.0781,-2.36524 -0.0231,-0.27517 0.29693,-0.21327 0.47265,-0.26367 1.21401,-0.0833 2.43564,-0.0401 3.65235,-0.0586 z"
+           id="path918-3"
+           inkscape:connector-curvature="0" />
+      </g>
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer6"
-       inkscape:label="Pictograms and folds"
-       style="display:inline" />
-    <g
-       inkscape:groupmode="layer"
-       id="layer5"
-       inkscape:label="Borders"
-       style="display:inline">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
-         id="path958"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
-         id="path958-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 336.50293,211.5 c 4.22694,0 5.01881,-0.46324 4.9966,-4.98249 v -6.51744 -6.51758 c 0.0222,-4.51925 -0.76966,-4.98249 -4.9966,-4.98249 h -9.00633 c -4.22588,0 -4.9966,0.46319 -4.9966,4.98249 v 6.51758 6.51744 c 0,4.5193 0.77072,4.98249 4.9966,4.98249 z"
-         id="path958-6"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 331.08094,251.5 c 2.89212,0 3.43393,-0.30212 3.41873,-3.24946 v -4.25051 -4.25058 c 0.0152,-2.94734 -0.52661,-3.24945 -3.41873,-3.24945 h -6.16221 c -2.8914,0 -3.41873,0.30208 -3.41873,3.24945 v 4.25058 4.25051 c 0,2.94738 0.52733,3.24946 3.41873,3.24946 z"
-         id="path958-6-0"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="scccssscsss" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="m 102.92728,268 c -35.296735,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 C 63.832405,262.37397 67.630545,266 102.92728,266 h 98.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 C 240.0054,264.37439 236.38025,268 201.08352,268 Z"
-         id="path931-8"
-         inkscape:connector-curvature="0" />
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         d="M 102.92188,44 C 67.62515,44 63.82701,47.626029 64,82.994141 v 2 C 63.82701,49.626029 67.62515,46 102.92188,46 h 98.15624 C 236.37485,46 240,49.625608 240,84.994141 v -2 C 240,47.625608 236.37485,44 201.07812,44 Z"
-         id="path931"
-         inkscape:connector-curvature="0" />
+       id="g3"
+       inkscape:label="24x24">
+      <g
+         inkscape:groupmode="layer"
+         id="g7-4"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 327.86523,189 c -1.12014,0 -2.01524,0.0241 -2.79101,0.1543 -0.77577,0.13022 -1.48014,0.38763 -2.00977,0.91601 -0.52962,0.52838 -0.79079,1.23687 -0.91992,2.01367 -0.12912,0.77681 -0.15002,1.67169 -0.14453,2.79493 V 201 v 5.1245 c -0.005,1.12104 0.0156,2.01529 0.14453,2.79102 0.12912,0.77681 0.39029,1.48529 0.91992,2.01367 0.52964,0.52838 1.234,0.78579 2.00977,0.91601 0.77577,0.13022 1.67087,0.1543 2.79101,0.1543 h 8.26954 c 1.12013,0 2.01264,-0.024 2.78711,-0.1543 0.77446,-0.13033 1.48001,-0.38927 2.00781,-0.91797 0.5278,-0.52869 0.78594,-1.23438 0.91601,-2.00976 C 341.97577,208.14208 342,207.24685 342,206.1245 V 201 194.875 c 0,-1.12235 -0.0242,-2.01758 -0.1543,-2.79297 -0.13007,-0.77538 -0.38821,-1.48107 -0.91601,-2.00976 -0.5278,-0.5287 -1.23334,-0.78764 -2.00781,-0.91797 C 338.1474,189.02397 337.25491,189 336.13477,189 Z"
+           id="path995"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccccccccssscccscscccss" />
+        <path
+           sodipodi:nodetypes="scccssscsss"
+           inkscape:connector-curvature="0"
+           id="path914"
+           d="m 327.636,188.49999 c -4.65703,0 -5.15812,0.47378 -5.1353,5.09575 v 6.40425 6.40426 c -0.0229,4.62196 0.47827,5.09574 5.1353,5.09574 h 8.72869 c 4.65703,0 5.1353,-0.47372 5.1353,-5.09574 v -6.40426 -6.40425 c 0,-4.62202 -0.47828,-5.09575 -5.13531,-5.09575 z"
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g8-7"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g2-8"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 336.50293,211.5 c 4.22694,0 5.01881,-0.46324 4.9966,-4.98249 v -6.51744 -6.51758 c 0.0222,-4.51925 -0.76966,-4.98249 -4.9966,-4.98249 h -9.00633 c -4.22588,0 -4.9966,0.46319 -4.9966,4.98249 v 6.51758 6.51744 c 0,4.5193 0.77072,4.98249 4.9966,4.98249 z"
+           id="path958-6"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g6-4"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient916-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 327.49609,189 c -2.09467,0 -3.20641,0.15795 -3.73828,0.66016 -0.26593,0.2511 -0.456,0.61757 -0.58203,1.23632 C 323.0498,191.51524 323,192.36681 323,193.48242 V 200 v 6.51758 c 0,1.11561 0.0498,1.96718 0.17578,2.58594 0.12603,0.61875 0.3161,0.98522 0.58203,1.23632 0.53187,0.50221 1.64361,0.66016 3.73828,0.66016 h 9.00782 c 2.0952,0 3.21398,-0.15771 3.74804,-0.66016 0.26704,-0.25122 0.45522,-0.61827 0.58008,-1.23632 0.12487,-0.61806 0.17297,-1.46882 0.16797,-2.58399 V 200 193.48047 c 0.005,-1.11517 -0.0431,-1.96593 -0.16797,-2.58399 -0.12486,-0.61805 -0.31305,-0.9851 -0.58008,-1.23632 C 339.71789,189.15771 338.59911,189 336.50391,189 Z m 0.88086,1.06641 c 2.7315,-0.003 5.4639,0.008 8.19532,0.0273 0.85948,0.0532 1.76737,-0.08 2.61132,0.16602 0.5672,0.10141 0.62914,0.77213 0.68164,1.23242 0.102,5.12029 0.0744,10.26846 0.0352,15.38867 -0.072,0.88247 0.14254,1.86311 -0.33398,2.66016 -0.51616,0.37575 -1.22058,0.30982 -1.82618,0.39062 -3.78525,0.0784 -7.57376,0.066 -11.35937,0.01 -0.64061,-0.0672 -1.38357,-0.003 -1.92578,-0.4043 -0.50523,-0.79819 -0.31286,-1.80279 -0.37696,-2.69727 -0.0388,-5.06456 -0.0699,-10.156 0.0313,-15.2207 0.0819,-0.47534 0.10336,-1.19594 0.67578,-1.34766 1.17623,-0.31105 2.39308,-0.15427 3.59179,-0.20507 z"
+           id="path914-8"
+           inkscape:connector-curvature="0" />
+      </g>
     </g>
     <g
        inkscape:groupmode="layer"
-       id="layer10"
-       inkscape:label="Highlights"
-       style="opacity:0.7">
-      <path
-         transform="matrix(0.66664182,0,0,0.63636364,106.67522,94.545454)"
-         sodipodi:nodetypes="scccssscsss"
-         inkscape:connector-curvature="0"
-         id="path990-8"
-         d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2908);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
-         clip-path="url(#clipPath994-1-2)" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient2673);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
-         d="M 335.73047,62 C 326.90629,62 325.95675,62.906017 326,71.748047 V 84 96.251953 C 325.9567,105.09398 326.90629,106 335.73047,106 h 16.53906 C 361.09371,106 362,105.09408 362,96.251953 V 84 71.748047 C 362,62.905917 361.09371,62 352.26953,62 Z m 11.58594,1.083984 c 1.58586,-0.002 3.172,-0.0046 4.75781,0.0098 2.24104,0.112648 4.61852,-0.159439 6.77539,0.677734 1.61064,0.815891 1.89861,2.822819 1.97851,4.447266 0.1486,8.949973 0.0584,17.944327 0.0664,26.912109 -0.1124,2.417589 0.23363,4.901277 -0.50976,7.251947 -0.35209,1.46925 -1.87421,2.11123 -3.22266,2.33594 -7.11783,0.21369 -14.25487,0.17302 -21.38281,0.16602 -2.37545,-0.10878 -4.96603,0.29495 -7.1211,-0.96485 -1.54366,-1.12044 -1.37997,-3.32646 -1.48632,-4.964838 -0.13752,-9.226199 -0.0249,-18.549024 0.004,-27.8125 0.10712,-1.790293 -0.16515,-3.606621 0.3418,-5.359375 0.3631,-1.607644 2.01509,-2.381908 3.52344,-2.517578 5.40981,-0.227052 10.84859,-0.125241 16.27539,-0.181641 z"
-         id="path996-9"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient920-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 324.91406,236.98828 c -1.43089,0 -2.16322,0.12118 -2.46484,0.39258 -0.15081,0.1357 -0.26235,0.33219 -0.34375,0.71289 -0.0814,0.3807 -0.11719,0.92536 -0.11719,1.64844 V 244 v 4.25781 c 0,0.72309 0.0358,1.26774 0.11719,1.64844 0.0814,0.3807 0.19294,0.57719 0.34375,0.71289 0.30162,0.2714 1.03395,0.39258 2.46484,0.39258 h 6.17188 c 1.43125,0 2.16767,-0.1209 2.4707,-0.39258 0.15152,-0.13584 0.26315,-0.33097 0.34375,-0.71094 0.0805,-0.37996 0.11533,-0.92581 0.11133,-1.64843 v -0.002 V 244 v -4.25781 -0.002 c 0.004,-0.72262 -0.0308,-1.26847 -0.11133,-1.64843 -0.0806,-0.37997 -0.19224,-0.5751 -0.34375,-0.71094 -0.30303,-0.27167 -1.03945,-0.39258 -2.4707,-0.39258 z m 2.31641,1.0293 c 0.90892,-0.001 1.81765,-0.001 2.72656,0.004 0.91032,0.0328 1.83236,-0.0486 2.73438,0.0996 0.24585,-0.0171 0.20202,0.27429 0.23632,0.4375 0.0753,2.8091 0.0533,5.67804 0.043,8.51368 -0.0226,0.85541 0.0164,1.70681 -0.0684,2.54882 0.0121,0.3147 -0.35695,0.2628 -0.57617,0.3125 -2.08305,0.061 -4.22761,0.0369 -6.33789,0.0371 -0.88599,-0.0302 -1.78126,0.0435 -2.66016,-0.0859 -0.25376,0.0253 -0.21301,-0.26186 -0.25781,-0.42579 -0.0802,-2.89787 -0.0539,-5.83578 -0.043,-8.7539 0.0277,-0.79099 -0.0254,-1.57718 0.0781,-2.36524 -0.0231,-0.27517 0.29693,-0.21327 0.47265,-0.26367 1.21401,-0.0833 2.43564,-0.0401 3.65235,-0.0586 z"
-         id="path918-3"
-         inkscape:connector-curvature="0" />
-      <path
-         style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient916-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         d="m 327.49609,189 c -2.09467,0 -3.20641,0.15795 -3.73828,0.66016 -0.26593,0.2511 -0.456,0.61757 -0.58203,1.23632 C 323.0498,191.51524 323,192.36681 323,193.48242 V 200 v 6.51758 c 0,1.11561 0.0498,1.96718 0.17578,2.58594 0.12603,0.61875 0.3161,0.98522 0.58203,1.23632 0.53187,0.50221 1.64361,0.66016 3.73828,0.66016 h 9.00782 c 2.0952,0 3.21398,-0.15771 3.74804,-0.66016 0.26704,-0.25122 0.45522,-0.61827 0.58008,-1.23632 0.12487,-0.61806 0.17297,-1.46882 0.16797,-2.58399 V 200 193.48047 c 0.005,-1.11517 -0.0431,-1.96593 -0.16797,-2.58399 -0.12486,-0.61805 -0.31305,-0.9851 -0.58008,-1.23632 C 339.71789,189.15771 338.59911,189 336.50391,189 Z m 0.88086,1.06641 c 2.7315,-0.003 5.4639,0.008 8.19532,0.0273 0.85948,0.0532 1.76737,-0.08 2.61132,0.16602 0.5672,0.10141 0.62914,0.77213 0.68164,1.23242 0.102,5.12029 0.0744,10.26846 0.0352,15.38867 -0.072,0.88247 0.14254,1.86311 -0.33398,2.66016 -0.51616,0.37575 -1.22058,0.30982 -1.82618,0.39062 -3.78525,0.0784 -7.57376,0.066 -11.35937,0.01 -0.64061,-0.0672 -1.38357,-0.003 -1.92578,-0.4043 -0.50523,-0.79819 -0.31286,-1.80279 -0.37696,-2.69727 -0.0388,-5.06456 -0.0699,-10.156 0.0313,-15.2207 0.0819,-0.47534 0.10336,-1.19594 0.67578,-1.34766 1.17623,-0.31105 2.39308,-0.15427 3.59179,-0.20507 z"
-         id="path914-8"
-         inkscape:connector-curvature="0" />
+       id="g4"
+       inkscape:label="32x32">
+      <g
+         inkscape:groupmode="layer"
+         id="g7-1"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 330.19336,134 c -1.42096,0 -2.54883,0.0308 -3.50586,0.19141 -0.95703,0.16064 -1.79146,0.4726 -2.41211,1.09179 -0.62065,0.61919 -0.93647,1.45612 -1.0957,2.41407 -0.15924,0.95795 -0.18666,2.08705 -0.17969,3.51171 V 149 v 7.79688 c -0.007,1.42131 0.0207,2.5495 0.17969,3.50585 0.15923,0.95796 0.47505,1.79488 1.0957,2.41407 0.62065,0.61919 1.45508,0.93115 2.41211,1.09179 0.95703,0.16065 2.0849,0.19141 3.50586,0.19141 h 11.61523 c 1.42097,0 2.54669,-0.0307 3.50196,-0.19141 0.95527,-0.16075 1.78779,-0.47425 2.40625,-1.09375 0.61845,-0.6195 0.93134,-1.45363 1.09179,-2.41015 C 348.96905,159.34816 349,158.22066 349,156.79688 V 149 141.20312 c 0,-1.42378 -0.031,-2.55128 -0.19141,-3.50781 -0.16045,-0.95653 -0.47334,-1.79065 -1.09179,-2.41015 -0.61846,-0.61951 -1.45098,-0.933 -2.40625,-1.09375 C 344.35528,134.03065 343.22956,134 341.80859,134 Z"
+           id="path999"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scscccccscsscccscscscss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient3257);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
+           id="path964-7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g8-2"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g2-9"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 330.07509,133.5 c -5.56175,0 -6.6037,0.58409 -6.57447,6.28227 v 8.21765 8.21781 c -0.0293,5.69818 1.01272,6.28227 6.57447,6.28227 h 11.85044 c 5.56037,0 6.57447,-0.58403 6.57447,-6.28227 v -8.21781 -8.21765 c 0,-5.69824 -1.0141,-6.28227 -6.57447,-6.28227 z"
+           id="path958-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g6-31"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           transform="matrix(0.66664182,0,0,0.63636364,106.67522,94.545454)"
+           sodipodi:nodetypes="scccssscsss"
+           inkscape:connector-curvature="0"
+           id="path990-8"
+           d="m 335.73108,62 c -8.82418,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.25162 c -0.0433,8.84203 0.90622,9.74838 9.7304,9.74838 h 16.53919 c 8.82418,0 9.7304,-0.90625 9.7304,-9.74838 V 84 71.74838 C 362.00067,62.90625 361.09445,62 352.27027,62 Z"
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2908);stroke-width:3.07065511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           clip-path="url(#clipPath994-1-2)" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g2"
+       inkscape:label="48x48">
+      <g
+         inkscape:groupmode="layer"
+         id="g7-8"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+           d="m 335.45642,62 c -2.16609,0 -3.87167,0.05009 -5.27508,0.286735 -1.40341,0.236639 -2.55181,0.680503 -3.39303,1.523515 -0.8412,0.843013 -1.2852,1.996072 -1.51858,3.406406 -0.23338,1.410336 -0.27894,3.127346 -0.26832,5.308412 v 12.474816 12.480783 c -0.0105,2.177715 0.0352,3.893853 0.26832,5.302673 0.23338,1.41034 0.67738,2.5634 1.51858,3.40641 0.84122,0.84301 1.98962,1.28688 3.39303,1.52351 1.40342,0.23665 3.10899,0.28674 5.27508,0.28674 H 352.545 c 2.1661,0 3.87077,-0.05 5.27128,-0.28674 1.4005,-0.23674 2.5454,-0.6821 3.3835,-1.52542 0.83812,-0.84331 1.27948,-1.99555 1.51477,-3.4045 C 362.94984,101.37441 363,99.660878 363,97.480667 V 84.999884 72.519333 c 0,-2.180211 -0.0502,-3.893733 -0.28545,-5.302677 -0.23529,-1.408942 -0.67666,-2.561177 -1.51478,-3.404494 -0.8381,-0.843317 -1.983,-1.288685 -3.3835,-1.525427 C 356.41577,62.049992 354.71109,62 352.545,62 Z"
+           id="path1020"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sccsccccccsscccscsccsss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient3194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
+           id="path964"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss"
+           clip-path="none" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g8-9"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g2-7"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="m 335.23154,61.500047 c -8.23154,0 -9.77365,0.90635 -9.7304,9.74838 V 84 96.75181 c -0.0433,8.84203 1.49886,9.74838 9.7304,9.74838 h 17.53897 c 8.22949,0 9.73039,-0.90625 9.73039,-9.74838 V 84 71.248427 c 0,-8.84213 -1.5009,-9.74838 -9.7304,-9.74838 z"
+           id="path958"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g6-3"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;opacity:1;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient2673);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none"
+           d="M 335.73047,62 C 326.90629,62 325.95675,62.906017 326,71.748047 V 84 96.251953 C 325.9567,105.09398 326.90629,106 335.73047,106 h 16.53906 C 361.09371,106 362,105.09408 362,96.251953 V 84 71.748047 C 362,62.905917 361.09371,62 352.26953,62 Z m 11.58594,1.083984 c 1.58586,-0.002 3.172,-0.0046 4.75781,0.0098 2.24104,0.112648 4.61852,-0.159439 6.77539,0.677734 1.61064,0.815891 1.89861,2.822819 1.97851,4.447266 0.1486,8.949973 0.0584,17.944327 0.0664,26.912109 -0.1124,2.417589 0.23363,4.901277 -0.50976,7.251947 -0.35209,1.46925 -1.87421,2.11123 -3.22266,2.33594 -7.11783,0.21369 -14.25487,0.17302 -21.38281,0.16602 -2.37545,-0.10878 -4.96603,0.29495 -7.1211,-0.96485 -1.54366,-1.12044 -1.37997,-3.32646 -1.48632,-4.964838 -0.13752,-9.226199 -0.0249,-18.549024 0.004,-27.8125 0.10712,-1.790293 -0.16515,-3.606621 0.3418,-5.359375 0.3631,-1.607644 2.01509,-2.381908 3.52344,-2.517578 5.40981,-0.227052 10.84859,-0.125241 16.27539,-0.181641 z"
+           id="path996-9"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="g5"
+       inkscape:label="256x256">
+      <g
+         inkscape:groupmode="layer"
+         id="g7"
+         inkscape:label="Backgrounds"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter48924)"
+           d="m 201.07298,45 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 157 230.00647 C 240.16759,265.37459 236.36971,269 201.07298,269 H 102.91622 C 67.6195,269 63.9946,265.375 63.9946,230.00647 V 157 83.99353 C 63.9946,48.624997 67.6195,45 102.91622,45 Z"
+           id="rect4158-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;filter:url(#filter48920)"
+           d="m 201.07298,45 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 157 230.00647 C 240.16759,265.37459 236.36971,269 201.07298,269 H 102.91622 C 67.6195,269 63.9946,265.375 63.9946,230.00647 V 157 83.99353 C 63.9946,48.624997 67.6195,45 102.91622,45 Z"
+           id="rect4158-1-2"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter4346)"
+           d="M 189.84323,74 C 119.24979,74 111.65402,81.250835 112,151.98706 V 298 444.01294 C 111.65402,514.74917 119.24979,522 189.84323,522 H 386.15677 C 456.75021,522 462.16345,514.72616 464,444.01294 V 298 151.98706 C 464,81.249993 456.75021,74 386.15677,74 Z"
+           id="rect4158-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss"
+           transform="matrix(0.5,0,0,0.5,8,8)" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;fill:url(#linearGradient4226);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 201.07298,44 c 35.29673,0 39.09461,3.625418 38.92162,38.99353 V 156 229.00647 C 240.16759,264.37459 236.36971,268 201.07298,268 H 102.91622 C 67.6195,268 63.9946,264.375 63.9946,229.00647 V 156 82.99353 C 63.9946,47.624997 67.6195,44 102.91622,44 Z"
+           id="rect4158"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="scccssscsss" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g8"
+         inkscape:label="Pictograms and folds"
+         style="display:inline;enable-background:new" />
+      <g
+         inkscape:groupmode="layer"
+         id="g1"
+         inkscape:label="Borders"
+         style="display:inline;enable-background:new">
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 102.92728,268 c -35.296735,0 -39.094875,-3.62603 -38.921885,-38.99414 v -2 C 63.832405,262.37397 67.630545,266 102.92728,266 h 98.15624 c 35.29673,0 38.92188,-3.62561 38.92188,-38.99414 v 2 C 240.0054,264.37439 236.38025,268 201.08352,268 Z"
+           id="path931-8"
+           inkscape:connector-curvature="0" />
+        <path
+           style="display:inline;enable-background:accumulate;color:#000000;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="M 102.92188,44 C 67.62515,44 63.82701,47.626029 64,82.994141 v 2 C 63.82701,49.626029 67.62515,46 102.92188,46 h 98.15624 C 236.37485,46 240,49.625608 240,84.994141 v -2 C 240,47.625608 236.37485,44 201.07812,44 Z"
+           id="path931"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         inkscape:groupmode="layer"
+         id="g6"
+         inkscape:label="Highlights"
+         style="display:inline;enable-background:new" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
### Before
```

icons
    ├── Highlights
    ├── Borders
    ├── Pictograms and folds
    ├── Backgrounds
    ├── Optional outline for white icons
    └── Baseplate
```
### After

```

icons
    ├── 256x256
    ├── 48x48
    ├── 32x32
    ├── 24x24
    ├── 16x16
    ├── Optional outline for white icons
    └── Baseplate

    each icon size group has its own highlights group, borders group etc.
```

I think this layers setup is much cleaner and much easier to manage, given that it increases the amount of layers at least     you can easily managed the objects related to each icon sizes rather than them flying around for example inside pictograms and folds layer.

Feel free to comment down below if you see wrong objects placed on wrong layers. 
