### PR TITLE
Adjusted Notification Banner Border Radius and On Click Color. 

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_notifications.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_notifications.scss
@@ -2,13 +2,14 @@
 
 $notification_banner_height: 64px;
 $notification_banner_width: 34em;
+$notification_banner_border_radius: 12px;  // similar to the implemented to yaru-gtk $window_radius: $button_radius + 6;
 
 // Banner notifications
 .notification-banner {
   min-height: $notification_banner_height;
   width: $notification_banner_width;
   box-shadow: 0 2px 4px 2px $shadow_color;
-  border-radius: $modal_radius;
+  border-radius: $notification_banner_border_radius; // Yaru: $modal_radius is too small (see issue #4082).
   margin: $base_margin;
   background-color: $bg_color; // Yaru change: use bg_color for better contrast with buttons
 
@@ -23,7 +24,9 @@ $notification_banner_width: 34em;
 
   &:active {
     // Yaru change: ↑↑↑
-    background-color: if($variant =='light', darken($bg_color, 4%), lighten($bg_color, 4%));
+    // Yaru notice: the original 4% was actually too dark and only appears to be too light (see issue #4082). fixed  !important flag.
+    // Yaru change: moved dark-shell on-click from 4% to 8%.
+    background-color: if($variant =='light', darken($bg_color, 4%), lighten($bg_color, 8%)) !important;
   }
 
   // Yaru: make notifications more visible on different headerbars:


### PR DESCRIPTION
<table>
<td>

| Current Implementation   |
|  -----------------------------------------  |
|  BORDER RADIUS  |
|  <image src=https://github.com/user-attachments/assets/879a5b3e-10a8-40ae-9e65-cd188fde7b4f width=350 /> |
|  BORDER RADIUS + ON CLICK  |
|  <image src=https://github.com/user-attachments/assets/45c63c90-a1a4-4ff3-a14b-a892bda4c60e width=350 />  |

</td>
<td>

| My Implementation   |
|  -----------------------------------------  |
|  BORDER RADIUS  |
|  <image src=https://github.com/user-attachments/assets/0104523d-9e00-4bd5-aa40-e313cf58e34c width=350/> |
|  BORDER RADIUS + ON CLICK  |
| <image src=https://github.com/user-attachments/assets/839cddf5-ba6d-42e5-a29f-6ec7f9b21611 width=350/> |

</td>
</table>

`radius`: 12px (base on a gtk window).

`onclick-color`: bg_color at 8 percent. I increased it from 4 to 8 because 4% is actually too dark. The reason behind the appearance of that overly bright on click color is the it uses the default upstream on click color. I solved it by adding a
 `!important` to the background-color property.

resolves #4082