### PR TITLE
ci: Avoid installing locales and man pages

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -22,6 +22,7 @@ jobs:
         # No symlinks should be in icons sources, they should be handled through lists
         test -z "$(find icons/src/{fullcolor,scalable} -type l)"
 
+    - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
     - name: Install dependencies
       run: |
         sudo apt install sassc libxml2-utils libglib2.0-dev python3-pip

--- a/.github/workflows/open-pr-on-optimized-symbolic-icons-changes.yaml
+++ b/.github/workflows/open-pr-on-optimized-symbolic-icons-changes.yaml
@@ -24,6 +24,7 @@ jobs:
         run: |
           echo "::set-output name=push-branch::auto-optimized-symbolic-icons"
 
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           sudo apt install scour

--- a/.github/workflows/open-pr-on-rendered-icons-changed.yaml
+++ b/.github/workflows/open-pr-on-rendered-icons-changed.yaml
@@ -48,6 +48,7 @@ jobs:
             symlinks:
               - icons/src/symlinks/**
 
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         if: ${{ steps.check-changed.outputs.changes != '[]' }}
         run: |

--- a/.github/workflows/track-lp-issues.yaml
+++ b/.github/workflows/track-lp-issues.yaml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Python 3
         uses: actions/setup-python@v5.6.0
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Speed up CI jobs by avoiding installation of locales and man pages.

The major performance gain that can be expected is that it makes the "Processing triggers for man-db" step a no-op. That step can otherwise take more than a minute, for example in [this recent run](https://github.com/ubuntu/yaru/actions/runs/17451766904/job/49557610398#step:4:104) it took 1m 51s:

<img width="794" height="40" alt="image" src="https://github.com/user-attachments/assets/08df45d7-206e-4d9b-ae5f-b2f8a129892e" />


UDENG-7865