### PR TITLE
gtksourceview: add 'version' attribute

### DIFF
--- a/gtksourceview/gtksourceview/dark.xml.in
+++ b/gtksourceview/gtksourceview/dark.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" kind="dark">
+<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" kind="dark" version="1.0">
   <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
 
   <!-- Yaru palette -->

--- a/gtksourceview/gtksourceview/default.xml.in
+++ b/gtksourceview/gtksourceview/default.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" kind="light">
+<style-scheme id="@FlavourThemeName@" _name="@FlavourThemeName@" kind="light" version="1.0">
   <_description>A GtkSourceView style to match @FlavourThemeName@</_description>
 
   <!-- Yaru palette -->


### PR DESCRIPTION
gedit and other tools complain:

```
$ gedit

(gedit): libgedit-gtksourceview-WARNING **: could not load style scheme file '/usr/share/libgedit-gtksourceview-300/styles/Yaru-dark.xml': missing 'version' attribute

(gedit): libgedit-gtksourceview-WARNING **:  could not load style scheme file '/usr/share/libgedit-gtksourceview-300/styles/Yaru.xml': missing 'version' attribute
```

So restore the `version` attribute.

Bug: https://github.com/ubuntu/yaru/issues/4140
LP: #2084420
Fixes: fc21541f6113 ("gtksourceview: Add support for new libgedit-gtksourceview xml scheme (#4088)")