### PR TITLE
gnome-shell: Optimize contrast for warning, success and destructive texts

### DIFF
--- a/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
@@ -1,3 +1,5 @@
+@import 'sass-utils';
+
 // Yaru custom definitions
 $base_hover_color: transparentize(white, 0.8);
 $base_active_color: transparentize(white, 0.75);
@@ -35,3 +37,19 @@ $osd_insensitive_bg_color: transparentize(mix($osd_fg_color, opacify($osd_bg_col
 $osd_insensitive_fg_color: mix($osd_fg_color, opacify($osd_bg_color, 1), 50%);
 $osd_borders_color: transparentize(black, 0.3);
 $osd_outer_borders_color: transparentize(white, 0.84);
+
+// Overrides defaults for contrast optimized ones.
+
+// colors for destructive elements
+$destructive_bg_color: optimize-contrast($destructive_fg_color, $red, $target: 5.5);
+$destructive_color: optimize-contrast($bg_color, $red, $target: 6.0);
+
+// colors for levelbars, entries, labels and infobars
+$success_bg_color: optimize-contrast($success_fg_color, $green, $target: 5.5);
+$success_color: optimize-contrast($bg_color, $green, $target: 6.0);
+
+$warning_bg_color: optimize-contrast($warning_fg_color, $yellow, $target: 5.5);
+$warning_color: optimize-contrast($bg_color, $yellow, $target: 6.0);
+
+$error_bg_color: optimize-contrast($error_fg_color, $red, $target: 5.5);
+$error_color: optimize-contrast($bg_color, $red, $target: 6.0);

--- a/gnome-shell/src/gnome-shell-sass/_yaru-default-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-default-colors.scss
@@ -4,6 +4,3 @@ $_base_color_light: $light_1; // Yaru: use our colors
 
 // Used for dash and other dark elements on light theme
 $yaru_borders_color_dark: lighten(desaturate(lighten($jet, 4%), 100%), 14%);
-
-// Overrides default
-$warning_bg_color: if($variant =='light', darken($yellow, 1%), $yellow);

--- a/gnome-shell/src/gnome-shell-sass/widgets/_osd.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_osd.scss
@@ -1,5 +1,7 @@
 /* OSD */
 
+@import 'sass-utils';
+
 $osd_levelbar_height:6px;
 
 .osd-window {
@@ -27,7 +29,8 @@ $osd_levelbar_height:6px;
     -barlevel-height: $osd_levelbar_height;
     -barlevel-background-color: transparentize($osd_fg_color, if($variant=='light', 0.7, 0.9));
     -barlevel-active-background-color: $osd_fg_color;
-    -barlevel-overdrive-color: $destructive_color;
+    // Yaru: Optimize overdrive color for contrast
+    -barlevel-overdrive-color: optimize-contrast($osd_bg_color, $destructive_color, $target: 5.5);
     -barlevel-overdrive-separator-width: $base_padding * 0.5;
     &:ltr { margin-right: $base_padding; }
     &:rtl { margin-left: $base_padding; }


### PR DESCRIPTION
In practice the shell only use the warning color, but optimize them all in case some extension relies on the other ones (yep, ubuntu-dock!)

<img width="986" height="860" alt="Schermata del 2025-10-03 05-39-04" src="https://github.com/user-attachments/assets/97b6f3c8-47d3-47bb-bdd2-677d554d06c1" />
<img width="986" height="860" alt="Schermata del 2025-10-03 05-39-16" src="https://github.com/user-attachments/assets/12fd4087-ff71-42c5-b1ea-cee469598719" />
<img width="1185" height="872" alt="Schermata del 2025-10-03 03-23-54" src="https://github.com/user-attachments/assets/75aa348a-b88c-4c83-8709-3c63225ee98c" />

Compare with original screenshots in #4320

Partially overrides #4320