### PR TITLE
fix: visual Correction on Ubuntu Dock Radius

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_dock.scss
+++ b/gnome-shell/src/gnome-shell-sass/_dock.scss
@@ -5,7 +5,7 @@
 
 // Dash to dock specifics
 $dash_padding: $base_padding + 4px; // 10px
-$dash_border_radius: $modal_radius * 1.5;
+$dash_border_radius: $modal_radius * 3;
 
 $dock_spacing: round($base_padding / 4);
 $dock_bottom_margin: $base_margin * 4;


### PR DESCRIPTION
I noticed that the padding of the dock radii doesn't uniformly match the icon containers' radius 

**before**
![Image](https://github.com/user-attachments/assets/39929c68-a05a-4a3f-9166-7ddde5e1f449)

**after**
![Image](https://github.com/user-attachments/assets/2839d163-c426-4ccd-85a2-f2c115d6f2f2)


## Ideal view

**BEFORE**

![Image](https://github.com/user-attachments/assets/bd3078f8-c0ab-4455-8dbe-989a3f1a425f)

**AFTER**
![Image](https://github.com/user-attachments/assets/9a89a942-79f1-47e9-989b-cf3fe228e7e2)


resolves #4225