### PR TITLE
build: Drop unused meson codepaths

### DIFF
--- a/gnome-shell/src/install-shell.sh
+++ b/gnome-shell/src/install-shell.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# -*- coding: UTF-8 -*-
-
-project_name="$1"
-destdir_prefix="${MESON_INSTALL_DESTDIR_PREFIX}/share"
-install_prefix="${MESON_INSTALL_PREFIX}/share"
-
-mkdir -p "${destdir_prefix}/themes/${project_name}"
-ln -sf "${install_prefix}/gnome-shell/theme/${project_name}" "${destdir_prefix}/themes/${project_name}/gnome-shell"

--- a/gnome-shell/src/meson.build
+++ b/gnome-shell/src/meson.build
@@ -168,22 +168,10 @@ foreach variant: variants
   install_data(data_sources, install_dir: install_dir)
 
   if install_theme_sources
-    if meson.version().version_compare('>= 0.61')
-      install_symlink('gnome-shell',
-        install_dir: gnomeshell_alt_themes_dir / theme_full_name,
-        # We could use a simpler definition, but that breaks $DESTDIR usage
-        # https://github.com/mesonbuild/meson/pull/10176
-        #pointing_to: get_option('prefix') / install_dir`
-        pointing_to: run_command(python, '-c',
-          'import os, sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))',
-          install_dir,
-          gnomeshell_alt_themes_dir / theme_full_name,
-          check: true,
-        ).stdout().strip(),
-      )
-    else
-      meson.add_install_script('install-shell.sh', theme_full_name)
-    endif
+    install_symlink('gnome-shell',
+      install_dir: gnomeshell_alt_themes_dir / theme_full_name,
+      pointing_to: get_option('prefix') / install_dir,
+    )
   endif
 endforeach
 

--- a/icons/meson.build
+++ b/icons/meson.build
@@ -403,16 +403,10 @@ foreach flavour: icon_flavors
         ).stdout().strip()
       endif
 
-      if meson.version().version_compare('>= 0.61')
-        install_symlink(fs.name(symlinks[i]),
-          install_dir: symlink_dir,
-          pointing_to: target,
-        )
-      else
-        meson.add_install_script('bash', '-c',
-          'mkdir -p "${DESTDIR}/@1@" && ln -svf @2@ ${DESTDIR}/@1@/@0@'.format(
-            fs.name(symlinks[i]), symlink_dir, target))
-      endif
+      install_symlink(fs.name(symlinks[i]),
+        install_dir: symlink_dir,
+        pointing_to: target,
+      )
     endforeach
 
     if is_dark_flavour
@@ -449,16 +443,10 @@ foreach flavour: icon_flavors
           check: true,
         ).stdout().strip()
 
-        if meson.version().version_compare('>= 0.61')
-          install_symlink(category,
-            install_dir: theme_install_dir / fs.parent(c),
-            pointing_to: target,
-          )
-        else
-          meson.add_install_script('bash', '-c',
-            'mkdir -p "${DESTDIR}/@2@"; ln -svf @1@ ${DESTDIR}/@2@/@0@'.format(
-                category, target, theme_install_dir / fs.parent(c)))
-        endif
+        install_symlink(category,
+          install_dir: theme_install_dir / fs.parent(c),
+          pointing_to: target,
+        )
       endforeach
     endif
 


### PR DESCRIPTION
We depend on newer meson now, so all such code is dead