### PR TITLE
Improve the Look of Gnome Shell Dialogs

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
@@ -1,5 +1,13 @@
 /* Modal Dialogs */
 
+// Yaru Custom Definition
+$dialog_padding: $base_padding * 4 $base_padding * 3 $base_padding * 3 $base_padding * 3;
+
+// Yaru Custom headline
+.headline {
+  @extend %title_4;
+}
+
 // style for all dialogs
 .modal-dialog {
   background-color: $bg_color;
@@ -50,6 +58,8 @@
 /* End Session Dialog */
 .end-session-dialog {
   width: 24em;
+  border-radius: $yaru_menu_border_radius; // Yaru Change: Override default radius
+  padding: $base_padding * 3; // Yaru Change: Override default padding
 
   // special style for session warnings
   .end-session-dialog-battery-warning,
@@ -81,6 +91,8 @@
 
 /* Run Dialog */
 .run-dialog {
+  padding: $base_padding * 3; // Yaru change: padding match to quick settings 
+  border-radius: $yaru_menu_border_radius; // Yaru change: match border-radius to quick settings
   width: 24em;
 
   // run dialog needs to override bottom padding
@@ -98,7 +110,9 @@
 
 /* Password or Authentication Dialog */
 .prompt-dialog {
-  width: 28em;
+  width: 26em; // Yaru Change: Decrease from 28 to 26 em
+  padding: $dialog_padding;  // Yaru change: padding match to quick settings
+  border-radius: $yaru_menu_border_radius; // Yaru change: match border-radius to quick settings 
 
   .prompt-dialog-password-grid {
     spacing-rows: $base_margin * 2;


### PR DESCRIPTION
Task:
- [x] rework prompt-dialog
- [x] rework session-dialogs
- [x]  rework run dialog

### Prompt Dialog
|  before  |  after  |
|  --- | ---  |
| <img src=https://github.com/user-attachments/assets/1900d820-40e6-49d3-8bb3-d3482a672150 width=400/> | <img src=https://github.com/user-attachments/assets/963670bb-5ed2-4439-8568-2373b14ddd16 width=380/> |

### Session Dialog
|  before  |  after  |
|  --- | ---  |
| <img src=https://github.com/user-attachments/assets/4aa9d4cd-0c7b-4b29-b464-3c3aac15be61 width=390/> | <img src=https://github.com/user-attachments/assets/deae04a9-87fb-46d9-b309-8fc9a383db44 width=390/> |

### Run Dialog
|  before  |  after  |
|  --- | ---  |
| <img src=https://github.com/user-attachments/assets/e18afcbc-cb87-47a9-b794-ffdf70a35d77 width=390/> | <img src=https://github.com/user-attachments/assets/cc3c40ea-95ec-48b1-8862-7cd227f310e7 width=390/> |

I might retain the original border radius later on. 

resolves #4177