### PR TITLE
Update themerc

### DIFF
--- a/xfwm4/src/default/xfwm4/themerc
+++ b/xfwm4/src/default/xfwm4/themerc
@@ -13,7 +13,6 @@ full_width_title=true
 title_vertical_offset_active=0
 title_vertical_offset_inactive=0
 button_offset=4
-maximized_offset=4
 button_spacing=0
 shadow_delta_height=2
 shadow_delta_width=0


### PR DESCRIPTION
Deleted Maximized offset=4 line. This makes selecting the "close" button more easy on maximized windows. Before, if you clicked just on the top right (or left) corner of the screen, "close" button isn't selected. Now, with the deletion of this line, yes.

Also, this changes unifies Yaru-default xfwm4 (white variant) with Yaru-dark xfwm4 (dark variant) , as this line doesn't exist on Yaru-dark xfwm4's themerc file.