### PR TITLE
ci/render-icons: Install ubuntu fonts in CI

### DIFF
--- a/.github/workflows/open-pr-on-rendered-icons-changed.yaml
+++ b/.github/workflows/open-pr-on-rendered-icons-changed.yaml
@@ -60,6 +60,7 @@ jobs:
             inkscape \
             libglib2.0-dev-bin \
             optipng \
+            fonts-ubuntu \
             python3-pip \
             sassc \
             scour \


### PR DESCRIPTION
We need these fonts to render various assets where text is used and not embedded into the SVGs themselves, so adjust CI job to ensure icons are properly rendered.

An example of badly rendered icons are the disk ones, where strings such as "SSD" are not centered, as they are using a fallback font