### PR TITLE
Suplement Missing Symbolic Icons

### DIFF
--- a/icons/Yaru/scalable/categories/org.gnome.Settings-screen-lock-symbolic.svg
+++ b/icons/Yaru/scalable/categories/org.gnome.Settings-screen-lock-symbolic.svg
@@ -1,0 +1,1 @@
+../org.gnome.Settings/screen-lock-symbolic.svg

--- a/icons/src/symlinks/symbolic/categories.list
+++ b/icons/src/symlinks/symbolic/categories.list
@@ -27,6 +27,7 @@ preferences-system-network-proxy-symbolic.svg org.gnome.Settings-network-proxy-s
 ../emblems/flag-outline-thin-symbolic.svg translations-symbolic.svg
 ../generic-symbols/warning-symbolic.svg permissions-warning-symbolic.svg
 ../mimetypes/package-x-generic-symbolic.svg package-generic-symbolic.svg
+../org.gnome.Settings/screen-lock-symbolic.svg org.gnome.Settings-screen-lock-symbolic.svg
 ../places/user-trash-symbolic.svg trash-symbolic.svg
 ../places/user-trash-symbolic.svg org.gnome.Settings-trash-file-history-symbolic.svg
 ../status/security-high-symbolic.svg org.gnome.Settings-device-security-symbolic.svg


### PR DESCRIPTION
I notice that some icons are falling back to hicolor in some apps like Settings and Nautilus. 
This PR will either add symlinks or make the icons from scratch.

Task:
- [ ] added all missing icons in gnome-control-center 
- [ ] added missing icon in nautilus
- [ ] others apps. this list will grow when more missing icons are found.

# Screenshots: `missing icons`
## under gnome-control-center
![Screenshot From 2024-12-08 15-35-18](https://github.com/user-attachments/assets/910f44a6-c1df-4dcf-8303-03bdc502d984)
![Screenshot From 2024-12-08 15-35-29](https://github.com/user-attachments/assets/6efebf66-ffc5-48f7-af82-eadd26722007)
## under nautilus
![image](https://github.com/user-attachments/assets/0c33fd73-7a8e-4b27-9496-0a670a447e80)

