### PR TITLE
Chore: Improve and Sync Wi-Fi Encrypted Indicator Icons

### DIFF
--- a/icons/Yaru/scalable/status/lock-small-symbolic.svg
+++ b/icons/Yaru/scalable/status/lock-small-symbolic.svg
@@ -1,5 +1,1 @@
-<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
- <path d="m1 3v5h6v-5zm1 1h4v3h-4z" color="#000000" fill="#808080" stroke-width=".5" style="font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:none;font-variant-numeric:normal;font-variant-position:normal;isolation:auto;mix-blend-mode:normal;shape-padding:0;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-transform:none;white-space:normal"/>
- <rect x="3" y="5" width="2" height="1" fill="#808080" fill-rule="evenodd" stroke-dasharray="4, 8" stroke-linecap="square" stroke-linejoin="round" stroke-width="2"/>
- <path d="m6 3c0-1.3807-0.61929-2.5-2-2.5s-2 1.1193-2 2.5" fill="none" stroke="#808080" stroke-linecap="square" stroke-linejoin="round" stroke-width=".75"/>
-</svg>
+network-wireless-encrypted-symbolic.svg

--- a/icons/Yaru/scalable/status/network-wireless-encrypted-symbolic.svg
+++ b/icons/Yaru/scalable/status/network-wireless-encrypted-symbolic.svg
@@ -1,3 +1,3 @@
-<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
- <path d="m3.5 0a2.5 2.5 0 0 0-2.5 2.5v1.5h-1v4h7v-4h-1v-1.5a2.5 2.5 0 0 0-2.5-2.5zm0 1a1.5 1.5 0 0 1 1.5 1.5v1.5h-3v-1.5a1.5 1.5 0 0 1 1.5-1.5zm-0.5 4h1v2h-1z" fill="#808080" fill-rule="evenodd"/>
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="m7 0a5 5 0 0 0-5 5v3h-2v8h14v-8h-2v-3a5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3v3h-6v-3a3 3 0 0 1 3-3zm-1 8h2v4h-2z" fill="#808080" fill-rule="evenodd"/>
 </svg>

--- a/icons/Yaru/scalable/status/network-wireless-encrypted-symbolic.svg
+++ b/icons/Yaru/scalable/status/network-wireless-encrypted-symbolic.svg
@@ -1,5 +1,3 @@
-<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:osb="http://www.openswatchbook.org/uri/2009/osb">
- <g transform="translate(-1153 267)" label="status">
-  <path d="m1161-265c-2.222 0-4 1.778-4 4v2h-1v7h10v-7h-1v-2c0-2.222-1.778-4-4-4zm0 1c1.662 0 3 1.338 3 3v2h-6v-2c0-1.662 1.338-3 3-3zm1 7v3h-2v-3z" color="#000000" color-rendering="auto" fill="#808080" image-rendering="auto" shape-rendering="auto" solid-color="#000000" style="font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:none;font-variant-numeric:normal;font-variant-position:normal;isolation:auto;mix-blend-mode:normal;shape-padding:0;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-transform:none;white-space:normal"/>
- </g>
+<svg version="1.1" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
+ <path d="m3.5 0a2.5 2.5 0 0 0-2.5 2.5v1.5h-1v4h7v-4h-1v-1.5a2.5 2.5 0 0 0-2.5-2.5zm0 1a1.5 1.5 0 0 1 1.5 1.5v1.5h-3v-1.5a1.5 1.5 0 0 1 1.5-1.5zm-0.5 4h1v2h-1z" fill="#808080" fill-rule="evenodd"/>
 </svg>

--- a/icons/src/scalable/default/status/network-wireless-encrypted-symbolic.svg
+++ b/icons/src/scalable/default/status/network-wireless-encrypted-symbolic.svg
@@ -1,35 +1,89 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' height='16' id='svg7384' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' width='16' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata20854'>
-    <rdf:RDF>
-      <cc:Work rdf:about=''>
-        <dc:title/>
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs id='defs7386'>
-    <linearGradient id='linearGradient5606' osb:paint='solid'>
-      <stop id='stop5608' offset='0' style='stop-color:#000000;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient4526' osb:paint='solid'>
-      <stop id='stop4528' offset='0' style='stop-color:#ffffff;stop-opacity:1;'/>
-    </linearGradient>
-    <linearGradient id='linearGradient3600-4' osb:paint='gradient'>
-      <stop id='stop3602-7' offset='0' style='stop-color:#f4f4f4;stop-opacity:1'/>
-      <stop id='stop3604-6' offset='1' style='stop-color:#dbdbdb;stop-opacity:1'/>
-    </linearGradient>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 8 8"
+   id="svg1"
+   sodipodi:docname="network-wireless-encrypted-symbolic.svg"
+   width="8"
+   height="8"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect4"
+       is_visible="true"
+       lpeversion="1"
+       nodesatellites_param="F,0,0,1,0,2.5,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,2.5,0,1 | F,0,0,1,0,1.5,0,1 @ F,0,0,1,0,1.5,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1"
+       radius="0"
+       unit="px"
+       method="auto"
+       mode="F"
+       chamfer_steps="1"
+       flexible="false"
+       use_knot_distance="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect14"
+       is_visible="true"
+       lpeversion="1"
+       nodesatellites_param="F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0.5,0,1 @ F,0,0,1,0,0.5,0,1 @ F,0,0,1,0,0.5,0,1 @ F,0,0,1,0,0.5,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 | F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 | F,0,0,1,0,0.5,0,1 @ F,0,0,1,0,0.5,0,1 @ F,0,1,1,0,0.5,0,1 @ F,0,1,1,0,0.57667736,0,1"
+       radius="0"
+       unit="px"
+       method="auto"
+       mode="F"
+       chamfer_steps="1"
+       flexible="false"
+       use_knot_distance="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
   </defs>
-  <g id='layer9' label='status' style='display:inline' transform='translate(-1153.0002,267)'>
-    
-    <path d='m 1161.0002,-265 c -2.222,0 -4,1.778 -4,4 v 2 h -1 v 7 h 10 v -7 h -1 v -2 c 0,-2.222 -1.778,-4 -4,-4 z m 0,1 c 1.662,0 3,1.338 3,3 v 2 h -6 v -2 c 0,-1.662 1.338,-3 3,-3 z m 1,7 v 3 h -2 v -3 z' id='path2684' style='color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:none;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.00000048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate'/>
-  </g>
-  <g id='layer2' style='display:inline' transform='translate(-912.00004,-100)'/>
-  <g id='layer4' style='display:inline' transform='translate(-912.00004,-100)'/>
-  <g id='g1812' style='display:inline' transform='translate(-912.00004,-100)'/>
-  <g id='g6217' style='display:inline' transform='translate(-912.00004,-100)'/>
-  <g id='layer3' style='display:inline' transform='translate(-912.00004,-100)'/>
-  <g id='g1833' style='display:inline' transform='translate(-912.00004,-100)'/>
-  <g id='layer1' style='display:inline' transform='translate(-912.00004,-100)'/>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="true"
+     inkscape:zoom="51.384323"
+     inkscape:cx="3.1916349"
+     inkscape:cy="5.3031739"
+     inkscape:window-width="1870"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       enabled="true"
+       visible="true" />
+  </sodipodi:namedview>
+  <path
+     d="M 3.5,0 A 2.5,2.5 0 0 0 1,2.5 V 4 H 0 V 8 H 7 V 4 H 6 V 2.5 A 2.5,2.5 0 0 0 3.5,0 Z m 0,1 A 1.5,1.5 0 0 1 5,2.5 V 4 H 2 V 2.5 A 1.5,1.5 0 0 1 3.5,1 Z M 3,5 H 4 V 7 H 3 Z"
+     style="fill:#808080;fill-rule:evenodd;fill-opacity:1"
+     id="path5" />
 </svg>

--- a/icons/src/scalable/default/status/network-wireless-encrypted-symbolic.svg
+++ b/icons/src/scalable/default/status/network-wireless-encrypted-symbolic.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    version="1.1"
-   viewBox="0 0 8 8"
+   viewBox="0 0 16 16"
    id="svg1"
    sodipodi:docname="network-wireless-encrypted-symbolic.svg"
-   width="8"
-   height="8"
+   width="16"
+   height="16"
    inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -58,9 +58,9 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showgrid="true"
-     inkscape:zoom="51.384323"
-     inkscape:cx="3.1916349"
-     inkscape:cy="5.3031739"
+     inkscape:zoom="30.280404"
+     inkscape:cx="7.2324003"
+     inkscape:cy="9.8908853"
      inkscape:window-width="1870"
      inkscape:window-height="1011"
      inkscape:window-x="0"
@@ -83,7 +83,7 @@
        visible="true" />
   </sodipodi:namedview>
   <path
-     d="M 3.5,0 A 2.5,2.5 0 0 0 1,2.5 V 4 H 0 V 8 H 7 V 4 H 6 V 2.5 A 2.5,2.5 0 0 0 3.5,0 Z m 0,1 A 1.5,1.5 0 0 1 5,2.5 V 4 H 2 V 2.5 A 1.5,1.5 0 0 1 3.5,1 Z M 3,5 H 4 V 7 H 3 Z"
-     style="fill:#808080;fill-rule:evenodd;fill-opacity:1"
+     d="M 7,0 A 5,5 0 0 0 2,5 V 8 H 0 v 8 H 14 V 8 H 12 V 5 A 5,5 0 0 0 7,0 Z m 0,2 a 3,3 0 0 1 3,3 V 8 H 4 V 5 A 3,3 0 0 1 7,2 Z m -1,8 h 2 v 4 H 6 Z"
+     style="fill:#808080;fill-opacity:1;fill-rule:evenodd;stroke-width:1"
      id="path5" />
 </svg>

--- a/icons/src/symlinks/symbolic/status.list
+++ b/icons/src/symlinks/symbolic/status.list
@@ -33,6 +33,7 @@ network-cellular-signal-ok-secure-rtl-symbolic.svg network-cellular-signal-ok-se
 network-cellular-signal-ok-rtl-symbolic.svg network-cellular-signal-ok-symbolic-rtl.svg
 network-cellular-signal-weak-secure-rtl-symbolic.svg network-cellular-signal-weak-secure-symbolic-rtl.svg
 network-cellular-signal-weak-rtl-symbolic.svg network-cellular-signal-weak-symbolic-rtl.svg
+network-wireless-encrypted-symbolic.svg lock-small-symbolic.svg
 content-loading-symbolic.svg image-loading-symbolic.svg
 power-profile-balanced-symbolic.svg resources-symbolic.svg
 power-profile-balanced-symbolic.svg speedometer-symbolic.svg


### PR DESCRIPTION
The network-wireless-encrypted-symbolic icon is not drawn correctly. According to the its css class it is supposed to be sized, $scalable_icon_size * 0.5 meaning the base icon is supposed to be 8x8 not 16x16 px . With the pixel fitted changed, the lock-small-symbolic is also transformed into a symlink syncing with network-wireless-encrypted-symbolic

I was supposed to just use the lock-small-symbolic icon but noticed that an outlined icon doesn't fit well in an 8x8 canvas
so I went and tried to pixel fit the original network-wireless-encrypted-symbolic.

**All in all**:
- Solved: lock icon for gnome-shell wifi indicator and gnome-control-center are now the same.
- the icon is already too small to be outlined so it was changed to be a filled icon.

## Preview:
**Before:**
<img width="45" height="45" alt="Screenshot From 2025-08-20 15-53-05" src="https://github.com/user-attachments/assets/7b512794-6bc3-4e3e-8d0d-6891f6eb4f19" />

**After:**
<img width="45" height="45" alt="Screenshot From 2025-08-20 16-45-42" src="https://github.com/user-attachments/assets/a2e91bc4-7759-447c-8553-19df59ba7507" />
