### PR TITLE
Deduplicate icons fixes

### DIFF
--- a/debian/check-symlinks.sh
+++ b/debian/check-symlinks.sh
@@ -11,6 +11,6 @@ check_package() {
     fi
 }
 
-for pkg in $(dh_listpackages | grep -v yaru-theme-unity); do
+for pkg in $(dh_listpackages); do
     check_package "$pkg"
 done

--- a/debian/check-symlinks.sh
+++ b/debian/check-symlinks.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+check_package() {
+    pkg=$1
+    broken=$(find "debian/$pkg" -xtype l 2>/dev/null)
+    if [ -n "$broken" ]; then
+        echo "Broken symlinks found in $pkg:"
+        echo "$broken"
+        exit 1
+    fi
+}
+
+for pkg in $(dh_listpackages | grep -v yaru-theme-unity); do
+    check_package "$pkg"
+done

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,9 @@
 %:
 	dh $@
 
+execute_after_dh_link:
+	debian/check-symlinks.sh
+
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		-Dgnome-shell-gresource=true \

--- a/gnome-shell/src/meson.build
+++ b/gnome-shell/src/meson.build
@@ -168,9 +168,10 @@ foreach variant: variants
   install_data(data_sources, install_dir: install_dir)
 
   if install_theme_sources
+    theme_sources_path = gnomeshell_alt_themes_dir / theme_full_name
     install_symlink('gnome-shell',
-      install_dir: gnomeshell_alt_themes_dir / theme_full_name,
-      pointing_to: get_option('prefix') / install_dir,
+      install_dir: theme_sources_path,
+      pointing_to: fs.relative_to(install_dir, theme_sources_path),
     )
   endif
 endforeach

--- a/icons/meson.build
+++ b/icons/meson.build
@@ -455,7 +455,11 @@ foreach flavour: icon_flavors
     # Cleanup empty directories, as per excluded files
     meson.add_install_script('bash', '-c',
       'find "${DESTDIR}/@0@" -type d -empty -print -delete'.format(theme_install_dir))
-    meson.add_install_script('meson/dedup-icons.py', theme_name)
+    meson.add_install_script(
+      'meson/dedup-icons.py', theme_name,
+      '--deprioritize-categories',
+      PANEL_ONLY_ICONS_CATEGORIES + ['categories'],
+    )
     meson.add_install_script('bash', '-xc',
       '[ -z "$(find "${DESTDIR}/@0@" -xtype l)" ]'.format(theme_install_dir))
     meson.add_install_script('meson/post_install.py', theme_name)

--- a/icons/meson.build
+++ b/icons/meson.build
@@ -29,6 +29,13 @@ cleanup_rendered_icons_accented_targets = []
 cleanup_symlinks_targets = []
 cleanup_symlinks_accented_targets = []
 
+# FIXME: Remove this when we can make yaru-theme-unity depend on
+# yaru-theme-icons, for now let's just duplicate them.
+duplicate_legacy_icons = uses_panel_icons and run_command(
+  'sh', '-eu', '-c', '[ -n "${DEB_HOST_ARCH}" ]',
+  check: false,
+).returncode() == 0
+
 svg_source_categories_excludes = ''
 foreach c: PANEL_ONLY_ICONS_CATEGORIES
   svg_source_categories_excludes += ' ! -path "*/@0@/*"'.format(c)
@@ -316,6 +323,8 @@ foreach flavour: icon_flavors
       endif
     endif
 
+    # FIXME: Meson does not fail if the directory does not exist!
+    assert(fs.is_dir(icon_dir))
     install_subdir(icon_dir,
       install_dir: theme_install_dir,
       strip_directory: true,
@@ -323,7 +332,6 @@ foreach flavour: icon_flavors
       exclude_directories: excluded_folders,
       follow_symlinks: false,
     )
-
 
     if is_dark_flavour
       assert(get_option('dark'), 'Dark flavour @0@ enabled, but we have no dark parent'.format(flavour))
@@ -436,6 +444,7 @@ foreach flavour: icon_flavors
       'meson/dedup-icons.py', theme_name,
       '--deprioritize-categories',
       PANEL_ONLY_ICONS_CATEGORIES + ['categories'],
+      duplicate_legacy_icons ? ['--skip-categories'] + PANEL_ONLY_ICONS_CATEGORIES : [],
     )
     meson.add_install_script('bash', '-xc',
       '[ -z "$(find "${DESTDIR}/@0@" -xtype l)" ]'.format(theme_install_dir))

--- a/icons/meson.build
+++ b/icons/meson.build
@@ -316,8 +316,6 @@ foreach flavour: icon_flavors
       endif
     endif
 
-    symlinks = []
-
     install_subdir(icon_dir,
       install_dir: theme_install_dir,
       strip_directory: true,
@@ -326,27 +324,6 @@ foreach flavour: icon_flavors
       follow_symlinks: false,
     )
 
-    foreach i: range(symlinks.length())
-      link_path = fs.parent(symlinks[i])
-      symlink_dir = theme_install_dir / link_path
-      target = links_targets[i]
-
-      if link_path == fs.parent(target)
-        target = fs.name(target)
-      else
-        target = run_command(python, '-c',
-          'import os, sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))',
-          target,
-          link_path,
-          check: true,
-        ).stdout().strip()
-      endif
-
-      install_symlink(fs.name(symlinks[i]),
-        install_dir: symlink_dir,
-        pointing_to: target,
-      )
-    endforeach
 
     if is_dark_flavour
       assert(get_option('dark'), 'Dark flavour @0@ enabled, but we have no dark parent'.format(flavour))

--- a/icons/meson/dedup-icons.py
+++ b/icons/meson/dedup-icons.py
@@ -52,10 +52,12 @@ def deduplicate_icons(theme_dir: Path, deprioritized_categories: list[str] = [],
                  if not any(part in skip_categories
                             for part in f.relative_to(theme_dir).parts)]
 
-    def sort_key(p: Path) -> tuple[bool, str]:
+    def sort_key(p: Path) -> tuple[bool, bool, str]:
         is_deprioritized = any(part in deprioritized_categories
                                for part in p.relative_to(theme_dir).parts)
-        return (is_deprioritized, str(p))
+        return (is_deprioritized,
+                any(c.isdigit() for c in p.stem) and '-' not in p.stem,
+                str(p))
 
     for candidates in group_by_size(files).values():
         if len(candidates) < 2:

--- a/icons/meson/dedup-icons.py
+++ b/icons/meson/dedup-icons.py
@@ -43,14 +43,19 @@ def group_by_size(files: list[Path]) -> dict[int, list[Path]]:
     return by_size
 
 
-def deduplicate_icons(theme_dir: Path) -> None:
+def deduplicate_icons(theme_dir: Path, deprioritized_categories: list[str] = []) -> None:
     files = find_regular_files(theme_dir)
+
+    def sort_key(p: Path) -> tuple[bool, str]:
+        is_deprioritized = any(part in deprioritized_categories
+                               for part in p.relative_to(theme_dir).parts)
+        return (is_deprioritized, str(p))
 
     for candidates in group_by_size(files).values():
         if len(candidates) < 2:
             continue
 
-        candidates.sort()
+        candidates.sort(key=sort_key)
 
         seen = []
         for path in candidates:
@@ -69,6 +74,10 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description='Replace duplicate icon files with relative-path symlinks.')
     parser.add_argument('theme_name', help='Name of the installed icon theme')
+    parser.add_argument(
+        '--deprioritize-categories', nargs='+', dest='deprioritized_categories',
+        default=[], metavar='CATEGORY',
+        help='Icon categories that should never be used as a symlink source')
     args = parser.parse_args()
 
     destdir = os.environ.get('DESTDIR', '')
@@ -80,7 +89,7 @@ def main() -> None:
         print(f'Theme directory not found: {theme_dir}', file=sys.stderr)
         sys.exit(1)
 
-    deduplicate_icons(theme_dir)
+    deduplicate_icons(theme_dir, args.deprioritized_categories)
 
 
 if __name__ == '__main__':

--- a/icons/meson/dedup-icons.py
+++ b/icons/meson/dedup-icons.py
@@ -43,8 +43,14 @@ def group_by_size(files: list[Path]) -> dict[int, list[Path]]:
     return by_size
 
 
-def deduplicate_icons(theme_dir: Path, deprioritized_categories: list[str] = []) -> None:
+def deduplicate_icons(theme_dir: Path, deprioritized_categories: list[str] = [],
+                      skip_categories: list[str] = []) -> None:
     files = find_regular_files(theme_dir)
+
+    if skip_categories:
+        files = [f for f in files
+                 if not any(part in skip_categories
+                            for part in f.relative_to(theme_dir).parts)]
 
     def sort_key(p: Path) -> tuple[bool, str]:
         is_deprioritized = any(part in deprioritized_categories
@@ -78,6 +84,10 @@ def main() -> None:
         '--deprioritize-categories', nargs='+', dest='deprioritized_categories',
         default=[], metavar='CATEGORY',
         help='Icon categories that should never be used as a symlink source')
+    parser.add_argument(
+        '--skip-categories', nargs='+', dest='skip_categories',
+        default=[], metavar='CATEGORY',
+        help='Icon categories to exclude entirely from deduplication')
     args = parser.parse_args()
 
     destdir = os.environ.get('DESTDIR', '')
@@ -89,7 +99,7 @@ def main() -> None:
         print(f'Theme directory not found: {theme_dir}', file=sys.stderr)
         sys.exit(1)
 
-    deduplicate_icons(theme_dir, args.deprioritized_categories)
+    deduplicate_icons(theme_dir, args.deprioritized_categories, args.skip_categories)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As per https://github.com/ubuntu/yaru/pull/4443 we have two issues ([details](https://github.com/ubuntu/yaru/pull/4443#issuecomment-4237340995)):
 - Unity Panel icons were using broken-symlinks
 - Unity icons may be linked to the default icon theme, but since we don't have an explicit theme dependency it was a potential problem in ubuntu, so just duplicate things at install phase there
 

Fix issues and add further debian checks