### PR TITLE
fix(icons): fix workscape-switcher-* icon-name in source file

### DIFF
--- a/icons/src/fullcolor/default/apps/workspace-switcher-left-bottom.svg
+++ b/icons/src/fullcolor/default/apps/workspace-switcher-left-bottom.svg
@@ -339,7 +339,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">workspace-switcher-right-top</tspan></text>
+           id="tspan3937">workspace-switcher-left-bottom</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"

--- a/icons/src/fullcolor/default/apps/workspace-switcher-left-top.svg
+++ b/icons/src/fullcolor/default/apps/workspace-switcher-left-top.svg
@@ -339,7 +339,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">workspace-switcher-right-top</tspan></text>
+           id="tspan3937">workspace-switcher-left-top</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"

--- a/icons/src/fullcolor/default/apps/workspace-switcher-right-bottom.svg
+++ b/icons/src/fullcolor/default/apps/workspace-switcher-right-bottom.svg
@@ -339,7 +339,7 @@
            y="-8.2548828"
            x="146.48828"
            sodipodi:role="line"
-           id="tspan3937">workspace-switcher-right-top</tspan></text>
+           id="tspan3937">workspace-switcher-right-bottom</tspan></text>
       <rect
          style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          id="rect16x16"


### PR DESCRIPTION
Those icons was rendered to the wrong destination file (`id="icon-name"` in SVG source), causing "Check rendered icon changes"  workflow to fail.

Related to: https://github.com/ubuntu/yaru/actions/runs/16900269814/job/49015137378?pr=4271