### PR TITLE
gnome-shell: Dialog error messages colors improvements

### DIFF
--- a/common/sass-utils.scss
+++ b/common/sass-utils.scss
@@ -210,3 +210,16 @@
 
     @return $fg;
 }
+
+@function composite($bg, $fg) {
+    @if alpha($bg) < 1 {
+        @error "Cannot composite with a non-opaque background color" $bg;
+    }
+
+    $alpha: alpha($fg);
+    @return rgb(
+      round(red($fg) * $alpha + red($bg) * (1 - $alpha)),
+      round(green($fg) * $alpha + green($bg) * (1 - $alpha)),
+      round(blue($fg) * $alpha + blue($bg) * (1 - $alpha))
+    );
+  }

--- a/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
@@ -53,5 +53,9 @@ $warning_color: optimize-contrast($bg_color, $yellow, $target: 6.0);
 $warning_fg_color: optimize-contrast($warning_bg_color,
     composite($warning_bg_color, $warning_fg_color), $target: 5.5);
 
+$warning_caption_bg_color: composite($bg_color, transparentize($warning_color, 0.9));
+$warning_caption_color: optimize-contrast($warning_caption_bg_color,
+    $warning_color, $target: 6.0);
+
 $error_bg_color: optimize-contrast($error_fg_color, $red, $target: 5.5);
 $error_color: optimize-contrast($bg_color, $red, $target: 6.0);

--- a/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
+++ b/gnome-shell/src/gnome-shell-sass/_yaru-colors.scss
@@ -50,6 +50,8 @@ $success_color: optimize-contrast($bg_color, $green, $target: 6.0);
 
 $warning_bg_color: optimize-contrast($warning_fg_color, $yellow, $target: 5.5);
 $warning_color: optimize-contrast($bg_color, $yellow, $target: 6.0);
+$warning_fg_color: optimize-contrast($warning_bg_color,
+    composite($warning_bg_color, $warning_fg_color), $target: 5.5);
 
 $error_bg_color: optimize-contrast($error_fg_color, $red, $target: 5.5);
 $error_color: optimize-contrast($bg_color, $red, $target: 6.0);

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
@@ -64,8 +64,9 @@ $dialog_padding: $base_padding * 4 $base_padding * 3 $base_padding * 3 $base_pad
   // special style for session warnings
   .end-session-dialog-battery-warning,
   .dialog-list-title {
-    color: $warning_color;
-    background-color: transparentize($warning_color, 0.9);
+    // Yaru: use contrast-optimized color.
+    color: $warning_caption_color;
+    background-color: $warning_caption_bg_color;
     padding: $base_padding * 1.5;
     border-radius: $base_border_radius;
     margin: $base_margin 0;
@@ -148,10 +149,11 @@ $dialog_padding: $base_padding * 4 $base_padding * 3 $base_padding * 3 $base_pad
   }
 
   .prompt-dialog-error-label {
-    color: $warning_color;
+    // Yaru: use contrast-optimized color.
+    color: $warning_caption_color;
     // Yaru: Use uniform aspect on dialog messages.
     // See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3897
-    background-color: transparentize($warning_color, 0.9);
+    background-color: $warning_caption_bg_color;
   }
 
   .prompt-dialog-info-label {

--- a/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_dialogs.scss
@@ -140,10 +140,25 @@ $dialog_padding: $base_padding * 4 $base_padding * 3 $base_padding * 3 $base_pad
   .prompt-dialog-null-label {
     @extend %caption;
     text-align: center;
+    // Yaru: Use uniform aspect on dialog messages.
+    // See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3897
+    padding: $base_padding * 1.5;
+    border-radius: $base_border_radius;
+    margin: $base_margin 0;
   }
 
   .prompt-dialog-error-label {
     color: $warning_color;
+    // Yaru: Use uniform aspect on dialog messages.
+    // See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3897
+    background-color: transparentize($warning_color, 0.9);
+  }
+
+  .prompt-dialog-info-label {
+    // Yaru: Use uniform aspect on dialog messages.
+    // See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3897
+    color: $fg_color;
+    background-color: transparentize($fg_color, 0.9);
   }
 }
 

--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
@@ -89,10 +89,11 @@ $_gdm_dialog_width: 25em;
 
   .conflicting-session-dialog-desc-warning {
     text-align: center;
-    color: $warning_color;
+    // Yaru: use contrast-optimized color.
+    color: $warning_caption_color;
     // Yaru: Use uniform aspect on dialog messages.
     // See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3897
-    background-color: transparentize($warning_color, 0.9);
+    background-color: $warning_caption_bg_color;
     padding: $base_padding * 1.5;
     border-radius: $base_border_radius;
     margin: $base_margin 0;

--- a/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
+++ b/gnome-shell/src/gnome-shell-sass/widgets/_login-lock.scss
@@ -90,6 +90,12 @@ $_gdm_dialog_width: 25em;
   .conflicting-session-dialog-desc-warning {
     text-align: center;
     color: $warning_color;
+    // Yaru: Use uniform aspect on dialog messages.
+    // See: https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3897
+    background-color: transparentize($warning_color, 0.9);
+    padding: $base_padding * 1.5;
+    border-radius: $base_border_radius;
+    margin: $base_margin 0;
   }
 }
 


### PR DESCRIPTION
Optimize the contrast of the dialog warnings

Dialog warnings were already a bit optimized, but now we take a step
further, since we can do composition we can find out the final
background color and then compute the correctly optimized text color

Generated colors are:
 - https://apcacontrast.com/?BG=efe9e1&TXT=7d4c03&DEV=G4g&BUF=A22
 - https://apcacontrast.com/?BG=332a1c&TXT=f99b11&DEV=G4g&BUF=A22

/cc @juanruitina

---

<img width="821" height="903" alt="Schermata del 2025-10-03 07-49-29" src="https://github.com/user-attachments/assets/971ba0d0-0dae-4673-825c-4eba6a5ca3e0" />
<img width="821" height="903" alt="Schermata del 2025-10-03 07-50-21" src="https://github.com/user-attachments/assets/3fdcf7f5-a2f0-434c-b2eb-449a4171385c" />
<img width="821" height="903" alt="Schermata del 2025-10-03 07-50-27" src="https://github.com/user-attachments/assets/65911210-ffdc-4e9a-9b83-8ca13f654267" />

Superseeds #4320 