### PR TITLE
Fix Caps-lock-is-on color in light theme

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/widgets/_entries.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_entries.scss
@@ -5,6 +5,9 @@ StEntry {
 
   StIcon.capslock-warning {
     icon-size: $scalable_icon_size;
+    // Yaru: in light themes, the PolKit popup is also light, so a
+    // darker color is required. In Gnome, the popup is dark in both
+    // themes.
     warning-color: if($variant == 'light', $fg_color, $warning_color);
     padding: 0 $base_margin;
   }

--- a/gnome-shell/src/gnome-shell-sass/widgets/_misc.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_misc.scss
@@ -41,6 +41,9 @@
   text-align: center;
   padding-bottom: 8px;
   @extend %caption;
+  // Yaru: in light themes, the PolKit popup is also light, so a
+  // darker color is required. In Gnome, the popup is dark in both
+  // themes.
   color: if($variant == 'light', $fg_color, $warning_color);
 }
 


### PR DESCRIPTION
When a Polkit dialog is open to ask for the password, if the user activates the Caps Lock, a message appears under the text entry notifying that it is active, to warn the user.

In dark theme, this message is painted in yellow, which is fine because it gives a good contrast against the background; but in litgh theme, a slightly darker yellow is used, which has poor contrast. This goes against the accessibility (A11Y) requirements of having, at least, a 4.5/1 contrast ratio in text. This only happens in Yaru, because in upstream Gnome theme, the dialog is always dark, no matter what style (dark or light) is selected by the user.

<img width="1366" height="705" alt="polkit-color" src="https://github.com/user-attachments/assets/ade3690e-d257-4ea0-95d0-6e7467cadbef" />

This patch fixes this by setting the WARNING text color to black in light themes.