### PR TITLE
adjusted radii of login entry. Initial commit

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
@@ -262,6 +262,7 @@ $_gdm_dialog_width: 25em;
 
 .login-dialog-prompt-entry {
   @extend %system_entry;
+  border-radius: $base_border_radius + 3; // Yaru Change: Match Upstream button radius 
 }
 
 .web-login-dialog-content-overlay {


### PR DESCRIPTION
before:
![Screenshot From 2025-05-10 11-06-07](https://github.com/user-attachments/assets/f38d7252-41d6-4475-b5f7-c7f5a0d52bc6)
after:
![Screenshot From 2025-05-10 09-30-56](https://github.com/user-attachments/assets/036c4944-9c6f-4445-993b-ad917a7042bb)

followed 9 px radius of `entry` widget using `base_border_radius` + 6
