### PR TITLE
ci: Install hub from sources instead of using a precompiled binary

### DIFF
--- a/.github/lpbugtracker.py
+++ b/.github/lpbugtracker.py
@@ -11,12 +11,13 @@ stored in the json file to show if any new issue was created since last check.
 import os
 import subprocess
 import logging
+import shutil
 from launchpadlib.launchpad import Launchpad
 
 log = logging.getLogger("lpbugtracker")
 log.setLevel(logging.DEBUG)
 
-HUB = ".github/hub"
+HUB = shutil.which("hub")
 HOME = os.path.expanduser("~")
 CACHEDIR = os.path.join(HOME, ".launchpadlib", "cache")
 

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - '.github/workflows/track-lp-issues.yaml'
+      - '.github/lpbugtracker.py'
   schedule:
     - cron: '0 20 * * *'
 

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -20,6 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install launchpadlib
+          sudo apt install hub
       - name: Mirror Yaru bugs from Launchpad
         id: getlpbugs
         run: |


### PR DESCRIPTION
If it ends up in the debian sources we may share a pre-compiled binary that is not a good thing to do