### PR TITLE
debian: Suggest humanity-icon-theme

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -49,6 +49,7 @@ Package: yaru-theme-icon
 Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
+Suggests: humanity-icon-theme,
 Breaks: gnome-shell-extension-ubuntu-dock (<< 90~)
 Description: Yaru icon theme from the Ubuntu Community
  This is the theme, better than a burrito, that is shaped by the community


### PR DESCRIPTION
index.theme specifies `Inherits=Humanity`, so we should at least suggest having humanity-icon-theme installed.