### PR TITLE
ci: fix `set-output` depreceations

### DIFF
--- a/.github/workflows/open-pr-on-changes.yaml
+++ b/.github/workflows/open-pr-on-changes.yaml
@@ -105,7 +105,7 @@ jobs:
           if [ -n "$MODIFIED" ]; then
             hasModif="true"
           fi
-          echo "::set-output name=modified::${hasModif}"
+          echo "modified=${hasModif}" >> $GITHUB_OUTPUT
         env:
           UPSTREAM_REPO_URL: ${{ matrix.buildenv.repo }}
           UPSTEAM_BRANCH: ${{ matrix.buildenv.upstreambranch }}

--- a/.github/workflows/open-pr-on-icons-changes.yaml
+++ b/.github/workflows/open-pr-on-icons-changes.yaml
@@ -191,7 +191,7 @@ jobs:
           if [ -n "$MODIFIED" ]; then
             hasModif="true"
           fi
-          echo "::set-output name=modified::${hasModif}"
+          echo "modified=${hasModif}" >> $GITHUB_OUTPUT
         env:
           UPSTREAM_REPO_URL: ${{ matrix.buildenv.repo }}
           UPSTEAM_BRANCH: ${{ matrix.buildenv.upstreambranch }}

--- a/.github/workflows/open-pr-on-optimized-symbolic-icons-changes.yaml
+++ b/.github/workflows/open-pr-on-optimized-symbolic-icons-changes.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup common variables
         id: env
         run: |
-          echo "::set-output name=push-branch::auto-optimized-symbolic-icons"
+          echo "push-branch=auto-optimized-symbolic-icons" >> $GITHUB_OUTPUT
 
       - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
           else
             changed=true
           fi
-          echo "::set-output name=modified::${changed}"
+          echo "modified=${changed}" >> $GITHUB_OUTPUT
 
       - name: Create or update Pull Request
         if: steps.check_optimization_changes.outputs.modified == 'true'

--- a/.github/workflows/open-pr-on-rendered-icons-changed.yaml
+++ b/.github/workflows/open-pr-on-rendered-icons-changed.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup common variables
         id: env
         run: |
-          echo "::set-output name=push-branch::auto-rendered-icons"
+          echo "push-branch=auto-rendered-icons" >> $GITHUB_OUTPUT
 
       - name: Check Source changes
         uses: dorny/paths-filter@v3
@@ -118,7 +118,7 @@ jobs:
           else
             changed=true
           fi
-          echo "::set-output name=changed::${changed}"
+          echo "changed=${changed}" >> $GITHUB_OUTPUT
 
       - name: Create or update Pull Request
         if: steps.check-rendering.outputs.changed == 'true'


### PR DESCRIPTION
### descriptions
- instead of using `set-output` pipe it to `GITHUB_ENV`

Closes #4291