### PR TITLE
ci: Skip licenserecon during build-deb action

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: canonical/desktop-engineering/gh-actions/common/build-debian@main
         with:
           docker-image: ubuntu:${{ env.UBUNTU_VERSION }}
+          lrc: skip
 
       - name: Install generated debs
         uses: kohlerdominik/docker-run-action@v2.0.0


### PR DESCRIPTION
We're about to merge a PR [1] which runs licenserecon aka lrc by default during the build-deb action to check the debian/copyright file. The motivation is that uploads to the archive can be rejected due to issues reported by lrc.

[1] https://github.com/canonical/desktop-engineering/pull/97

In this repo, it complains about a few differences between the debian/copyright file and the output of licensecheck:

    en: Versions: licenserecon '11.0'  licensecheck '3.3.9-1ubuntu2'

    Parsing Source Tree  ....
    Reading d/copyright  ....
    Running licensecheck ....

    d/copyright      | licensecheck

    GPL-3+           | CC0-1.0           gnome-shell/src/data/icons/scalable/status/wellbeing-symbolic.svg
    GPL-3+           | LGPL-2.1          gnome-shell/src/gnome-shell-sass/_common.scss
    GPL-3+           | CC0-1.0           gnome-shell/upstream/data/icons/scalable/status/wellbeing-symbolic.svg
    CC-BY-SA-4.0     | GPL-3+            icons/src/cursors/anicursorgen.py
    CC-BY-SA-4.0     | GPL-2             icons/src/cursors/render-cursors.py
    LGPL-3.0         | LGPL-3            icons/src/fullcolor/render-bitmaps.py
    LGPL-3.0         | LGPL-3            icons/src/scalable/extract-symbolic-icons.rb
    CC-BY-SA-4.0     | GPL-3             icons/src/symlinks/generate-symlinks.sh
    GPL-3+           | GPL-3             meson.build

Since some of those are in the code from upstream gnome-shell, and yaru is already available in the archives, the easiest solution is to skip lrc when building yaru.